### PR TITLE
Add pure intrinsic calibration functions

### DIFF
--- a/src/caliscope/core/calibrate_intrinsics.py
+++ b/src/caliscope/core/calibrate_intrinsics.py
@@ -1,0 +1,433 @@
+"""Pure functions for intrinsic camera calibration.
+
+This module provides stateless functions for calibrating camera intrinsic
+parameters (camera matrix and distortion coefficients) from charuco corner
+observations. Unlike the legacy IntrinsicCalibrator class, these functions
+have no side effects and return immutable results.
+
+The design follows "Level 1 purity": pure functions that return results,
+with mutation handled by the caller (typically a Presenter or Controller).
+"""
+
+from dataclasses import dataclass
+import logging
+
+import cv2
+import numpy as np
+from numpy.typing import NDArray
+
+from caliscope.core.point_data import ImagePoints
+
+logger = logging.getLogger(__name__)
+
+# Minimum corners required per frame for OpenCV calibration
+MIN_CORNERS_PER_FRAME = 4
+
+
+@dataclass(frozen=True)
+class IntrinsicCalibrationResult:
+    """Immutable result of intrinsic camera calibration.
+
+    Attributes:
+        camera_matrix: 3x3 camera intrinsic matrix containing focal lengths
+            and principal point coordinates.
+        distortions: Distortion coefficients. Shape (5,) for standard model
+            (k1, k2, p1, p2, k3) or (4,) for fisheye model (k1, k2, k3, k4).
+        reprojection_error: Root mean squared reprojection error in pixels,
+            as returned by cv2.calibrateCamera.
+        frames_used: Number of frames used in calibration.
+    """
+
+    camera_matrix: NDArray[np.float64]
+    distortions: NDArray[np.float64]
+    reprojection_error: float
+    frames_used: int
+
+
+@dataclass(frozen=True)
+class HoldoutResult:
+    """Results from out-of-sample reprojection error evaluation.
+
+    Attributes:
+        rmse: Aggregate RMSE across all held-out observations in normalized
+            coordinates. Multiply by mean focal length for approximate pixels.
+        rmse_pixels: Approximate RMSE in pixel units (rmse * mean_focal_length).
+        per_frame_rmse: Per-frame RMSE for diagnostics. Keys are sync_index.
+        total_points: Total points evaluated across all successful frames.
+        total_frames: Number of held-out frames attempted.
+        failed_frames: sync_index values where solvePnP failed.
+    """
+
+    rmse: float
+    rmse_pixels: float
+    per_frame_rmse: dict[int, float]
+    total_points: int
+    total_frames: int
+    failed_frames: list[int]
+
+
+def calibrate_intrinsics(
+    image_points: ImagePoints,
+    port: int,
+    image_size: tuple[int, int],
+    selected_frames: list[int],
+    *,
+    fisheye: bool = False,
+) -> IntrinsicCalibrationResult:
+    """Calibrate camera intrinsic parameters from charuco corner observations.
+
+    This is a pure function that returns calibration results without mutating
+    any input data. The caller is responsible for applying results to CameraData.
+
+    Args:
+        image_points: Detected charuco corners across all frames. Must contain
+            columns: sync_index, port, point_id, img_loc_x, img_loc_y,
+            obj_loc_x, obj_loc_y, obj_loc_z.
+        port: Camera port to calibrate.
+        image_size: (width, height) of camera images in pixels.
+        selected_frames: List of sync_index values to use for calibration.
+            Use select_calibration_frames() to choose optimal frames.
+        fisheye: If True, use fisheye camera model (4 distortion coefficients).
+            If False, use standard camera model (5 distortion coefficients).
+
+    Returns:
+        IntrinsicCalibrationResult with camera matrix, distortion coefficients,
+        reprojection RMSE, and frame count.
+
+    Raises:
+        ValueError: If no valid frames found for the specified port,
+            or if all frames have insufficient corners (< 4 per frame).
+    """
+    obj_points_list, img_points_list = _extract_calibration_arrays(image_points, port, selected_frames)
+
+    if len(obj_points_list) == 0:
+        raise ValueError(
+            f"No valid calibration frames found for port {port}. "
+            f"Ensure frames have at least {MIN_CORNERS_PER_FRAME} corners each."
+        )
+
+    width, height = image_size
+
+    if fisheye:
+        # Fisheye requires specific array shapes: (N, 1, D)
+        obj_pts = [p.reshape(-1, 1, 3).astype(np.float32) for p in obj_points_list]
+        img_pts = [p.reshape(-1, 1, 2).astype(np.float32) for p in img_points_list]
+
+        # Pre-initialize output matrices (required for fisheye.calibrate)
+        camera_matrix = np.zeros((3, 3), dtype=np.float64)
+        dist_coeffs = np.zeros(4, dtype=np.float64)
+
+        error, mtx, dist, rvecs, tvecs = cv2.fisheye.calibrate(
+            obj_pts,
+            img_pts,
+            (width, height),
+            camera_matrix,
+            dist_coeffs,
+            flags=cv2.fisheye.CALIB_RECOMPUTE_EXTRINSIC,
+        )
+        # fisheye.calibrate returns dist as (4,) already
+        dist = dist.ravel()
+    else:
+        # Standard calibration accepts (N, D) arrays
+        obj_pts = [p.astype(np.float32) for p in obj_points_list]
+        img_pts = [p.astype(np.float32) for p in img_points_list]
+
+        # Pre-initialize output matrices (required by type checker, works at runtime)
+        camera_matrix = np.zeros((3, 3), dtype=np.float64)
+        dist_coeffs = np.zeros(5, dtype=np.float64)
+
+        error, mtx, dist, rvecs, tvecs = cv2.calibrateCamera(
+            obj_pts,
+            img_pts,
+            (width, height),
+            camera_matrix,
+            dist_coeffs,
+        )
+        # calibrateCamera returns dist as (1, 5), flatten it
+        dist = dist.ravel()
+
+    logger.info(f"Calibration complete for port {port}: error={error:.4f}px, frames={len(obj_points_list)}")
+
+    return IntrinsicCalibrationResult(
+        camera_matrix=np.asarray(mtx, dtype=np.float64),
+        distortions=np.asarray(dist, dtype=np.float64),
+        reprojection_error=float(error),
+        frames_used=len(obj_points_list),
+    )
+
+
+def compute_holdout_error(
+    image_points: ImagePoints,
+    result: IntrinsicCalibrationResult,
+    port: int,
+    holdout_frames: list[int],
+    *,
+    fisheye: bool = False,
+) -> HoldoutResult:
+    """Compute out-of-sample reprojection error on held-out frames.
+
+    For each held-out frame:
+    1. Extract detected 2D corners and corresponding 3D object points
+    2. Undistort 2D points to normalized coordinates
+    3. Estimate board pose using solvePnP with identity K (since we undistorted)
+    4. Project 3D object points back to normalized coordinates
+    5. Compute error between projected and undistorted points
+
+    This provides a cross-validation metric for calibration quality. If the
+    calibration overfits to training frames, holdout RMSE will be higher.
+
+    Args:
+        image_points: Detected charuco corners (same source as calibration).
+        result: Result from calibrate_intrinsic().
+        port: Camera port.
+        holdout_frames: List of sync_index values NOT used in calibration.
+        fisheye: Must match the value used in calibrate_intrinsic().
+
+    Returns:
+        HoldoutResult with aggregate RMSE, per-frame RMSE, and failure info.
+    """
+    per_frame_errors: dict[int, NDArray] = {}
+    failed_frames: list[int] = []
+
+    for sync_index in holdout_frames:
+        frame_result = _evaluate_frame(
+            image_points,
+            result.camera_matrix,
+            result.distortions,
+            port,
+            sync_index,
+            fisheye=fisheye,
+        )
+
+        if frame_result is None:
+            failed_frames.append(sync_index)
+        else:
+            per_frame_errors[sync_index] = frame_result
+
+    # Compute aggregate statistics
+    if per_frame_errors:
+        all_errors = np.vstack(list(per_frame_errors.values()))
+        rmse = float(np.sqrt(np.mean(np.sum(all_errors**2, axis=1))))
+        total_points = sum(len(e) for e in per_frame_errors.values())
+
+        per_frame_rmse = {idx: float(np.sqrt(np.mean(np.sum(err**2, axis=1)))) for idx, err in per_frame_errors.items()}
+
+        # Approximate pixel RMSE using mean focal length
+        fx, fy = result.camera_matrix[0, 0], result.camera_matrix[1, 1]
+        mean_focal = (fx + fy) / 2
+        rmse_pixels = rmse * mean_focal
+    else:
+        rmse = float("nan")
+        rmse_pixels = float("nan")
+        per_frame_rmse = {}
+        total_points = 0
+
+    return HoldoutResult(
+        rmse=rmse,
+        rmse_pixels=rmse_pixels,
+        per_frame_rmse=per_frame_rmse,
+        total_points=total_points,
+        total_frames=len(holdout_frames),
+        failed_frames=failed_frames,
+    )
+
+
+def _extract_calibration_arrays(
+    image_points: ImagePoints,
+    port: int,
+    frames: list[int],
+) -> tuple[list[NDArray], list[NDArray]]:
+    """Extract per-frame object and image point arrays for OpenCV calibration.
+
+    Returns:
+        (object_points, image_points) where each is a list of (N, D) arrays
+        per frame. D=3 for object points, D=2 for image points.
+
+        Filters out frames with < MIN_CORNERS_PER_FRAME corners.
+    """
+    df = image_points.df
+
+    # Filter to specified port and frames
+    mask = (df["port"] == port) & (df["sync_index"].isin(frames))
+    port_df = df[mask]
+
+    obj_points_list: list[NDArray] = []
+    img_points_list: list[NDArray] = []
+
+    for sync_index in frames:
+        frame_df = port_df[port_df["sync_index"] == sync_index]
+
+        if len(frame_df) < MIN_CORNERS_PER_FRAME:
+            logger.debug(f"Skipping frame {sync_index}: only {len(frame_df)} corners (need {MIN_CORNERS_PER_FRAME})")
+            continue
+
+        # Extract image coordinates as numpy array
+        img_loc: NDArray = np.asarray(frame_df[["img_loc_x", "img_loc_y"]])
+
+        # Extract object coordinates (3D board coordinates)
+        # For planar charuco, z is typically 0 or NaN
+        obj_loc: NDArray = np.asarray(frame_df[["obj_loc_x", "obj_loc_y", "obj_loc_z"]])
+
+        # Handle NaN in obj_loc_z (planar board, z=0)
+        obj_loc = np.nan_to_num(obj_loc, nan=0.0)
+
+        obj_points_list.append(obj_loc)
+        img_points_list.append(img_loc)
+
+    return obj_points_list, img_points_list
+
+
+def _undistort_points(
+    points: NDArray,
+    camera_matrix: NDArray,
+    distortions: NDArray,
+    *,
+    fisheye: bool = False,
+) -> NDArray:
+    """Undistort 2D points to normalized coordinates.
+
+    Args:
+        points: (N, 2) array of distorted pixel coordinates.
+        camera_matrix: 3x3 camera intrinsic matrix.
+        distortions: Distortion coefficients.
+        fisheye: Whether to use fisheye model.
+
+    Returns:
+        (N, 2) array of undistorted normalized coordinates.
+    """
+    points_reshaped = np.ascontiguousarray(points, dtype=np.float32).reshape(-1, 1, 2)
+
+    # Output in normalized coordinates (identity projection matrix)
+    P = np.eye(3, dtype=np.float64)
+
+    if fisheye:
+        undistorted = cv2.fisheye.undistortPoints(points_reshaped, camera_matrix, distortions, P=P)
+    else:
+        undistorted = cv2.undistortPoints(points_reshaped, camera_matrix, distortions, P=P)
+
+    return undistorted.reshape(-1, 2)
+
+
+def _estimate_pose_for_frame(
+    img_points_normalized: NDArray,
+    obj_points: NDArray,
+) -> tuple[NDArray, NDArray] | None:
+    """Estimate board pose from normalized 2D points and 3D object points.
+
+    Uses solvePnP with identity K (since points are already normalized).
+
+    Args:
+        img_points_normalized: (N, 2) undistorted normalized coordinates.
+        obj_points: (N, 3) 3D object coordinates on the board.
+
+    Returns:
+        (rvec, tvec) if successful, None if pose estimation failed.
+    """
+    if len(img_points_normalized) < MIN_CORNERS_PER_FRAME:
+        return None
+
+    # Check for degenerate point distribution
+    if not _points_are_well_distributed(img_points_normalized):
+        return None
+
+    # Identity K and zero distortion since we're using normalized coordinates
+    K = np.eye(3, dtype=np.float64)
+    D = np.zeros(5, dtype=np.float64)
+
+    # Prepare arrays for OpenCV
+    obj_pts = obj_points.astype(np.float32)
+    img_pts = img_points_normalized.astype(np.float32)
+
+    # Try IPPE first (optimal for planar targets like charuco boards)
+    success, rvec, tvec = cv2.solvePnP(obj_pts, img_pts, K, D, flags=cv2.SOLVEPNP_IPPE)
+
+    if not success:
+        # Fallback to iterative solver
+        success, rvec, tvec = cv2.solvePnP(obj_pts, img_pts, K, D, flags=cv2.SOLVEPNP_ITERATIVE)
+
+    if not success:
+        return None
+
+    # Sanity check: verify pose produces reasonable reprojection
+    projected, _ = cv2.projectPoints(obj_pts, rvec, tvec, K, D)
+    reprojection_error = np.sqrt(np.mean((img_points_normalized - projected.reshape(-1, 2)) ** 2))
+
+    # Reject poses with unreasonably high error (in normalized units)
+    # 0.1 normalized ~ 50-100 pixels depending on focal length
+    MAX_ACCEPTABLE_ERROR = 0.1
+    if reprojection_error > MAX_ACCEPTABLE_ERROR:
+        logger.debug(f"Rejecting pose with error {reprojection_error:.4f} (threshold {MAX_ACCEPTABLE_ERROR})")
+        return None
+
+    # Verify board is in front of camera (z > 0)
+    if tvec[2, 0] < 0:
+        logger.debug("Rejecting pose with negative z (board behind camera)")
+        return None
+
+    return rvec, tvec
+
+
+def _points_are_well_distributed(points: NDArray, min_span: float = 0.01) -> bool:
+    """Check if points span sufficient area for stable pose estimation.
+
+    Args:
+        points: (N, 2) array of points.
+        min_span: Minimum required span in each dimension.
+
+    Returns:
+        True if points are sufficiently distributed.
+    """
+    if len(points) < MIN_CORNERS_PER_FRAME:
+        return False
+
+    min_coords = points.min(axis=0)
+    max_coords = points.max(axis=0)
+    span = max_coords - min_coords
+
+    return bool(span[0] > min_span and span[1] > min_span)
+
+
+def _evaluate_frame(
+    image_points: ImagePoints,
+    camera_matrix: NDArray,
+    distortions: NDArray,
+    port: int,
+    sync_index: int,
+    *,
+    fisheye: bool = False,
+) -> NDArray | None:
+    """Evaluate reprojection error for a single held-out frame.
+
+    Returns:
+        (N, 2) array of errors (undistorted - projected) in normalized
+        coordinates, or None if evaluation failed.
+    """
+    df = image_points.df
+    frame_df = df[(df["port"] == port) & (df["sync_index"] == sync_index)]
+
+    if len(frame_df) < MIN_CORNERS_PER_FRAME:
+        return None
+
+    # Extract points as numpy arrays
+    img_loc: NDArray = np.asarray(frame_df[["img_loc_x", "img_loc_y"]])
+    obj_loc: NDArray = np.asarray(frame_df[["obj_loc_x", "obj_loc_y", "obj_loc_z"]])
+    obj_loc = np.nan_to_num(obj_loc, nan=0.0)
+
+    # Undistort to normalized coordinates
+    img_normalized = _undistort_points(img_loc, camera_matrix, distortions, fisheye=fisheye)
+
+    # Estimate board pose
+    pose = _estimate_pose_for_frame(img_normalized, obj_loc)
+    if pose is None:
+        return None
+
+    rvec, tvec = pose
+
+    # Project object points to normalized coordinates
+    K = np.eye(3, dtype=np.float64)
+    D = np.zeros(5, dtype=np.float64)
+    projected, _ = cv2.projectPoints(obj_loc.astype(np.float32), rvec, tvec, K, D)
+
+    # Compute error
+    errors = img_normalized - projected.reshape(-1, 2)
+    return errors

