### PR TITLE
626 memory overflow for long videos and 4k cameras

### DIFF
--- a/caliscope/configurator.py
+++ b/caliscope/configurator.py
@@ -9,6 +9,7 @@ import numpy as np
 import rtoml
 from dataclasses import asdict
 import cv2
+from enum import Enum, auto
 
 from caliscope.calibration.charuco import Charuco
 from caliscope.cameras.camera import Camera
@@ -19,6 +20,17 @@ from concurrent.futures import ThreadPoolExecutor
 
 logger = caliscope.logger.get(__name__)
 
+class ConfigSettings(Enum):
+    """
+    Control settings used to manage the processing of data
+    """
+    creation_date = "creation_date"
+    camera_count = "camera_count"
+    save_tracked_points_video = "save_tracked_points_video"
+    fps_sync_stream_processing = "fps_sync_stream_processing"
+
+    
+#%%
 
 class Configurator:
     """
@@ -43,43 +55,39 @@ class Configurator:
             logger.info(
                 "No existing config.toml found; creating starter file with charuco"
             )
-
             self.dict = rtoml.loads("")
-            self.dict["CreationDate"] = datetime.now()
-            self.dict["camera_count"] = 0
-            self.dict["Save_Tracked_Point_Video"] = True
+            self.dict[ConfigSettings.creation_date.value] = datetime.now()
+            self.dict[ConfigSettings.camera_count.value] = 0
+            self.dict[ConfigSettings.save_tracked_points_video.value] = True
+            self.dict[ConfigSettings.fps_sync_stream_processing.value] = 100
             self.update_config_toml()
 
             # default values enforced below
             charuco = Charuco(4, 5, 11, 8.5, square_size_overide_cm=5.4)
             self.save_charuco(charuco)
 
-        # if exists(self.point_estimates_toml_path):
-        # self.refresh_point_estimates_from_toml()
-
     def save_camera_count(self, count):
         self.camera_count = count
-        self.dict["camera_count"] = count
+        self.dict[ConfigSettings.camera_count.value] = count
         self.update_config_toml()
 
     def get_camera_count(self):
-        return self.dict["camera_count"]
+        return self.dict[ConfigSettings.camera_count.value]
 
-    def get_intrinsic_wait_time(self):
-        return self.dict["intrinsic_wait_time"]
 
-    def get_extrinsic_wait_time(self):
-        return self.dict["extrinsic_wait_time"]
-
-    def get_fps_recording(self):
-        return self.dict["fps_recording"]
-
-    def get_fps_extrinsic_calibration(self):
-        return self.dict["fps_extrinsic_calibration"]
-
-    def get_fps_intrinsic_calibration(self):
-        return self.dict["fps_intrinsic_calibration"]
-
+    def get_save_tracked_points(self):
+        if ConfigSettings.save_tracked_points_video.value not in self.dict.keys():
+            return True
+        else:
+            return self.dict[ConfigSettings.save_tracked_points_video.value]
+    
+    def get_fps_sync_stream_processing(self):
+        if ConfigSettings.fps_sync_stream_processing.value not in self.dict.keys():
+            return 100 
+        else:
+            return self.dict[ConfigSettings.fps_sync_stream_processing.value]
+        
+        
     def refresh_config_from_toml(self):
         logger.info("Populating config dictionary with config.toml data")
         # with open(self.config_toml_path, "r") as f:

--- a/caliscope/configurator.py
+++ b/caliscope/configurator.py
@@ -47,6 +47,7 @@ class Configurator:
             self.dict = rtoml.loads("")
             self.dict["CreationDate"] = datetime.now()
             self.dict["camera_count"] = 0
+            self.dict["Save_Tracked_Point_Video"] = True
             self.update_config_toml()
 
             # default values enforced below
@@ -319,7 +320,6 @@ class Configurator:
 
         with open(self.point_estimates_toml_path, "w") as f:
             rtoml.dump(self.dict["point_estimates"], f)
-        # self.update_config_toml()
 
 
 if __name__ == "__main__":

--- a/caliscope/controller.py
+++ b/caliscope/controller.py
@@ -36,12 +36,12 @@ logger = caliscope.logger.get(__name__)
 FILTERED_FRACTION = 0.025  # by default, 2.5% of image points with highest reprojection error are filtered out during calibration
 
 
-class CalibrationStage(Enum):
-    NO_INTRINSIC_VIDEO = auto()
-    INTRINSIC_VIDEO_NO_INTRINSIC_CAL = auto()
-    PARTIAL_INTRINSICS = auto()
-    FULL_INTRINSICS_NO_EXTRINSICS = auto()
-    FULLY_CALIBRATED = auto()
+# class CalibrationStage(Enum):
+#     NO_INTRINSIC_VIDEO = auto()
+#     INTRINSIC_VIDEO_NO_INTRINSIC_CAL = auto()
+#     PARTIAL_INTRINSICS = auto()
+#     FULL_INTRINSICS_NO_EXTRINSICS = auto()
+#     FULLY_CALIBRATED = auto()
 
 
 class Controller(QObject):
@@ -346,7 +346,12 @@ class Controller(QObject):
                 output_path.unlink()  # make sure this doesn't exist to begin with.
 
             self.load_extrinsic_stream_manager()
-            self.extrinsic_stream_manager.process_streams(fps_target=100)
+
+            # config settings that help to throttle processing rate to manage resource demands            
+            include_video = self.config.get_save_tracked_points()
+            fps_target = self.config.get_fps_sync_stream_processing()
+            
+            self.extrinsic_stream_manager.process_streams(fps_target=fps_target, include_video=include_video)
             logger.info(
                 f"Processing of extrinsic calibration begun...waiting for output to populate: {output_path}"
             )
@@ -419,7 +424,12 @@ class Controller(QObject):
             self.post_processor = PostProcessor(
                 self.camera_array, recording_path, tracker_enum
             )
-            self.post_processor.create_xy()
+
+            # config settings that help to throttle processing rate to manage resource demands            
+            include_video = self.config.get_save_tracked_points()
+            fps_target = self.config.get_fps_sync_stream_processing()
+
+            self.post_processor.create_xy(include_video=include_video,fps_target=fps_target)
             self.post_processor.create_xyz()
 
         self.process_recordings_thread = QThread()

--- a/caliscope/post_processing/post_processor.py
+++ b/caliscope/post_processing/post_processor.py
@@ -52,12 +52,14 @@ class PostProcessor:
             self.recording_path, self.camera_array.cameras, self.tracker
         )
 
-    def create_xy(self):
+    def create_xy(self, fps_target=100, include_video=True):
         """
         Reads through all .mp4  files in the recording path and applies the tracker to them
         The xy_TrackerName.csv file is saved out to the same directory by the VideoRecorder
