### PR TITLE
Rename Managers to Repositories

### DIFF
--- a/scripts/widget_visualization/wv_capture_volume.py
+++ b/scripts/widget_visualization/wv_capture_volume.py
@@ -24,9 +24,9 @@ from caliscope.core.capture_volume.capture_volume import CaptureVolume  # noqa: 
 from caliscope.gui.vizualize.calibration.capture_volume_visualizer import (  # noqa: E402
     CaptureVolumeVisualizer,
 )
-from caliscope.managers.camera_array_manager import CameraArrayManager  # noqa: E402
-from caliscope.managers.capture_volume_data_manager import (  # noqa: E402
-    CaptureVolumeDataManager,
+from caliscope.repositories import (  # noqa: E402
+    CameraArrayRepository,
+    CaptureVolumeRepository,
 )
 
 from utils import capture_widget, clear_output_dir, process_events_for  # noqa: E402
@@ -48,18 +48,18 @@ def main():
     QApplication(sys.argv)
 
     # Load camera array
-    camera_manager = CameraArrayManager(SAMPLE_PROJECT / "camera_array.toml")
-    camera_array = camera_manager.load()
+    camera_repository = CameraArrayRepository(SAMPLE_PROJECT / "camera_array.toml")
+    camera_array = camera_repository.load()
     print(f"Loaded camera array with {len(camera_array.cameras)} cameras")
 
     # Load capture volume data
-    cv_manager = CaptureVolumeDataManager(SAMPLE_PROJECT)
-    if not cv_manager.exists():
+    cv_repository = CaptureVolumeRepository(SAMPLE_PROJECT)
+    if not cv_repository.exists():
         print("ERROR: Capture volume data not found in project")
         sys.exit(1)
 
-    point_estimates = cv_manager.load_point_estimates()
-    metadata = cv_manager.load_metadata()
+    point_estimates = cv_repository.load_point_estimates()
+    metadata = cv_repository.load_metadata()
     print(f"Loaded point estimates with {len(point_estimates.obj)} points")
 
     # Create CaptureVolume

--- a/src/caliscope/repositories/__init__.py
+++ b/src/caliscope/repositories/__init__.py
@@ -1,0 +1,21 @@
+"""
+Repository layer: persistence gateways for domain objects.
+
+Repositories handle load/save operations to TOML/CSV files. They are the
+boundary between domain logic and storage, converting between domain objects
+and their serialized representations.
+"""
+
+from caliscope.repositories.camera_array_repository import CameraArrayRepository
+from caliscope.repositories.charuco_repository import CharucoRepository
+from caliscope.repositories.project_settings_repository import ProjectSettingsRepository
+from caliscope.repositories.capture_volume_repository import CaptureVolumeRepository
+from caliscope.repositories.point_data_bundle_repository import PointDataBundleRepository
+
+__all__ = [
+    "CameraArrayRepository",
+    "CharucoRepository",
+    "ProjectSettingsRepository",
+    "CaptureVolumeRepository",
+    "PointDataBundleRepository",
+]

--- a/src/caliscope/repositories/camera_array_repository.py
+++ b/src/caliscope/repositories/camera_array_repository.py
@@ -1,5 +1,5 @@
 """
-Manages camera array data (intrinsics, extrinsics, metadata).
+Repository for camera array data (intrinsics, extrinsics, metadata).
 Provides atomic operations for individual camera updates.
 """
 
@@ -12,11 +12,11 @@ from caliscope import persistence
 logger = logging.getLogger(__name__)
 
 
-class CameraArrayManager:
+class CameraArrayRepository:
     """
-    Manages camera array data stored in camera_array.toml.
+    Persistence gateway for camera array data stored in camera_array.toml.
 
-    This manager is thread-safe as it holds no mutable state and each operation
+    This repository is thread-safe as it holds no mutable state and each operation
     is independent. The save_camera() method uses a load-modify-save pattern
     which is correct but not optimized for high-frequency updates.
     """

--- a/src/caliscope/repositories/capture_volume_repository.py
+++ b/src/caliscope/repositories/capture_volume_repository.py
@@ -1,5 +1,5 @@
 """
-Manages capture volume data: point estimates (2D-3D correspondences) and
+Repository for capture volume data: point estimates (2D-3D correspondences) and
 capture volume metadata (stage, origin index). These are combined because
 they represent different facets of the same domain concept and are always
 loaded/saved together during calibration workflows.
@@ -16,13 +16,13 @@ from caliscope import persistence
 logger = logging.getLogger(__name__)
 
 
-class CaptureVolumeDataManager:
+class CaptureVolumeRepository:
     """
-    Manages capture volume data stored across two files:
+    Persistence gateway for capture volume data stored across two files:
     - point_estimates.toml: 2D-3D point correspondences
     - capture_volume.toml: Metadata (stage, origin_sync_index)
 
-    This manager is thread-safe as it holds no mutable state. The
+    This repository is thread-safe as it holds no mutable state. The
     save_capture_volume() method coordinates multiple persistence calls
     which is acceptable for this domain; if this logic grows, consider
     extracting a dedicated use-case service.

--- a/src/caliscope/repositories/charuco_repository.py
+++ b/src/caliscope/repositories/charuco_repository.py
@@ -1,6 +1,6 @@
 """
-Manages Charuco calibration board definition.
-Simplest manager as Charuco is a single domain object with no dependencies.
+Repository for Charuco calibration board definition.
+Simplest repository as Charuco is a single domain object with no dependencies.
 """
 
 import logging
@@ -12,11 +12,11 @@ from caliscope import persistence
 logger = logging.getLogger(__name__)
 
 
-class CharucoManager:
+class CharucoRepository:
     """
-    Manages Charuco board definition stored in charuco.toml.
+    Persistence gateway for Charuco board definition stored in charuco.toml.
 
-    This manager is thread-safe as it holds no state and performs only
+    This repository is thread-safe as it holds no state and performs only
     atomic file operations.
     """
 

--- a/src/caliscope/repositories/point_data_bundle_repository.py
+++ b/src/caliscope/repositories/point_data_bundle_repository.py
@@ -1,5 +1,5 @@
 """
-Manager for PointDataBundle persistence with complete snapshotting.
+Repository for PointDataBundle persistence with complete snapshotting.
 
 This module provides atomic save/load operations for calibration data bundles,
 ensuring data integrity when the active calibration changes. Each bundle is
@@ -29,9 +29,9 @@ from caliscope.persistence import (
 logger = logging.getLogger(__name__)
 
 
-class PointDataBundleManager:
+class PointDataBundleRepository:
     """
-    Handles atomic save/load of PointDataBundle with complete snapshots.
+    Persistence gateway for PointDataBundle with complete snapshots.
 
     Each bundle directory contains:
     - camera_array.toml: Snapshot of calibration used for processing
@@ -39,13 +39,13 @@ class PointDataBundleManager:
     - world_points.csv: 3D triangulated points
     - bundle.toml: Provenance metadata and operations history
 
-    The manager is short-lived and should be created per operation to avoid
+    The repository is short-lived and should be created per operation to avoid
     stale state. It delegates all format-specific I/O to the persistence layer.
     """
 
     def __init__(self, base_path: Path):
         """
-        Initialize manager for a specific bundle directory.
+        Initialize repository for a specific bundle directory.
 
         Args:
             base_path: Directory where bundle components will be stored.

--- a/src/caliscope/repositories/project_settings_repository.py
+++ b/src/caliscope/repositories/project_settings_repository.py
@@ -1,5 +1,5 @@
 """
-Manages global project configuration settings with in-memory caching.
+Repository for global project configuration settings with in-memory caching.
 All persistence errors are converted to ValueError for cleaner API boundaries.
 """
 
@@ -12,12 +12,12 @@ from caliscope import persistence
 logger = logging.getLogger(__name__)
 
 
-class ProjectSettingsManager:
+class ProjectSettingsRepository:
     """
-    Manages project-wide settings stored in project_settings.toml.
+    Persistence gateway for project-wide settings stored in project_settings.toml.
 
     Settings are loaded once on initialization and cached. Call refresh() to
-    reload from disk. This manager is thread-safe as it holds no mutable state
+    reload from disk. This repository is thread-safe as it holds no mutable state
     beyond the cached settings dictionary.
     """
 

--- a/tests/test_point_data_bundle.py
+++ b/tests/test_point_data_bundle.py
@@ -8,7 +8,7 @@ from caliscope.core.capture_volume.capture_volume import CaptureVolume
 from caliscope.core.capture_volume.point_estimates import PointEstimates
 from caliscope.core.point_data_bundle import PointDataBundle
 from caliscope.helper import copy_contents_to_clean_dest
-from caliscope.managers.point_data_bundle_manager import PointDataBundleManager
+from caliscope.repositories import PointDataBundleRepository
 from caliscope.core.point_data import ImagePoints, WorldPoints
 from caliscope import persistence
 
@@ -240,12 +240,12 @@ def test_point_data_bundle(tmp_path: Path):
     bundle_dir = tmp_path / "test_bundle"
     bundle_dir.mkdir(exist_ok=True)
 
-    manager = PointDataBundleManager(bundle_dir)
+    repository = PointDataBundleRepository(bundle_dir)
     logger.info(f"Saving bundle to {bundle_dir}...")
-    manager.save(bundle)
+    repository.save(bundle)
 
     logger.info("Loading bundle back...")
-    loaded_bundle = manager.load()
+    loaded_bundle = repository.load()
 
     # Verify data integrity
     assert len(loaded_bundle.image_points.df) == len(bundle.image_points.df), "Image point count mismatch after load"


### PR DESCRIPTION
## Summary

- Rename 5 persistence gateway classes from `*Manager` to `*Repository`
- Move from `managers/` to new `repositories/` directory
- Clean architectural separation: repositories handle persistence, managers/ now only contains proto-Presenters

## Changes

| Old | New |
|-----|-----|
| `CameraArrayManager` | `CameraArrayRepository` |
| `CharucoManager` | `CharucoRepository` |
| `ProjectSettingsManager` | `ProjectSettingsRepository` |
| `CaptureVolumeDataManager` | `CaptureVolumeRepository` |
| `PointDataBundleManager` | `PointDataBundleRepository` |

## Test plan

- [x] All 94 tests pass
- [x] Lint and format pass

Closes #863