--- a/tests/test_calibrate_intrinsics.py
+++ b/tests/test_calibrate_intrinsics.py
@@ -1,0 +1,223 @@
+"""Tests for pure intrinsic calibration functions.
+
+These tests validate:
+1. Basic calibration produces valid camera parameters
+2. Holdout error computation works correctly
+3. Frame selection improves generalization vs naive selection
+"""
+
+import logging
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from caliscope import __root__
+from caliscope.core.calibrate_intrinsics import (
+    HoldoutResult,
+    IntrinsicCalibrationResult,
+    calibrate_intrinsics,
+    compute_holdout_error,
+)
+from caliscope.core.point_data import ImagePoints
+
+logger = logging.getLogger(__name__)
+
+# Test data paths
+PRERECORDED_SESSION = Path(__root__, "tests", "sessions", "prerecorded_calibration")
+INTRINSIC_CSV = PRERECORDED_SESSION / "calibration" / "intrinsic" / "CHARUCO" / "xy_CHARUCO.csv"
+
+# Image size from prerecorded calibration (typical webcam resolution)
+IMAGE_SIZE = (1280, 720)
+
+
+def _load_test_data() -> tuple[ImagePoints, list[int]]:
+    """Load test data and return (image_points, port0_frames)."""
+    image_points = ImagePoints.from_csv(INTRINSIC_CSV)
+    df = image_points.df
+    port0_frames = sorted(df[df["port"] == 0]["sync_index"].unique().tolist())
+    return image_points, port0_frames
+
+
+class TestCalibrateIntrinsics:
+    """Unit tests for calibrate_intrinsics function."""
+
+    def test_calibrate_returns_valid_result(self):
+        """Calibration produces reasonable camera matrix and distortions."""
+        image_points, port0_frames = _load_test_data()
+
+        # Use first 20 frames for calibration
+        selected = port0_frames[:20]
+
+        result = calibrate_intrinsics(
+            image_points,
+            port=0,
+            image_size=IMAGE_SIZE,
+            selected_frames=selected,
+        )
+
+        # Check result type
+        assert isinstance(result, IntrinsicCalibrationResult)
+
+        # Camera matrix should be 3x3
+        assert result.camera_matrix.shape == (3, 3)
+
+        # Focal lengths should be positive and reasonable for the image size
+        fx, fy = result.camera_matrix[0, 0], result.camera_matrix[1, 1]
+        assert fx > 0
+        assert fy > 0
+        # Focal length can vary widely depending on lens/sensor (0.3x to 5x image dimension)
+        assert 0.3 * IMAGE_SIZE[0] < fx < 5 * IMAGE_SIZE[0]
+        assert 0.3 * IMAGE_SIZE[1] < fy < 5 * IMAGE_SIZE[1]
+
+        # Principal point should be near image center
+        cx, cy = result.camera_matrix[0, 2], result.camera_matrix[1, 2]
+        assert 0.3 * IMAGE_SIZE[0] < cx < 0.7 * IMAGE_SIZE[0]
+        assert 0.3 * IMAGE_SIZE[1] < cy < 0.7 * IMAGE_SIZE[1]
+
+        # Standard model has 5 distortion coefficients
+        assert result.distortions.shape == (5,)
+
+        # Reprojection error should be reasonable (< 1 pixel is good)
+        assert 0 < result.reprojection_error < 2.0
+
+        # Frames used should match selected (or less if some had insufficient corners)
+        assert 0 < result.frames_used <= len(selected)
+
+    def test_calibrate_insufficient_frames_raises(self):
+        """Calibration with no valid frames raises ValueError."""
+        image_points, _ = _load_test_data()
+
+        # Empty frame list
+        with pytest.raises(ValueError, match="No valid calibration frames"):
+            calibrate_intrinsics(
+                image_points,
+                port=0,
+                image_size=IMAGE_SIZE,
+                selected_frames=[],
+            )
+
+    def test_calibrate_nonexistent_port_raises(self):
+        """Calibration for non-existent port raises ValueError."""
+        image_points, _ = _load_test_data()
+
+        with pytest.raises(ValueError, match="No valid calibration frames"):
+            calibrate_intrinsics(
+                image_points,
+                port=999,  # Non-existent port
+                image_size=IMAGE_SIZE,
+                selected_frames=[0, 1, 2],
+            )
+
+
+class TestComputeHoldoutError:
+    """Unit tests for compute_holdout_error function."""
+
+    def test_holdout_error_returns_valid_result(self):
+        """Holdout error computation produces reasonable results."""
+        image_points, port0_frames = _load_test_data()
+
+        # Calibrate on first 30 frames
+        train_frames = port0_frames[:30]
+        calibration_result = calibrate_intrinsics(
+            image_points,
+            port=0,
+            image_size=IMAGE_SIZE,
+            selected_frames=train_frames,
+        )
+
+        holdout_frames = port0_frames[30:]  # Use frames not in training
+
+        result = compute_holdout_error(
+            image_points,
+            calibration_result,
+            port=0,
+            holdout_frames=holdout_frames,
+        )
+
+        assert isinstance(result, HoldoutResult)
+
+        # RMSE should be a positive number (not NaN)
+        assert not np.isnan(result.rmse)
+        assert result.rmse > 0
+
+        # RMSE in pixels should be reasonable (< 5 pixels is good)
+        assert not np.isnan(result.rmse_pixels)
+        assert result.rmse_pixels < 5.0
+
+        # Per-frame RMSE should have entries for successful frames
+        assert len(result.per_frame_rmse) > 0
+
+        # Total frames should match input
+        assert result.total_frames == len(holdout_frames)
+
+        # Should have evaluated some points
+        assert result.total_points > 0
+
+    def test_holdout_empty_frames_returns_nan(self):
+        """Holdout with no valid frames returns NaN RMSE."""
+        image_points, port0_frames = _load_test_data()
+
+        # Calibrate first
+        train_frames = port0_frames[:30]
+        calibration_result = calibrate_intrinsics(
+            image_points,
+            port=0,
+            image_size=IMAGE_SIZE,
+            selected_frames=train_frames,
+        )
+
+        result = compute_holdout_error(
+            image_points,
+            calibration_result,
+            port=0,
+            holdout_frames=[],
+        )
+
+        assert np.isnan(result.rmse)
+        assert result.total_frames == 0
+        assert result.total_points == 0
+
+
+# NOTE: Frame selection validation tests are deferred.
+#
+# The goal is to prove that select_calibration_frames() produces calibrations
+# that generalize better than naive frame selection, measured by out-of-sample
+# RMSE using compute_holdout_error().
+#
+# However, the current frame selector has design issues that need to be addressed:
+# 1. Coverage-based filtering excludes frames where the board appears small (far away)
+# 2. But distance diversity (board at varying distances) is actually valuable for calibration
+# 3. The selector should optimize for diversity across multiple dimensions:
+#    - Spatial coverage (where in image)
+#    - Orientation diversity (board tilt/rotation)
+#    - Distance diversity (board size in frame)
+#
+# See .todo_capture.md for follow-up issue to revisit the selection algorithm
+# and create a proper testing framework for intrinsic calibration quality.
+
+
+if __name__ == "__main__":
+    import caliscope.logger
+
+    caliscope.logger.setup_logging()
+
+    # Run actual tests so assertions can be caught in debugger
+    test_calibrate = TestCalibrateIntrinsics()
+    test_calibrate.test_calibrate_returns_valid_result()
+    logger.info("PASS: test_calibrate_returns_valid_result")
+
+    test_calibrate.test_calibrate_insufficient_frames_raises()
+    logger.info("PASS: test_calibrate_insufficient_frames_raises")
+
+    test_calibrate.test_calibrate_nonexistent_port_raises()
+    logger.info("PASS: test_calibrate_nonexistent_port_raises")
+
+    test_holdout = TestComputeHoldoutError()
+    test_holdout.test_holdout_error_returns_valid_result()
+    logger.info("PASS: test_holdout_error_returns_valid_result")
+
+    test_holdout.test_holdout_empty_frames_returns_nan()
+    logger.info("PASS: test_holdout_empty_frames_returns_nan")
+
+    logger.info("All tests passed!")


### PR DESCRIPTION
## Summary

- Add `calibrate_intrinsics()` pure function that returns `IntrinsicCalibrationResult`
- Add `compute_holdout_error()` for validating frame selection via out-of-sample RMSE
- Both functions return immutable results without mutating CameraData

## Context

This is groundwork for #835 (IntrinsicCalibrationPresenter). The pure functions give us:
- Testable calibration logic
- Out-of-sample error for validating frame selection quality
- Clear data flow (caller applies results to CameraData)

## Test plan

- [x] Unit tests for calibration function
- [x] Unit tests for holdout error computation
- [x] Type checking passes

Closes #865