+
+        Note that high fps target and including video will increase processing overhead
         """
-        self.sync_stream_manager.process_streams(fps_target=100)
+        self.sync_stream_manager.process_streams(include_video=include_video, fps_target=fps_target)
 
         while self.sync_stream_manager.recorder.recording:
             sleep(1)

--- a/caliscope/synchronized_stream_manager.py
+++ b/caliscope/synchronized_stream_manager.py
@@ -61,7 +61,7 @@ class SynchronizedStreamManager:
         self.synchronizer = Synchronizer(self.streams)
         self.recorder = VideoRecorder(self.synchronizer, suffix=self.subfolder_name)
 
-    def process_streams(self, fps_target=None):
+    def process_streams(self, fps_target=None, include_video=True):
         """
         Output file will be created in a subfolder named `tracker.name`
         This will include mp4 files with visualized landmarks as well as the file `xy.csv`
@@ -71,7 +71,7 @@ class SynchronizedStreamManager:
         logger.info(f"beginning to create recording for files saved to {self.output_dir}")
         self.recorder.start_recording(
             self.output_dir,
-            include_video=True,
+            include_video=include_video,
             show_points=True,
             store_point_history=True,
         )

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -18,7 +18,7 @@ from caliscope.calibration.stereocalibrator import StereoCalibrator
 from caliscope.calibration.capture_volume.quality_controller import QualityController
 
 from caliscope.synchronized_stream_manager import SynchronizedStreamManager
