### PR TITLE
Pass CameraData to RecordedStream directly

### DIFF
--- a/src/caliscope/managers/intrinsic_stream_manager.py
+++ b/src/caliscope/managers/intrinsic_stream_manager.py
@@ -33,8 +33,7 @@ class IntrinsicStreamManager:
             logger.info(f"Loading stream tools associated with camera {camera.port}")
             stream = RecordedStream(
                 directory=self.recording_dir,
-                port=camera.port,
-                rotation_count=camera.rotation_count,
+                camera=camera,
                 tracker=self.tracker,
                 break_on_last=False,
             )

--- a/src/caliscope/managers/synchronized_stream_manager.py
+++ b/src/caliscope/managers/synchronized_stream_manager.py
@@ -52,8 +52,7 @@ class SynchronizedStreamManager:
         for camera in self.all_camera_data.values():
             stream = RecordedStream(
                 directory=self.recording_dir,
-                port=camera.port,
-                rotation_count=camera.rotation_count,
+                camera=camera,
                 tracker=self.tracker,
                 break_on_last=True,
             )

--- a/src/caliscope/recording/recorded_stream.py
+++ b/src/caliscope/recording/recorded_stream.py
@@ -7,6 +7,7 @@ from time import perf_counter, sleep
 import cv2
 import numpy as np
 import pandas as pd
+from caliscope.cameras.camera_array import CameraData
 from caliscope.tracker import Tracker
 from caliscope.packets import FramePacket
 
@@ -24,17 +25,15 @@ class RecordedStream:
     def __init__(
         self,
         directory: Path,
-        port: int,
-        # size: tuple = None,
-        rotation_count: int = 0,
+        camera: CameraData,
         fps_target: int = None,
         tracker: Tracker = None,
         break_on_last=True,
     ):
-        # self.port = port
         self.directory = directory
-        self.port = port
-        self.rotation_count = rotation_count
+        self.camera = camera
+        self.port = camera.port
+        self.rotation_count = camera.rotation_count
 
         # stop while loop if end reached.
         # Preferred behavior for automated file processing, not interactive frame selection

--- a/tests/test_intrinsic_calibrator.py
+++ b/tests/test_intrinsic_calibrator.py
@@ -27,9 +27,10 @@ def test_intrinsic_calibrator(tmp_path: Path):
 
     charuco_tracker = CharucoTracker(charuco)
 
-    stream = RecordedStream(recording_directory, port=1, rotation_count=0, tracker=charuco_tracker)
+    stream_camera = CameraData(port=1, size=[640, 480])  # placeholder; stream reads actual from video
+    stream = RecordedStream(recording_directory, camera=stream_camera, tracker=charuco_tracker)
 
-    camera = CameraData(port=0, size=stream.size)
+    camera = CameraData(port=0, size=stream.size)  # fresh camera for calibration
 
     assert camera.rotation is None
     assert camera.translation is None
@@ -88,9 +89,10 @@ def test_autopopulate_data(tmp_path: Path):
 
     charuco_tracker = CharucoTracker(charuco)
 
-    stream = RecordedStream(recording_directory, port=1, rotation_count=0, tracker=charuco_tracker)
+    stream_camera = CameraData(port=1, size=[640, 480])  # placeholder; stream reads actual from video
+    stream = RecordedStream(recording_directory, camera=stream_camera, tracker=charuco_tracker)
 
-    camera = CameraData(port=0, size=stream.size)
+    camera = CameraData(port=0, size=stream.size)  # fresh camera for calibration
 
     assert camera.rotation is None
     assert camera.translation is None

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -6,6 +6,7 @@ from time import sleep
 import cv2
 
 from caliscope import __root__
+from caliscope.cameras.camera_array import CameraData
 from caliscope.core.charuco import Charuco
 from caliscope.recording.recorded_stream import RecordedStream
 from caliscope.trackers.charuco_tracker import CharucoTracker
@@ -20,7 +21,8 @@ def test_stream():
 
     charuco_tracker = CharucoTracker(charuco)
 
-    stream = RecordedStream(recording_directory, port=1, rotation_count=0, tracker=charuco_tracker, fps_target=6)
+    camera = CameraData(port=1, size=[640, 480])  # placeholder size; stream reads actual from video
+    stream = RecordedStream(recording_directory, camera=camera, tracker=charuco_tracker, fps_target=6)
     frame_q = Queue()
     stream.subscribe(frame_q)
     stream.play_video()

--- a/tests/test_triangulator.py
+++ b/tests/test_triangulator.py
@@ -45,10 +45,7 @@ def test_triangulator(tmp_path: Path):
 
     streams = {}
     for port, camera in camera_array.cameras.items():
-        rotation_count = camera.rotation_count
-        streams[port] = RecordedStream(
-            recording_directory, port, rotation_count, fps_target=100, tracker=charuco_tracker
-        )
+        streams[port] = RecordedStream(recording_directory, camera=camera, fps_target=100, tracker=charuco_tracker)
 
     logger.info("Creating Synchronizer")
     syncr = Synchronizer(streams)


### PR DESCRIPTION
## Summary
- Replace separate `port` and `rotation_count` parameters with a `CameraData` reference
- Simplifies the interface and positions `RecordedStream` to use camera intrinsics in future work (#737)

## Changes
- `RecordedStream.__init__` now takes `camera: CameraData` instead of `port: int, rotation_count: int`
- Updated call sites in `IntrinsicStreamManager` and `SynchronizedStreamManager`
- Updated tests to create `CameraData` objects

## Test plan
- [x] All 5 affected tests pass (`test_stream`, `test_intrinsic_calibrator` x2, `test_triangulator`, `test_sync_stream_manager`)
- [x] Ruff linting passes

Closes #736