### PR TITLE
feat(scripts): add Ralph Wiggum visual testing framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 scripts/*
+!scripts/ralph_wiggum_viz/
+scripts/ralph_wiggum_viz/output/
 tests/debug/*
 *context.txt
 *.png

--- a/scripts/ralph_wiggum_viz/README.md
+++ b/scripts/ralph_wiggum_viz/README.md
@@ -1,0 +1,167 @@
+# Ralph Wiggum GUI Visual Testing
+
+Visual debugging and development technique for PySide6/Qt applications. Named for the "I'm in danger" meme — when you're deep in visual bugs and need to see what's actually happening.
+
+## The Technique
+
+Instead of relying on logs or assertions, capture screenshots at each step and have Claude verify them visually. This creates a fast iteration loop for GUI development:
+
+1. Make code change
+2. Run script that exercises UI and captures screenshots
+3. Claude reviews screenshots (via Haiku delegation)
+4. Claude makes next code change
+5. Repeat
+
+**Key insight:** The script IS the spec — visual TDD.
+
+## When to Use
+
+- Display corruption (wrong colors, rotation, shearing)
+- Widget/component rendering problems
+- GUI feature development needing visual validation
+- Any bug where "you need to see the actual output"
+
+## Directory Structure
+
+```
+scripts/ralph_wiggum_viz/
+├── utils.py              # Core utilities
+├── rw_charuco_widget.py  # Widget interaction test
+├── rw_capture_volume.py  # 3D OpenGL rendering test
+├── rw_full_workflow.py   # Full app smoke test
+├── README.md
+└── output/               # Screenshots saved here (gitignored)
+```
+
+## Running Scripts
+
+```bash
+# With display
+python scripts/ralph_wiggum_viz/rw_charuco_widget.py
+
+# Headless (Linux) - required for CI or remote sessions
+xvfb-run --auto-servernum python scripts/ralph_wiggum_viz/rw_full_workflow.py
+```
+
+## Core Utilities
+
+```python
+from utils import capture_widget, process_events_for, clear_output_dir
+
+# Capture widget to PNG
+capture_widget(widget, "01_initial.png")
+
+# Let Qt process events (essential before captures)
+process_events_for(500)  # milliseconds
+
+# Clear output directory at start of test
+clear_output_dir()
+```
+
+## Writing New Scripts
+
+### Naming Convention
+
+Use `rw_` prefix to avoid pytest collection:
+- `rw_my_feature.py` (not `test_my_feature.py`)
+
+### Basic Pattern
+
+```python
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from PySide6.QtWidgets import QApplication
+from utils import capture_widget, clear_output_dir, process_events_for
+
+def main():
+    clear_output_dir()
+    app = QApplication(sys.argv)
+
+    # Create your widget
+    widget = YourWidget()
+    widget.show()
+    process_events_for(500)
+
+    # Capture initial state
+    capture_widget(widget, "01_initial.png")
+
+    # Interact with widget
+    widget.some_button.click()
+    process_events_for(300)
+    capture_widget(widget, "02_after_click.png")
+
+    # Print verification checklist
+    print("Verification checklist:")
+    print("  [ ] 01: Widget renders correctly")
+    print("  [ ] 02: Button click had expected effect")
+
+if __name__ == "__main__":
+    main()
+```
+
+### Async Loading Pattern
+
+For widgets that load data asynchronously (like MainWindow loading a workspace):
+
+```python
+class WorkflowTest:
+    def __init__(self, window):
+        self.window = window
+
+    def run(self):
+        # Launch operation first
+        self.window.launch_workspace(path)
+        # Then connect to completion signal
+        self.window.controller.load_workspace_thread.finished.connect(
+            self.on_loaded
+        )
+
+    def on_loaded(self):
+        # Now safe to interact
+        QTimer.singleShot(500, self.capture_state)
+```
+
+## Visual Verification with Haiku
+
+After capturing screenshots, spawn a Haiku agent with targeted questions:
+
+```
+Use Task tool with model="haiku":
+
+"Review the screenshots in scripts/ralph_wiggum_viz/output/
+
+We tested [describe what the script does]:
+1. Screenshot 01: [what it should show]
+2. Screenshot 02: [what it should show]
+
+Verify:
+- Does 01 show [specific expected element]?
+- Does 02 show [specific change from interaction]?
+- Any error dialogs or rendering issues?"
+```
+
+The orchestrator provides context about what the script did — Haiku answers specific verification questions rather than generic "describe these images".
+
+### Override: Direct Review
+
+If Haiku's descriptions aren't helping after 2-3 iterations, read the screenshots directly to get unstuck. Note: each screenshot costs ~1.3k tokens in the main context.
+
+## Example Scripts
+
+| Script | Tests | Complexity |
+|--------|-------|------------|
+| `rw_charuco_widget.py` | Spinbox/checkbox interactions | Simple - direct widget |
+| `rw_capture_volume.py` | 3D OpenGL rendering | Medium - data loading |
+| `rw_full_workflow.py` | Full app navigation | Complex - async loading |
+
+## Tips
+
+- **OpenGL widgets** need longer delays (1000-1500ms) for initialization
+- **Print progress** so you can see where scripts fail
+- **Print verification checklist** at the end for quick reference
+- **Clear output dir** at start to avoid stale screenshots
+- **Use process_events_for()** before every capture — Qt needs time to render

--- a/scripts/ralph_wiggum_viz/rw_capture_volume.py
+++ b/scripts/ralph_wiggum_viz/rw_capture_volume.py
@@ -1,0 +1,134 @@
+"""Visual test for CaptureVolumeVisualizer (3D OpenGL rendering).
+
+Ralph Wiggum script testing the 3D capture volume display.
+Loads a calibrated project, creates the visualizer, and captures
+screenshots of the OpenGL scene with camera frustums and point cloud.
+
+Usage:
+    python scripts/ralph_wiggum_viz/rw_capture_volume.py
+
+Or headless:
+    xvfb-run python scripts/ralph_wiggum_viz/rw_capture_volume.py
+"""
+
+import sys
+from pathlib import Path
+
+# Add project src to path
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from PySide6.QtWidgets import QApplication  # noqa: E402
+
+from caliscope.core.capture_volume.capture_volume import CaptureVolume  # noqa: E402
+from caliscope.gui.vizualize.calibration.capture_volume_visualizer import (  # noqa: E402
+    CaptureVolumeVisualizer,
+)
+from caliscope.managers.camera_array_manager import CameraArrayManager  # noqa: E402
+from caliscope.managers.capture_volume_data_manager import (  # noqa: E402
+    CaptureVolumeDataManager,
+)
+
+from utils import capture_widget, clear_output_dir, process_events_for  # noqa: E402
+
+# Use sample project which is fully calibrated
+SAMPLE_PROJECT = Path("/home/mprib/caliscope_projects/new_minimal_project")
+
+
+def main():
+    clear_output_dir()
+
+    if not SAMPLE_PROJECT.exists():
+        print(f"ERROR: Sample project not found at {SAMPLE_PROJECT}")
+        sys.exit(1)
+
+    print(f"Using project: {SAMPLE_PROJECT}")
+
+    # Initialize Qt application
+    QApplication(sys.argv)
+
+    # Load camera array
+    camera_manager = CameraArrayManager(SAMPLE_PROJECT / "camera_array.toml")
+    camera_array = camera_manager.load()
+    print(f"Loaded camera array with {len(camera_array.cameras)} cameras")
+
+    # Load capture volume data
+    cv_manager = CaptureVolumeDataManager(SAMPLE_PROJECT)
+    if not cv_manager.exists():
+        print("ERROR: Capture volume data not found in project")
+        sys.exit(1)
+
+    point_estimates = cv_manager.load_point_estimates()
+    metadata = cv_manager.load_metadata()
+    print(f"Loaded point estimates with {len(point_estimates.obj)} points")
+
+    # Create CaptureVolume
+    capture_volume = CaptureVolume(
+        camera_array=camera_array,
+        _point_estimates=point_estimates,
+        stage=metadata.get("stage", 0),
+        origin_sync_index=metadata.get("origin_sync_index"),
+    )
+
+    # Create the visualizer
+    visualizer = CaptureVolumeVisualizer(capture_volume=capture_volume)
+    visualizer.scene.resize(800, 600)
+    visualizer.scene.show()
+
+    # OpenGL needs extra time to initialize
+    process_events_for(1500)
+
+    # Step 1: Initial view
+    capture_widget(visualizer.scene, "01_initial_3d.png")
+    print("Step 1: Initial 3D view captured")
+
+    # Step 2: Display points at first sync index
+    if visualizer.point_estimates is not None:
+        first_sync = visualizer.min_sync_index
+        visualizer.display_points(first_sync)
+        process_events_for(500)
+        capture_widget(visualizer.scene, "02_with_points.png")
+        print(f"Step 2: Points displayed at sync_index={first_sync}")
+
+        # Step 3: Move to middle sync index
+        mid_sync = (visualizer.min_sync_index + visualizer.max_sync_index) // 2
+        visualizer.display_points(mid_sync)
+        process_events_for(500)
+        capture_widget(visualizer.scene, "03_mid_sync.png")
+        print(f"Step 3: Points at mid sync_index={mid_sync}")
+
+        # Step 4: Move to last sync index
+        last_sync = visualizer.max_sync_index
+        visualizer.display_points(last_sync)
+        process_events_for(500)
+        capture_widget(visualizer.scene, "04_last_sync.png")
+        print(f"Step 4: Points at last sync_index={last_sync}")
+
+    # Step 5: Rotate camera view
+    visualizer.scene.setCameraPosition(azimuth=45, elevation=30, distance=5)
+    process_events_for(500)
+    capture_widget(visualizer.scene, "05_rotated_view.png")
+    print("Step 5: Rotated camera view (azimuth=45, elevation=30)")
+
+    # Step 6: Different rotation
+    visualizer.scene.setCameraPosition(azimuth=135, elevation=60, distance=3)
+    process_events_for(500)
+    capture_widget(visualizer.scene, "06_top_view.png")
+    print("Step 6: Top-ish view (azimuth=135, elevation=60)")
+
+    print("\n" + "=" * 50)
+    print("CAPTURE VOLUME TEST COMPLETE")
+    print("=" * 50)
+    print("\nScreenshots saved to: scripts/ralph_wiggum/gui/output/")
+    print("\nVerification checklist:")
+    print("  [ ] 01: 3D scene renders with axis and camera frustums")
+    print("  [ ] 02: White point cloud visible in scene")
+    print("  [ ] 03: Points moved (different position in capture volume)")
+    print("  [ ] 04: Points at different position again")
+    print("  [ ] 05: View rotated (different angle)")
+    print("  [ ] 06: View from above (higher elevation)")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ralph_wiggum_viz/rw_charuco_widget.py
+++ b/scripts/ralph_wiggum_viz/rw_charuco_widget.py
@@ -1,0 +1,122 @@
+"""Visual test for CharucoWidget interactions.
+
+Ralph Wiggum script demonstrating widget interaction testing pattern.
+Creates the CharucoWidget and interacts with spinboxes/checkboxes to
+change parameters, capturing screenshots at each state.
+
+Usage:
+    python scripts/ralph_wiggum_viz/rw_charuco_widget.py
+
+Or headless:
+    xvfb-run python scripts/ralph_wiggum_viz/rw_charuco_widget.py
+"""
+
+import sys
+from pathlib import Path
+
+# Add project src to path
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from PySide6.QtWidgets import QApplication  # noqa: E402
+
+from caliscope.controller import Controller  # noqa: E402
+from caliscope.gui.charuco_widget import CharucoWidget  # noqa: E402
+
+from utils import capture_widget, clear_output_dir, process_events_for  # noqa: E402
+
+# Use sample project which has config files
+SAMPLE_PROJECT = Path("/home/mprib/caliscope_projects/new_minimal_project")
+
+
+def main():
+    clear_output_dir()
+
+    if not SAMPLE_PROJECT.exists():
+        print(f"ERROR: Sample project not found at {SAMPLE_PROJECT}")
+        sys.exit(1)
+
+    print(f"Using project: {SAMPLE_PROJECT}")
+
+    # Initialize Qt application
+    QApplication(sys.argv)
+
+    # Create controller (loads charuco config from project)
+    controller = Controller(SAMPLE_PROJECT)
+
+    # Create the CharucoWidget
+    widget = CharucoWidget(controller)
+    widget.resize(600, 700)
+    widget.show()
+
+    process_events_for(500)  # Let it render
+
+    # Step 1: Capture initial state
+    capture_widget(widget, "01_initial.png")
+    print(
+        f"Step 1: Initial state - rows={widget.charuco_config.row_spin.value()}, "
+        f"cols={widget.charuco_config.column_spin.value()}"
+    )
+
+    # Step 2: Change rows (interact with spinbox)
+    original_rows = widget.charuco_config.row_spin.value()
+    new_rows = original_rows + 2
+    print(f"Step 2: Changing rows from {original_rows} to {new_rows}...")
+    widget.charuco_config.row_spin.setValue(new_rows)
+    process_events_for(300)
+    capture_widget(widget, "02_more_rows.png")
+    print(f"Step 2: Rows changed to {new_rows}")
+
+    # Step 3: Change columns
+    original_cols = widget.charuco_config.column_spin.value()
+    new_cols = original_cols + 3
+    print(f"Step 3: Changing columns from {original_cols} to {new_cols}...")
+    widget.charuco_config.column_spin.setValue(new_cols)
+    process_events_for(300)
+    capture_widget(widget, "03_more_columns.png")
+    print(f"Step 3: Columns changed to {new_cols}")
+
+    # Step 4: Toggle invert checkbox
+    was_inverted = widget.charuco_config.invert_checkbox.isChecked()
+    print(f"Step 4: Toggling invert from {was_inverted} to {not was_inverted}...")
+    widget.charuco_config.invert_checkbox.click()
+    process_events_for(300)
+    capture_widget(widget, "04_inverted.png")
+    print(f"Step 4: Invert toggled to {widget.charuco_config.invert_checkbox.isChecked()}")
+
+    # Step 5: Change board dimensions (width)
+    original_width = widget.charuco_config.width_spin.value()
+    new_width = original_width * 1.5
+    print(f"Step 5: Changing width from {original_width} to {new_width}...")
+    widget.charuco_config.width_spin.setValue(new_width)
+    process_events_for(300)
+    capture_widget(widget, "05_wider_board.png")
+    print(f"Step 5: Width changed to {new_width}")
+
+    # Step 6: Reset to something reasonable and toggle invert back
+    print("Step 6: Resetting to clean state...")
+    widget.charuco_config.row_spin.setValue(4)
+    widget.charuco_config.column_spin.setValue(5)
+    widget.charuco_config.width_spin.setValue(8.5)
+    if widget.charuco_config.invert_checkbox.isChecked():
+        widget.charuco_config.invert_checkbox.click()
+    process_events_for(300)
+    capture_widget(widget, "06_reset.png")
+    print("Step 6: Reset to 4x5 standard board")
+
+    print("\n" + "=" * 50)
+    print("CHARUCO WIDGET TEST COMPLETE")
+    print("=" * 50)
+    print("\nScreenshots saved to: scripts/ralph_wiggum/gui/output/")
+    print("\nVerification checklist:")
+    print("  [ ] 01: Initial charuco board renders with config controls visible")
+    print("  [ ] 02: Board has more rows (taller grid)")
+    print("  [ ] 03: Board has more columns (wider grid)")
+    print("  [ ] 04: Board colors are inverted (white corners)")
+    print("  [ ] 05: Board aspect ratio changed (wider)")
+    print("  [ ] 06: Board reset to standard 4x5 non-inverted")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ralph_wiggum_viz/rw_full_workflow.py
+++ b/scripts/ralph_wiggum_viz/rw_full_workflow.py
@@ -1,0 +1,211 @@
+"""Full app workflow smoke test for Caliscope.
+
+Ralph Wiggum visual testing script that:
+1. Launches the full application with a sample project
+2. Navigates to the Camera tab
+3. Plays video, captures screenshot
+4. Pauses, moves slider, captures screenshot
+5. Clicks autocalibrate, waits 4 seconds, captures screenshot
+6. Navigates to Capture Volume tab (if enabled), captures screenshot
+
+Uses QTimer.singleShot() for sequencing async operations.
+
+Usage:
+    xvfb-run python scripts/ralph_wiggum_viz/rw_full_workflow.py
+
+Or with a display:
+    python scripts/ralph_wiggum_viz/rw_full_workflow.py
+"""
+
+import sys
+from pathlib import Path
+
+# Add project src to path
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from PySide6.QtCore import QTimer  # noqa: E402
+from PySide6.QtWidgets import QApplication  # noqa: E402
+
+from caliscope.cameras.camera_array import CameraArray  # noqa: E402
+from caliscope.gui.main_widget import MainWindow  # noqa: E402
+from caliscope.gui.vizualize.calibration.capture_volume_visualizer import (  # noqa: E402
+    CaptureVolumeVisualizer,
+)
+
+from utils import capture_widget, clear_output_dir  # noqa: E402
+
+# Sample project path - fully calibrated
+SAMPLE_PROJECT = Path("/home/mprib/caliscope_projects/new_minimal_project")
+
+
+class FullWorkflowTest:
+    """Orchestrates the full workflow test sequence."""
+
+    def __init__(self, window: MainWindow, project_path: Path):
+        self.window = window
+        self.project_path = project_path
+        self.step = 0
+
+    def run(self):
+        """Start the test sequence."""
+        print(f"Loading project: {self.project_path}")
+
+        # Launch workspace first (this creates the controller)
+        self.window.launch_workspace(str(self.project_path))
+
+        # Now connect to workspace load completion
+        # (controller exists after launch_workspace is called)
+        self.window.controller.load_workspace_thread.finished.connect(self.on_workspace_loaded)
+
+    def on_workspace_loaded(self):
+        """Called when workspace finishes loading asynchronously."""
+        print("Workspace loaded, starting test sequence...")
+
+        # Small delay to let UI fully render
+        QTimer.singleShot(500, self.capture_initial)
+
+    def capture_initial(self):
+        """Step 1: Capture initial main window state."""
+        capture_widget(self.window, "01_main_initial.png")
+        print("Step 1: Initial state captured")
+
+        # Navigate to Cameras tab
+        cameras_index = self.window.find_tab_index_by_title("Cameras")
+        if cameras_index >= 0 and self.window.central_tab.isTabEnabled(cameras_index):
+            self.window.central_tab.setCurrentIndex(cameras_index)
+            QTimer.singleShot(500, self.capture_cameras_tab)
+        else:
+            print("WARNING: Cameras tab not found or not enabled")
+            self.try_capture_volume()
+
+    def capture_cameras_tab(self):
+        """Step 2: Capture Cameras tab."""
+        capture_widget(self.window, "02_cameras_tab.png")
+        print("Step 2: Cameras tab captured")
+
+        # Get the first camera's playback widget
+        tab_widget = self.window.intrinsic_cal_widget.tabWidget
+        if tab_widget.count() > 0:
+            first_cam_widget = tab_widget.widget(0)
+
+            # Click play button
+            print("Clicking play button...")
+            first_cam_widget.play_button.click()
+            QTimer.singleShot(1000, self.capture_playing)
+        else:
+            print("WARNING: No camera widgets found")
+            self.try_capture_volume()
+
+    def capture_playing(self):
+        """Step 3: Capture video playing state."""
+        capture_widget(self.window, "03_video_playing.png")
+        print("Step 3: Video playing captured")
+
+        # Pause and move slider
+        tab_widget = self.window.intrinsic_cal_widget.tabWidget
+        first_cam_widget = tab_widget.widget(0)
+
+        # Pause
+        print("Pausing video...")
+        first_cam_widget.play_button.click()
+
+        # Move slider to ~1/3 position
+        slider = first_cam_widget.slider
+        target_pos = slider.minimum() + (slider.maximum() - slider.minimum()) // 3
+        slider.setValue(target_pos)
+
+        QTimer.singleShot(500, self.capture_slider_moved)
+
+    def capture_slider_moved(self):
+        """Step 4: Capture after slider moved."""
+        capture_widget(self.window, "04_slider_moved.png")
+        print("Step 4: Slider moved captured")
+
+        # Click autocalibrate button
+        tab_widget = self.window.intrinsic_cal_widget.tabWidget
+        first_cam_widget = tab_widget.widget(0)
+
+        print("Clicking autocalibrate button...")
+        first_cam_widget.autocalibrate_btn.click()
+
+        # Wait 4 seconds for autocalibration to progress
+        QTimer.singleShot(4000, self.capture_autocalibrating)
+
+    def capture_autocalibrating(self):
+        """Step 5: Capture during autocalibration."""
+        capture_widget(self.window, "05_autocalibrating.png")
+        print("Step 5: Autocalibrating captured (4 seconds after click)")
+
+        # Try to navigate to Capture Volume tab
+        self.try_capture_volume()
+
+    def try_capture_volume(self):
+        """Step 6: Try to capture Capture Volume tab if enabled."""
+        cv_index = self.window.find_tab_index_by_title("Capture Volume")
+        if cv_index >= 0 and self.window.central_tab.isTabEnabled(cv_index):
+            self.window.central_tab.setCurrentIndex(cv_index)
+            # Longer delay for OpenGL initialization
+            QTimer.singleShot(1500, self.capture_capture_volume)
+        else:
+            print("Capture Volume tab not enabled (expected if not calibrated)")
+            self.finish()
+
+    def capture_capture_volume(self):
+        """Step 6: Capture Capture Volume tab."""
+        capture_widget(self.window, "06_capture_volume_tab.png")
+        print("Step 6: Capture Volume tab captured")
+        self.finish()
+
+    def finish(self):
+        """Test complete."""
+        print("\n" + "=" * 50)
+        print("RALPH WIGGUM WORKFLOW TEST COMPLETE")
+        print("=" * 50)
+        print("\nScreenshots saved to: scripts/ralph_wiggum/gui/output/")
+        print("\nVerification checklist:")
+        print("  [ ] 01: Main window renders, tabs visible")
+        print("  [ ] 02: Cameras tab shows camera sub-tabs, video frame visible")
+        print("  [ ] 03: Video frame has changed (different from 02)")
+        print("  [ ] 04: Frame changed after slider move (different position)")
+        print("  [ ] 05: Frame changed during autocalibration (grid overlay may appear)")
+        print("  [ ] 06: 3D capture volume renders (if tab was enabled)")
+        print()
+
+        QApplication.instance().quit()
+
+
+def main():
+    clear_output_dir()
+
+    if not SAMPLE_PROJECT.exists():
+        print(f"ERROR: Sample project not found at {SAMPLE_PROJECT}")
+        print("Please ensure the project exists or update SAMPLE_PROJECT path.")
+        sys.exit(1)
+
+    print(f"Project directory: {SAMPLE_PROJECT}")
+
+    # Initialize Qt application
+    app = QApplication(sys.argv)
+
+    # Warm up OpenGL (same as launch_main does)
+    dummy_widget = CaptureVolumeVisualizer(camera_array=CameraArray({}))
+    del dummy_widget
+
+    # Create main window
+    window = MainWindow()
+    window.resize(1200, 800)
+    window.show()
+
+    # Create and run test
+    test = FullWorkflowTest(window, SAMPLE_PROJECT)
+
+    # Start test after window is shown
+    QTimer.singleShot(100, test.run)
+
+    # Run event loop
+    app.exec()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ralph_wiggum_viz/utils.py
+++ b/scripts/ralph_wiggum_viz/utils.py
@@ -1,0 +1,103 @@
+"""Core utilities for Ralph Wiggum GUI visual testing.
+
+Provides reusable helpers for capturing screenshots and sequencing actions
+in PySide6/Qt applications. These utilities support the "Visual Ralph Wiggum"
+technique where Claude reviews screenshots to verify UI correctness.
+
+Usage:
+    from utils import capture_widget, process_events_for, schedule_actions
+
+    app = QApplication(sys.argv)
+    widget = MyWidget()
+    widget.show()
+
+    process_events_for(500)  # Let it render
+    capture_widget(widget, "01_initial.png")
+"""
+
+from collections.abc import Callable
+from pathlib import Path
+
+from PySide6.QtCore import QCoreApplication, QEventLoop, QTimer
+from PySide6.QtWidgets import QWidget
+
+OUTPUT_DIR = Path(__file__).parent / "output"
+
+
+def ensure_output_dir() -> Path:
+    """Create output directory if it doesn't exist."""
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    return OUTPUT_DIR
+
+
+def capture_widget(widget: QWidget, filename: str) -> Path:
+    """Capture a widget's current visual state to a PNG file.
+
+    Uses widget.grab() which captures the widget as it appears on screen,
+    including any child widgets and their current state.
+
+    Args:
+        widget: The Qt widget to capture
+        filename: Output filename (should end in .png)
+
+    Returns:
+        Path to the saved screenshot
+    """
+    path = ensure_output_dir() / filename
+    pixmap = widget.grab()
+    pixmap.save(str(path))
+    print(f"Captured: {path}")
+    return path
+
+
+def process_events_for(ms: int = 100) -> None:
+    """Process Qt events for a specified duration.
+
+    Allows the GUI to update, animations to run, and async operations
+    to complete before capturing screenshots. Essential for ensuring
+    the UI is in the expected state.
+
+    Args:
+        ms: Duration in milliseconds to process events
+    """
+    app = QCoreApplication.instance()
+    if app is None:
+        return
+
+    loop = QEventLoop()
+    QTimer.singleShot(ms, loop.quit)
+    loop.exec()
+
+
+def schedule_actions(actions: list[tuple[int, Callable[[], None]]]) -> None:
+    """Schedule a sequence of actions with delays.
+
+    Useful for scripting complex UI interactions where each step needs
+    time for the UI to respond before the next action.
+
+    Args:
+        actions: List of (delay_ms, callable) tuples. Each callable is
+            executed after its corresponding delay from when this
+            function is called.
+
+    Example:
+        schedule_actions([
+            (0, lambda: button.click()),
+            (500, lambda: capture_widget(widget, "01_after_click.png")),
+            (1000, lambda: app.quit()),
+        ])
+    """
+    for delay_ms, action in actions:
+        QTimer.singleShot(delay_ms, action)
+
+
+def clear_output_dir() -> None:
+    """Remove all files from the output directory.
+
+    Useful at the start of a test run to ensure clean state.
+    """
+    output_dir = ensure_output_dir()
+    for file in output_dir.iterdir():
+        if file.is_file():
+            file.unlink()
+    print(f"Cleared: {output_dir}")


### PR DESCRIPTION
## Summary

- Add visual debugging infrastructure for PySide6/Qt GUI development
- Instead of logs or assertions, captures screenshots and delegates verification to Claude (via Haiku) for fast iteration on visual bugs
- The loop: make code change → run script → Claude reviews screenshots → iterate

## What's Included

**Core utilities** (`scripts/ralph_wiggum_viz/utils.py`):
- `capture_widget()` - screenshot any Qt widget
- `process_events_for()` - let Qt render before capturing
- `clear_output_dir()` - clean slate for each run

**Example scripts**:
- `rw_charuco_widget.py` - widget interaction pattern (spinboxes, checkboxes)
- `rw_capture_volume.py` - 3D OpenGL rendering
- `rw_full_workflow.py` - full app smoke test with async loading

**Documentation** (`README.md`):
- Technique explanation
- Running instructions (`xvfb-run` for headless)
- Templates for new scripts
- Haiku delegation pattern for verification

## Design Decisions

- **`rw_` prefix**: Avoids pytest collection (not `test_*`)
- **Haiku delegation**: Each screenshot costs ~1.3k tokens; delegating to Haiku keeps main context lean for iterative work
- **`scripts/ralph_wiggum_viz/`**: Tracked in git, but `output/` is gitignored

## Test plan

- [x] `rw_charuco_widget.py` runs and captures 6 screenshots showing widget interactions
- [x] `rw_capture_volume.py` runs and captures 6 screenshots of 3D scene
- [x] `rw_full_workflow.py` runs full app workflow with async loading
- [x] Haiku verification passes on all screenshots

Closes #849