### PR TITLE
fix log path reference

### DIFF
--- a/caliscope/__init__.py
+++ b/caliscope/__init__.py
@@ -22,6 +22,7 @@ APP_DIR = Path(user_data_dir(appname=__package_name__))
 # - macOS:   ~/Library/Logs/caliscope
 # - Linux:   ~/.config/caliscope/logs  (or ~/.local/state/... depending on XDG spec)
 LOG_DIR = APP_DIR / "logs"
+LOG_FILE_PATH = LOG_DIR / "caliscope.log"
 
 # Define the path to the settings file
 APP_SETTINGS_PATH = APP_DIR / "settings.toml"

--- a/caliscope/logger.py
+++ b/caliscope/logger.py
@@ -2,14 +2,9 @@ import logging
 import logging.handlers
 import os
 import sys
-from pathlib import Path
 
 from PySide6 import QtCore
-
-# Assuming LOG_DIR is defined in your project's __init__.py or config
-# from caliscope import LOG_DIR
-# Using a placeholder for this example:
-LOG_DIR = Path("./logs")
+from caliscope import LOG_FILE_PATH, LOG_DIR
 
 
 class StderrLogger:
@@ -87,9 +82,12 @@ def setup_logging():
 
     # 1. File Handler
     LOG_DIR.mkdir(parents=True, exist_ok=True)
-    log_file = LOG_DIR / "caliscope.log"
+
+    with LOG_FILE_PATH.open("a") as f:
+        f.write("Rotating Log File Handler Setting Up....")
+
     file_handler = logging.handlers.RotatingFileHandler(
-        filename=log_file, maxBytes=5 * 1024 * 1024, backupCount=5, encoding="utf-8"
+        filename=LOG_FILE_PATH, maxBytes=5 * 1024 * 1024, backupCount=5, encoding="utf-8"
     )
     file_handler.setFormatter(formatter)
     file_handler.setLevel(logging.INFO)

--- a/caliscope/startup.py
+++ b/caliscope/startup.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import rtoml
 
-from caliscope import APP_DIR, APP_SETTINGS_PATH, LOG_DIR, __package_name__, __repo_url__
+from caliscope import APP_SETTINGS_PATH, LOG_FILE_PATH, __package_name__, __repo_url__
 
 logger = logging.getLogger(__name__)
 
@@ -17,13 +17,13 @@ def initialize_app():
     Returns the loaded user settings.
     """
 
-    log_startup_info()
+    """Logs essential application information on startup."""
+    logger.info(f"--- Launching {__package_name__} ---")
+    logger.info(f"Source code available at: {__repo_url__}")
+    logger.info(f"Logs saved to: {LOG_FILE_PATH}")
+    logger.info("-------------------------------------------")
 
     try:
-        # Create the app directory if it doesn't exist
-        APP_DIR.mkdir(exist_ok=True, parents=True)
-        LOG_DIR.mkdir(exist_ok=True, parents=True)
-
         # If the settings file doesn't exist, create it with defaults
         if not APP_SETTINGS_PATH.exists():
             logger.info(f"Settings file not found. Creating a new one at {APP_SETTINGS_PATH}")
@@ -43,11 +43,3 @@ def initialize_app():
         logger.error(f"Failed to initialize application directories or settings: {e}")
         # Depending on how critical this is, you might want to exit or return default settings
         return {}
-
-
-def log_startup_info():
-    """Logs essential application information on startup."""
-    logger.info(f"--- Launching {__package_name__} ---")
-    logger.info(f"Source code available at: {__repo_url__}")
-    logger.info(f"Log files are stored in: {LOG_DIR}")
-    logger.info("-------------------------------------------")


### PR DESCRIPTION
temp reference had been created as a placeholder and never got updated.

Some other small tweaks to the the app initiation and log setup were made to improve overall readability.