### PR TITLE
add text labels to camera meshes for better identification

### DIFF
--- a/caliscope/gui/vizualize/calibration/capture_volume_visualizer.py
+++ b/caliscope/gui/vizualize/calibration/capture_volume_visualizer.py
@@ -50,9 +50,12 @@ class CaptureVolumeVisualizer:
                 logger.info(f"Skip mesh creation for camera on port {port}: missing rotation/translation.")
                 continue
 
-            mesh: CameraMesh = mesh_from_camera(cam)
+            mesh: CameraMesh
+            text: gl.GLTextItem
+            mesh, text = mesh_from_camera(cam)
             self.meshes[port] = mesh
             self.scene.addItem(mesh)
+            self.scene.addItem(text)
 
         # self.scene.show()
 

--- a/caliscope/gui/vizualize/camera_mesh.py
+++ b/caliscope/gui/vizualize/camera_mesh.py
@@ -88,7 +88,7 @@ def rotation_to_float(rotation_matrix):
 
 
 # helper functions to assist with scene creation
-def mesh_from_camera(camera_data: CameraData) -> CameraMesh:
+def mesh_from_camera(camera_data: CameraData) -> tuple[CameraMesh, gl.GLTextItem]:
     """ "
     Mesh is placed at origin by default. Note that it appears rotations
     are in the mesh frame of reference and translations are in
@@ -119,7 +119,11 @@ def mesh_from_camera(camera_data: CameraData) -> CameraMesh:
     x, y, z = [p for p in camera_origin_world]
     mesh.translate(x, y, z)
 
-    return mesh
+    # add text label to distinguish multiple cameras and shift it slightly above the mesh
+    z += 0.05
+    tx = gl.GLTextItem(text=f"Cam {camera_data.port}", pos=(x, y, z), font=pg.QtGui.QFont("Helvetica", 10))
+
+    return mesh, tx
 
 
 def rotationMatrixToEulerAngles(R):

--- a/caliscope/gui/vizualize/playback_triangulation_widget.py
+++ b/caliscope/gui/vizualize/playback_triangulation_widget.py
@@ -89,9 +89,12 @@ class TriangulationVisualizer:
         if self.camera_array.all_extrinsics_calibrated():
             self.meshes = {}
             for port, cam in self.camera_array.cameras.items():
-                mesh: CameraMesh = mesh_from_camera(cam)
+                mesh: CameraMesh
+                text: gl.GLTextItem
+                mesh, text = mesh_from_camera(cam)
                 self.meshes[port] = mesh
                 self.scene.addItem(mesh)
+                self.scene.addItem(text)
 
         self.scatter = gl.GLScatterPlotItem(
             pos=np.array([0, 0, 0]),


### PR DESCRIPTION
`GLTextItem` with port number is added to each mesh in the 3D visualization. Function `mesh_from_camera` now returns the mesh and the text object instead of only the mesh object.

Implements part of #782 