### PR TITLE
652 allow setting of legacy pattern for charuco

### DIFF
--- a/caliscope/calibration/charuco.py
+++ b/caliscope/calibration/charuco.py
@@ -36,6 +36,7 @@ class Charuco:
         aruco_scale=0.75,
         square_size_overide_cm=None,
         inverted=False,
+        legacy_pattern=False
     ):  # after printing, measure actual and return to overide
         """
         Create board based on shape and dimensions
@@ -54,6 +55,7 @@ class Charuco:
         # to maximize size of squares
         self.square_size_overide_cm = square_size_overide_cm
         self.inverted = inverted
+        self.legacy_pattern = legacy_pattern
 
     @property
     def board_height_cm(self):
@@ -105,12 +107,15 @@ class Charuco:
 
         aruco_length = square_length * self.aruco_scale
         # create the board
-        return cv2.aruco.CharucoBoard(size=(self.columns, self.rows),
+        board = cv2.aruco.CharucoBoard(size=(self.columns, self.rows),
                                       squareLength= square_length,
                                       markerLength= aruco_length,
                                       dictionary= self.dictionary_object,
         )
 
+        logger.info(f"Setting legacy pattern of board to {self.legacy_pattern}")
+        board.setLegacyPattern(self.legacy_pattern)
+        return board
 
     def board_img(self, pixmap_scale=1000):
         """

--- a/caliscope/configurator.py
+++ b/caliscope/configurator.py
@@ -200,6 +200,12 @@ class Configurator:
         logger.info("Loading charuco from config")
         params = self.dict["charuco"]
 
+        # the below is intended to catch people using older configs without this info
+        # if you come across this in mid 2025 or later, these may be safe to delete
+        logger.info(f"charuco param are: {params}:")
+        if "legacy_pattern" not in params.keys():
+            params["legacy_pattern"]=False
+
         charuco = Charuco(
             columns=params["columns"],
             rows=params["rows"],
@@ -210,6 +216,7 @@ class Configurator:
             aruco_scale=params["aruco_scale"],
             square_size_overide_cm=params["square_size_overide_cm"],
             inverted=params["inverted"],
+            legacy_pattern=params["legacy_pattern"]
         )
 
         return charuco

--- a/caliscope/gui/charuco_widget.py
+++ b/caliscope/gui/charuco_widget.py
@@ -142,6 +142,7 @@ class CharucoWidget(QWidget):
         # a
         inverted = self.charuco_config.invert_checkbox.isChecked()
         dictionary_str = self.params["dictionary"]
+        legacy_pattern = self.params["legacy_pattern"]
 
         self.charuco = Charuco(
             columns,
@@ -153,6 +154,7 @@ class CharucoWidget(QWidget):
             aruco_scale=aruco_scale,
             square_size_overide_cm=square_edge_length,
             inverted=inverted,
+            legacy_pattern=legacy_pattern
         )
 
         if not self.charuco_added:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "caliscope"
-version = "0.5.2"
+version = "0.5.3"
 description = "GUI based multicamera calibration that integrates with 2D landmark tracking to triangulate 3D landmark positions"
 authors = ["Mac Prible <prible@gmail.com>"]
 license = "BSD-2-Clause"


### PR DESCRIPTION
This may have unearthed some weird technical debt building up in the charuco widget, but otherwise I think this is now working and will integrate with the calib.io boards that are professionally made.