### PR TITLE
Fix off-by-one issue in RecordedStream frame_index

### DIFF
--- a/src/caliscope/recording/recorded_stream.py
+++ b/src/caliscope/recording/recorded_stream.py
@@ -218,10 +218,7 @@ class RecordedStream:
             for q in self.subscribers:
                 q.put(frame_packet)
 
-            logger.debug(f"Incrementing frame index from {self.frame_index} to {self.frame_index + 1}")
-            self.frame_index += 1
-
-            if self.frame_index > self.last_frame_index and self.break_on_last:
+            if self.frame_index == self.last_frame_index and self.break_on_last:
                 logger.info(f"Ending recorded playback at port {self.port}")
                 # time of -1 indicates end of stream
                 frame_packet = FramePacket(
@@ -237,8 +234,7 @@ class RecordedStream:
                 break
 
             ############ Autopause if last frame and in playback mode (i.e. break_on_last == False)
-            if not self.break_on_last and self.frame_index > self.last_frame_index:
-                self.frame_index = self.last_frame_index
+            if not self.break_on_last and self.frame_index == self.last_frame_index:
                 self._pause_event.set()
 
             ############ SPIN LOCK FOR PAUSE ##################
@@ -259,3 +255,6 @@ class RecordedStream:
                 self.frame_index = self._jump_q.get()
                 logger.info(f"Setting port {self.port} capture object to frame index {self.frame_index}")
                 self.capture.set(cv2.CAP_PROP_POS_FRAMES, self.frame_index)
+            else:
+                # Increment for next iteration (only if not jumping)
+                self.frame_index += 1

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -58,12 +58,15 @@ def test_stream():
             sleep(1)  # need to make sure fps_target wait plays out
             stream.jump_to(target_frame)
             sleep(1)  # need to make sure fps_target wait plays out
-            assert stream.frame_index == 21
+            # frame_index should match the jump target (the frame we just displayed)
+            assert stream.frame_index == 20
 
             logger.info(f"After attempting to jump to target frame {target_frame} ")
-            current_frame = int(stream.capture.get(cv2.CAP_PROP_POS_FRAMES))
-            logger.info(f"Current frame is now {current_frame}")
-            assert current_frame == 21
+            # OpenCV's CAP_PROP_POS_FRAMES returns the NEXT frame to be read
+            next_frame_position = int(stream.capture.get(cv2.CAP_PROP_POS_FRAMES))
+            logger.info(f"Next frame position is {next_frame_position}")
+            # After reading frame 20, capture position advances to 21
+            assert next_frame_position == 21
             stream.unpause()
 
         # cv2.imshow("Test", frame_packet.frame_with_points)


### PR DESCRIPTION
## Summary

- Fixes the off-by-one issue where `frame_index` was incremented before the pause spinlock, causing it to always be "one ahead" of the displayed frame when paused
- After `jump_to(N)`, `stream.frame_index` now correctly equals `N` instead of `N+1`

## Changes

- Move `frame_index` increment from before pause spinlock to after jump check
- Change end-of-stream checks from `>` to `==` (pre-increment semantics)
- Remove unnecessary `frame_index` reset in autopause branch
- Update test assertions and improve variable naming for clarity

## Test plan

- [x] `test_stream.py` passes with corrected assertions
- [x] Full test suite (64 tests) passes

Fixes #640