-
+from caliscope.helper import copy_contents
 
 from caliscope.controller import FILTERED_FRACTION
 from caliscope.configurator import Configurator
@@ -28,30 +28,30 @@ logger = caliscope.logger.get(__name__)
 TEST_SESSIONS = ["mediapipe_calibration"]
 
 
-def copy_contents(src_folder, dst_folder):
-    """
-    Helper function to port a test case data folder over to a temp directory
-    used for testing purposes so that the test case data doesn't get overwritten
-    """
-    src_path = Path(src_folder)
-    dst_path = Path(dst_folder)
+# def copy_contents(src_folder, dst_folder):
+#     """
+#     Helper function to port a test case data folder over to a temp directory
+#     used for testing purposes so that the test case data doesn't get overwritten
+#     """
+#     src_path = Path(src_folder)
+#     dst_path = Path(dst_folder)
 
-    # Create the destination folder if it doesn't exist
-    dst_path.mkdir(parents=True, exist_ok=True)
+#     # Create the destination folder if it doesn't exist
+#     dst_path.mkdir(parents=True, exist_ok=True)
 
-    for item in src_path.iterdir():
-        # Construct the source and destination paths
-        src_item = src_path / item
-        dst_item = dst_path / item.name
+#     for item in src_path.iterdir():
+#         # Construct the source and destination paths
+#         src_item = src_path / item
+#         dst_item = dst_path / item.name
 
-        # Copy file or directory
-        if src_item.is_file():
-            logger.info(f"Copying file at {src_item} to {dst_item}")
-            shutil.copy2(src_item, dst_item)  # Copy file preserving metadata
+#         # Copy file or directory
+#         if src_item.is_file():
+#             logger.info(f"Copying file at {src_item} to {dst_item}")
+#             shutil.copy2(src_item, dst_item)  # Copy file preserving metadata
 
-        elif src_item.is_dir():
-            logger.info(f"Copying directory at {src_item} to {dst_item}")
-            shutil.copytree(src_item, dst_item)
+#         elif src_item.is_dir():
+#             logger.info(f"Copying directory at {src_item} to {dst_item}")
+#             shutil.copytree(src_item, dst_item)
 
 
 @pytest.fixture(params=TEST_SESSIONS)

--- a/tests/test_no_video_calibrate.py
+++ b/tests/test_no_video_calibrate.py
@@ -1,0 +1,28 @@
+
+from pathlib import Path
+from caliscope import __root__
+from caliscope.motion_trial import MotionTrial
+from caliscope.packets import XYZPacket
+import caliscope.logger
+
+logger = caliscope.logger.get(__name__)
+
+def test_no_video_calibrate():
+    """
+    Saving out of video may be maxing system resources when high res/many cameras. 
+    Allow user to toggle this off to free up resources
+    """
+    
+    
+    # copy over project to test
+    pass
+
+
+
+
+
+
+
+
+if __name__ == "__main__":
+    pass

--- a/tests/test_smoothing.py
+++ b/tests/test_smoothing.py
@@ -30,7 +30,8 @@ def test_smoothing_xyz():
 
     # Define your filter parameters
     order = 2
-    fs = config.get_fps_recording()  # sample rate, Hz
+    # fs = config.get_fps_recording()  # sample rate, Hz
+    fs = 15 # the value originally stored in the config file
     # note that the cutoff must be < 0.5*(sampling rate, a.k.a. nyquist frequency)
     cutoff = 6  # desired cutoff frequency, Hz
 


### PR DESCRIPTION
These changes allow the user to set two parameters within the `config.toml` (shown with their default values):

`fps_sync_stream_processing = 100`
`save_tracked_points_video = true`

With many cameras and higher resolutions, these defaults may result in excessive system resource demands. To reduce those demands, the processing fps can be reduced or the saving of videos with tracked points can be toggled off by setting it to `false`.

If changes are made in `config.toml`, the user can click `Reload Workspace` from the main tab and future processing should be updated to reflect the configuration.


