### PR TITLE
Implement IntrinsicCalibrationPresenter

### DIFF
--- a/src/caliscope/gui/presenters/__init__.py
+++ b/src/caliscope/gui/presenters/__init__.py
@@ -1,0 +1,13 @@
+"""Presenters for MVP architecture.
+
+Presenters coordinate workflow state and adapt domain logic for Views.
+They hold transient "scratchpad" state; results aren't persisted until
+emitted to the Controller.
+"""
+
+from caliscope.gui.presenters.intrinsic_calibration_presenter import (
+    IntrinsicCalibrationPresenter,
+    PresenterState,
+)
+
+__all__ = ["IntrinsicCalibrationPresenter", "PresenterState"]

--- a/src/caliscope/gui/presenters/intrinsic_calibration_presenter.py
+++ b/src/caliscope/gui/presenters/intrinsic_calibration_presenter.py
@@ -1,0 +1,403 @@
+"""Presenter for intrinsic camera calibration workflow.
+
+Coordinates the collection of charuco corner observations and calibration
+via the domain's pure functions. Emits raw FramePackets for the View to
+handle display transforms (undistortion, rotation, padding).
+
+This is a "scratchpad" presenter - accumulated data and calibration results
+are transient until emitted to the Controller for persistence.
+"""
+
+import logging
+from enum import Enum, auto
+from pathlib import Path
+from queue import Empty, Queue
+from threading import Event, Thread
+
+import cv2
+import numpy as np
+from PySide6.QtCore import QObject, Signal
+
+from caliscope.cameras.camera_array import CameraData
+from caliscope.core.calibrate_intrinsics import (
+    IntrinsicCalibrationResult,
+    calibrate_intrinsics,
+)
+from caliscope.core.frame_selector import select_calibration_frames
+from caliscope.core.point_data import ImagePoints
+from caliscope.packets import FramePacket, PointPacket
+from caliscope.recording.recorded_stream import RecordedStream
+from caliscope.task_manager.cancellation import CancellationToken
+from caliscope.task_manager.task_handle import TaskHandle
+from caliscope.task_manager.task_manager import TaskManager
+from caliscope.task_manager.task_state import TaskState
+from caliscope.tracker import Tracker
+
+logger = logging.getLogger(__name__)
+
+
+class PresenterState(Enum):
+    """Workflow states for intrinsic calibration.
+
+    States are computed from internal reality, not stored separately.
+    This prevents state/reality divergence.
+    """
+
+    READY = auto()  # Initial state, can start collection
+    COLLECTING = auto()  # Video playing, accumulating points
+    CALIBRATING = auto()  # calibrate_intrinsics() running via TaskManager
+    CALIBRATED = auto()  # Result available, can toggle undistortion
+
+
+class IntrinsicCalibrationPresenter(QObject):
+    """Presenter for single-camera intrinsic calibration workflow.
+
+    Manages the collection of charuco observations from recorded video and
+    submission of calibration to TaskManager. Exposes a display_queue for
+    the View's processing thread to consume directly (avoids GUI thread hop).
+
+    Signals:
+        state_changed: Emitted when computed state changes. View updates UI.
+        calibration_complete: Emitted when calibration succeeds. Contains
+            a new CameraData with calibration results applied.
+        calibration_failed: Emitted when calibration fails. Contains error message.
+
+    Queue:
+        display_queue: View's processing thread reads FramePackets from here.
+            Keeps heavy frame data off the GUI thread until processed into QPixmap.
+    """
+
+    state_changed = Signal(PresenterState)
+    calibration_complete = Signal(CameraData)  # Calibrated camera, ready to use
+    calibration_failed = Signal(str)
+
+    def __init__(
+        self,
+        camera: CameraData,
+        video_path: Path,
+        tracker: Tracker,
+        task_manager: TaskManager,
+        parent: QObject | None = None,
+    ) -> None:
+        """Initialize the presenter.
+
+        Args:
+            camera: CameraData with port, size, rotation_count
+            video_path: Path to the video file for this camera
+            tracker: CharucoTracker for point detection
+            task_manager: TaskManager for background calibration
+            parent: Optional Qt parent
+        """
+        super().__init__(parent)
+
+        self._camera = camera
+        self._video_path = video_path
+        self._tracker = tracker
+        self._task_manager = task_manager
+
+        # Derived properties for convenience
+        self._port = camera.port
+        # CameraData.size is list[int], convert to tuple for API compatibility
+        self._image_size: tuple[int, int] = (camera.size[0], camera.size[1])
+
+        # Scratchpad state
+        self._collected_points: list[tuple[int, PointPacket]] = []
+        self._calibrated_camera: CameraData | None = None
+        self._calibration_task: TaskHandle | None = None
+
+        # Collection state
+        self._stream: RecordedStream | None = None
+        self._frame_queue: Queue[FramePacket] = Queue()  # From RecordedStream
+        self._display_queue: Queue[FramePacket | None] = Queue()  # For View consumption
+        self._consumer_thread: Thread | None = None
+        self._stop_event = Event()
+        self._is_collecting = False
+
+        # Load initial frame so View has something to display
+        self._load_initial_frame()
+
+    @property
+    def state(self) -> PresenterState:
+        """Compute current state from internal reality - never stale."""
+        if self._calibrated_camera is not None:
+            return PresenterState.CALIBRATED
+
+        if self._calibration_task is not None and self._calibration_task.state == TaskState.RUNNING:
+            return PresenterState.CALIBRATING
+
+        if self._is_collecting:
+            return PresenterState.COLLECTING
+
+        return PresenterState.READY
+
+    @property
+    def display_queue(self) -> Queue[FramePacket | None]:
+        """Queue for View's processing thread to consume frames from.
+
+        None sentinel signals end of current sequence (e.g., after stop).
+        """
+        return self._display_queue
+
+    @property
+    def calibrated_camera(self) -> CameraData | None:
+        """Access calibrated camera for View's undistortion setup."""
+        return self._calibrated_camera
+
+    @property
+    def camera(self) -> CameraData:
+        """Access original camera data for View's display setup."""
+        return self._camera
+
+    def refresh_display(self) -> None:
+        """Put a fresh frame on the display queue.
+
+        Call this when display settings change (e.g., undistort toggle)
+        and the View needs to re-render with new settings.
+        """
+        self._load_initial_frame()
+
+    def _load_initial_frame(self) -> None:
+        """Read first frame from video and put on display queue."""
+        cap = cv2.VideoCapture(str(self._video_path))
+        success, frame = cap.read()
+        cap.release()
+
+        if success:
+            # Note: FramePacket.frame typed as float64 but cv2 returns uint8
+            initial_packet = FramePacket(
+                port=self._port,
+                frame_index=0,
+                frame_time=0.0,
+                frame=np.asarray(frame),  # type: ignore[arg-type]
+                points=None,
+            )
+            self._display_queue.put(initial_packet)
+            logger.debug(f"Loaded initial frame for port {self._port}")
+        else:
+            logger.warning(f"Failed to load initial frame from {self._video_path}")
+
+    def start_calibration(self) -> None:
+        """Start collecting calibration frames.
+
+        Creates RecordedStream with tracker, subscribes to queue,
+        and starts playback. Transitions to COLLECTING state.
+        """
+        if self.state not in (PresenterState.READY, PresenterState.CALIBRATED):
+            logger.warning(f"Cannot start calibration in state {self.state}")
+            return
+
+        logger.info(f"Starting calibration collection for port {self._port}")
+
+        # Clear previous attempt's data
+        self._collected_points.clear()
+        self._calibrated_camera = None
+        self._calibration_task = None
+
+        # Create stream with tracker
+        self._stream = RecordedStream(
+            directory=self._video_path.parent,
+            camera=self._camera,
+            tracker=self._tracker,
+            break_on_last=True,
+        )
+        self._stream.subscribe(self._frame_queue)
+
+        # Start consumer thread
+        self._stop_event.clear()
+        self._consumer_thread = Thread(target=self._consume_frames, daemon=True)
+        self._consumer_thread.start()
+
+        # Mark as collecting before starting playback
+        self._is_collecting = True
+        self._emit_state_changed()
+
+        # Start playback
+        self._stream.play_video()
+
+    def stop_calibration(self) -> None:
+        """Stop collection and return to READY state.
+
+        Stops the stream, clears accumulated data, and resets state.
+        """
+        if self.state != PresenterState.COLLECTING:
+            logger.warning(f"Cannot stop calibration in state {self.state}")
+            return
+
+        logger.info(f"Stopping calibration collection for port {self._port}")
+
+        # Signal consumer to stop
+        self._stop_event.set()
+
+        # Stop stream playback
+        if self._stream is not None:
+            self._stream.stop_event.set()
+
+        # Wait for consumer thread
+        if self._consumer_thread is not None:
+            self._consumer_thread.join(timeout=2.0)
+            self._consumer_thread = None
+
+        # Clean up stream
+        if self._stream is not None:
+            self._stream.unsubscribe(self._frame_queue)
+            self._stream.capture.release()
+            self._stream = None
+
+        # Drain queue
+        while not self._frame_queue.empty():
+            try:
+                self._frame_queue.get_nowait()
+            except Empty:
+                break
+
+        # Clear state
+        self._collected_points.clear()
+        self._is_collecting = False
+        self._emit_state_changed()
+
+        # Reload initial frame for display
+        self._load_initial_frame()
+
+    def _consume_frames(self) -> None:
+        """Pull frames from queue, accumulate points, emit for display.
+
+        Runs in a separate thread. Exits when stop_event is set or
+        end-of-stream packet is received.
+        """
+        logger.debug(f"Consumer thread started for port {self._port}")
+
+        while not self._stop_event.is_set():
+            try:
+                packet: FramePacket = self._frame_queue.get(timeout=0.1)
+            except Empty:
+                continue
+
+            # End of stream signal
+            if packet.frame_index == -1:
+                logger.info(f"End of stream reached for port {self._port}")
+                self._on_collection_complete()
+                break
+
+            # Accumulate points (store frame_index with PointPacket)
+            # Skip empty detections - PointPacket exists but has no points
+            if packet.points is not None and len(packet.points.point_id) > 0:
+                self._collected_points.append((packet.frame_index, packet.points))
+
+            # Put on display queue for View's processing thread
+            self._display_queue.put(packet)
+
+        logger.debug(f"Consumer thread exiting for port {self._port}")
+
+    def _on_collection_complete(self) -> None:
+        """Called when video playback finishes. Submits calibration task."""
+        self._is_collecting = False
+
+        if len(self._collected_points) == 0:
+            logger.warning(f"No points collected for port {self._port}")
+            self.calibration_failed.emit("No charuco boards detected in video")
+            self._emit_state_changed()
+            return
+
+        logger.info(f"Collection complete for port {self._port}: {len(self._collected_points)} frames with points")
+
+        # Build ImagePoints from collected data
+        try:
+            image_points = self._build_image_points()
+        except Exception as e:
+            logger.error(f"Failed to build ImagePoints: {e}")
+            self.calibration_failed.emit(str(e))
+            self._emit_state_changed()
+            return
+
+        # Select calibration frames
+        selection_result = select_calibration_frames(image_points, self._port, self._image_size)
+
+        if not selection_result.selected_frames:
+            logger.warning(f"No frames selected for calibration at port {self._port}")
+            self.calibration_failed.emit("Frame selection found no suitable frames")
+            self._emit_state_changed()
+            return
+
+        logger.info(f"Selected {len(selection_result.selected_frames)} frames for calibration")
+
+        # Submit calibration to TaskManager
+        def calibration_worker(token: CancellationToken, handle: TaskHandle) -> IntrinsicCalibrationResult:
+            return calibrate_intrinsics(
+                image_points,
+                self._port,
+                self._image_size,
+                selection_result.selected_frames,
+            )
+
+        self._calibration_task = self._task_manager.submit(
+            calibration_worker,
+            name=f"Intrinsic calibration port {self._port}",
+        )
+        self._calibration_task.completed.connect(self._on_calibration_complete)
+        self._calibration_task.failed.connect(self._on_calibration_failed)
+
+        self._emit_state_changed()
+
+    def _build_image_points(self) -> ImagePoints:
+        """Convert accumulated (frame_index, PointPacket) to ImagePoints."""
+        import pandas as pd
+
+        rows = []
+        for frame_index, points in self._collected_points:
+            # For single-camera calibration, sync_index == frame_index
+            point_count = len(points.point_id)
+
+            # Build row data matching ImagePoints schema
+            row_data = {
+                "sync_index": [frame_index] * point_count,
+                "port": [self._port] * point_count,
+                "frame_index": [frame_index] * point_count,
+                "frame_time": [0.0] * point_count,  # Not used for calibration
+                "point_id": points.point_id.tolist(),
+                "img_loc_x": points.img_loc[:, 0].tolist(),
+                "img_loc_y": points.img_loc[:, 1].tolist(),
+                "obj_loc_x": points.obj_loc[:, 0].tolist() if points.obj_loc is not None else [None] * point_count,
+                "obj_loc_y": points.obj_loc[:, 1].tolist() if points.obj_loc is not None else [None] * point_count,
+                "obj_loc_z": points.obj_loc[:, 2].tolist() if points.obj_loc is not None else [None] * point_count,
+            }
+            rows.append(pd.DataFrame(row_data))
+
+        df = pd.concat(rows, ignore_index=True)
+        return ImagePoints(df)
+
+    def _on_calibration_complete(self, result: IntrinsicCalibrationResult) -> None:
+        """Handle successful calibration. Creates calibrated CameraData."""
+        logger.info(
+            f"Calibration complete for port {self._port}: "
+            f"error={result.reprojection_error:.4f}px, "
+            f"frames={result.frames_used}"
+        )
+
+        # Create new CameraData with calibration results applied
+        self._calibrated_camera = CameraData(
+            port=self._camera.port,
+            size=self._camera.size,
+            rotation_count=self._camera.rotation_count,
+            error=result.reprojection_error,
+            matrix=result.camera_matrix,
+            distortions=result.distortions,
+            grid_count=result.frames_used,
+        )
+
+        self.calibration_complete.emit(self._calibrated_camera)
+        self._emit_state_changed()
+
+        # Reload initial frame so View has something to display/undistort
+        self._load_initial_frame()
+
+    def _on_calibration_failed(self, exc_type: str, message: str) -> None:
+        """Handle calibration failure."""
+        logger.error(f"Calibration failed for port {self._port}: {exc_type}: {message}")
+        self.calibration_failed.emit(f"{exc_type}: {message}")
+        self._emit_state_changed()
+
+    def _emit_state_changed(self) -> None:
+        """Emit state_changed signal with current computed state."""
+        current_state = self.state
+        logger.debug(f"State changed to {current_state} for port {self._port}")
+        self.state_changed.emit(current_state)

--- a/src/caliscope/gui/views/__init__.py
+++ b/src/caliscope/gui/views/__init__.py
@@ -1,0 +1,5 @@
+"""Views for MVP architecture.
+
+Views handle rendering and user input. They receive display-ready data
+from Presenters and delegate actions back via method calls.
+"""

--- a/src/caliscope/gui/views/intrinsic_calibration_dev_view.py
+++ b/src/caliscope/gui/views/intrinsic_calibration_dev_view.py
@@ -1,0 +1,244 @@
+"""Minimal development View for intrinsic calibration testing.
+
+This is a development harness to validate the IntrinsicCalibrationPresenter.
+Not intended for production use - serves as a testbed for the Presenter's
+workflow before building the production View.
+"""
+
+import logging
+from queue import Empty, Queue
+from threading import Event
+
+from PySide6.QtCore import Qt, QThread, Signal
+from PySide6.QtGui import QPixmap
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from caliscope.cameras.camera_array import CameraData
+from caliscope.gui.camera_undistort_view import CameraUndistortView
+from caliscope.gui.frame_emitters.tools import (
+    apply_rotation,
+    cv2_to_qlabel,
+    resize_to_square,
+)
+from caliscope.gui.presenters.intrinsic_calibration_presenter import (
+    IntrinsicCalibrationPresenter,
+    PresenterState,
+)
+from caliscope.packets import FramePacket
+
+logger = logging.getLogger(__name__)
+
+
+class FrameProcessingThread(QThread):
+    """Processes raw frames for display - runs off GUI thread.
+
+    Reads directly from Presenter's display_queue (no intermediate signal).
+    Applies display transforms and emits QPixmaps for the GUI thread.
+    """
+
+    pixmap_ready = Signal(QPixmap)
+
+    def __init__(
+        self,
+        display_queue: Queue[FramePacket | None],
+        camera: CameraData,
+        pixmap_edge_length: int = 500,
+        parent: QThread | None = None,
+    ):
+        super().__init__(parent)
+        self._display_queue = display_queue
+        self._camera = camera
+        self._pixmap_edge_length = pixmap_edge_length
+        self._undistort_enabled = False
+        self._undistort_view: CameraUndistortView | None = None
+        self._keep_running = Event()
+
+    def set_undistort(self, enabled: bool, calibrated_camera: CameraData | None) -> None:
+        """Enable/disable undistortion."""
+        self._undistort_enabled = enabled
+
+        # Create undistort view on first enable
+        if enabled and self._undistort_view is None and calibrated_camera is not None:
+            h, w = calibrated_camera.size[1], calibrated_camera.size[0]
+            self._undistort_view = CameraUndistortView(calibrated_camera, (h, w))
+            logger.info(f"Created undistort view for port {calibrated_camera.port}")
+
+    def stop(self) -> None:
+        """Signal thread to stop."""
+        self._keep_running.clear()
+
+    def run(self) -> None:
+        """Main processing loop - reads directly from Presenter's queue."""
+        self._keep_running.set()
+        logger.debug(f"Frame processing thread started for port {self._camera.port}")
+
+        while self._keep_running.is_set():
+            try:
+                packet = self._display_queue.get(timeout=0.1)
+            except Empty:
+                continue
+
+            # None sentinel - Presenter signals end of sequence
+            if packet is None:
+                continue
+
+            # Skip packets with no frame (e.g., end-of-stream markers)
+            if packet.frame is None:
+                continue
+
+            # Processing pipeline (mirrors PlaybackFrameEmitter)
+            frame = packet.frame_with_points
+
+            if self._undistort_enabled and self._undistort_view is not None:
+                frame = self._undistort_view.undistort_frame(frame)
+
+            frame = resize_to_square(frame)
+            frame = apply_rotation(frame, self._camera.rotation_count)
+
+            image = cv2_to_qlabel(frame)
+            pixmap = QPixmap.fromImage(image)
+            pixmap = pixmap.scaled(
+                self._pixmap_edge_length,
+                self._pixmap_edge_length,
+                Qt.AspectRatioMode.KeepAspectRatio,
+            )
+
+            self.pixmap_ready.emit(pixmap)
+
+        logger.debug(f"Frame processing thread exiting for port {self._camera.port}")
+
+
+class IntrinsicCalibrationDevView(QWidget):
+    """Minimal development View for testing IntrinsicCalibrationPresenter.
+
+    Layout:
+    - Frame display (QLabel)
+    - Status label showing current state
+    - Calibrate/Stop button
+    - Undistort checkbox (enabled after calibration)
+    """
+
+    def __init__(
+        self,
+        presenter: IntrinsicCalibrationPresenter,
+        parent: QWidget | None = None,
+    ):
+        super().__init__(parent)
+        self._presenter = presenter
+
+        self._setup_ui()
+        self._setup_processing_thread()
+        self._connect_signals()
+
+        # Initial UI state
+        self._update_ui_for_state(presenter.state)
+
+    def _setup_ui(self) -> None:
+        """Create UI elements."""
+        layout = QVBoxLayout(self)
+
+        # Frame display
+        self._frame_label = QLabel()
+        self._frame_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._frame_label.setMinimumSize(500, 500)
+        self._frame_label.setStyleSheet("background-color: #1a1a1a;")
+        layout.addWidget(self._frame_label)
+
+        # Status label
+        self._status_label = QLabel("Status: READY")
+        self._status_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(self._status_label)
+
+        # Controls row
+        controls = QHBoxLayout()
+
+        self._calibrate_btn = QPushButton("Calibrate")
+        self._calibrate_btn.clicked.connect(self._on_calibrate_clicked)
+        controls.addWidget(self._calibrate_btn)
+
+        self._undistort_checkbox = QCheckBox("Undistort")
+        self._undistort_checkbox.setEnabled(False)
+        self._undistort_checkbox.toggled.connect(self._on_undistort_toggled)
+        controls.addWidget(self._undistort_checkbox)
+
+        layout.addLayout(controls)
+
+    def _setup_processing_thread(self) -> None:
+        """Create and start the frame processing thread."""
+        self._processing_thread = FrameProcessingThread(
+            display_queue=self._presenter.display_queue,
+            camera=self._presenter.camera,
+        )
+        self._processing_thread.pixmap_ready.connect(self._on_pixmap_ready)
+        self._processing_thread.start()
+
+    def _connect_signals(self) -> None:
+        """Connect presenter signals to view slots."""
+        self._presenter.state_changed.connect(self._update_ui_for_state)
+        self._presenter.calibration_complete.connect(self._on_calibration_complete)
+        self._presenter.calibration_failed.connect(self._on_calibration_failed)
+
+    def _on_pixmap_ready(self, pixmap: QPixmap) -> None:
+        """Update frame display."""
+        self._frame_label.setPixmap(pixmap)
+
+    def _update_ui_for_state(self, state: PresenterState) -> None:
+        """Update UI elements based on presenter state."""
+        self._status_label.setText(f"Status: {state.name}")
+
+        if state == PresenterState.READY:
+            self._calibrate_btn.setText("Calibrate")
+            self._calibrate_btn.setEnabled(True)
+            self._undistort_checkbox.setEnabled(False)
+        elif state == PresenterState.COLLECTING:
+            self._calibrate_btn.setText("Stop")
+            self._calibrate_btn.setEnabled(True)
+            self._undistort_checkbox.setEnabled(False)
+        elif state == PresenterState.CALIBRATING:
+            self._calibrate_btn.setText("Calibrating...")
+            self._calibrate_btn.setEnabled(False)
+            self._undistort_checkbox.setEnabled(False)
+        elif state == PresenterState.CALIBRATED:
+            self._calibrate_btn.setText("Recalibrate")
+            self._calibrate_btn.setEnabled(True)
+            self._undistort_checkbox.setEnabled(True)
+
+    def _on_calibrate_clicked(self) -> None:
+        """Handle calibrate/stop button click."""
+        state = self._presenter.state
+
+        if state == PresenterState.COLLECTING:
+            self._presenter.stop_calibration()
+        elif state in (PresenterState.READY, PresenterState.CALIBRATED):
+            # Reset undistort when starting new calibration
+            self._undistort_checkbox.setChecked(False)
+            self._presenter.start_calibration()
+
+    def _on_undistort_toggled(self, checked: bool) -> None:
+        """Handle undistort checkbox toggle."""
+        self._processing_thread.set_undistort(checked, self._presenter.calibrated_camera)
+        # Request fresh frame to show undistort effect
+        self._presenter.refresh_display()
+
+    def _on_calibration_complete(self, calibrated_camera: CameraData) -> None:
+        """Handle successful calibration."""
+        error = calibrated_camera.error or 0.0
+        grid_count = calibrated_camera.grid_count or 0
+        self._status_label.setText(f"Status: CALIBRATED (RMSE: {error:.3f}px, frames: {grid_count})")
+
+    def _on_calibration_failed(self, error_msg: str) -> None:
+        """Handle calibration failure."""
+        self._status_label.setText(f"Status: FAILED - {error_msg}")
+
+    def closeEvent(self, event) -> None:
+        """Clean up on close."""
+        self._processing_thread.stop()
+        self._processing_thread.wait(2000)
+        super().closeEvent(event)

--- a/src/caliscope/trackers/charuco_tracker.py
+++ b/src/caliscope/trackers/charuco_tracker.py
@@ -56,8 +56,8 @@ class CharucoTracker(Tracker):
         return self.charuco.get_connected_points()
 
     def find_corners_single_frame(self, gray_frame, mirror):
-        ids = np.array([])
-        img_loc = np.array([])
+        ids = np.array([], dtype=np.int32)
+        img_loc = np.empty((0, 2), dtype=np.float64)
 
         # detect if aruco markers are present
         aruco_corners, aruco_ids, rejected = cv2.aruco.detectMarkers(gray_frame, self.dictionary_object)
@@ -104,7 +104,7 @@ class CharucoTracker(Tracker):
                 corners = np.column_stack([corners, np.zeros(len(ids))])
             return corners
         else:
-            return np.array([])
+            return np.empty((0, 3), dtype=np.float64)
 
     # @property
     def scatter_draw_instructions(self, point_id: int) -> dict:


### PR DESCRIPTION
## Summary

- Add `IntrinsicCalibrationPresenter` with computed state (READY/COLLECTING/CALIBRATING/CALIBRATED)
- Queue-based frame pipeline keeps heavy FramePackets off GUI thread until processed into QPixmaps
- Presenter emits `CameraData` on `calibration_complete` signal for downstream persistence
- Dev view harness with frame display, undistort toggle, and recalibrate support
- Fix CharucoTracker to return properly shaped empty arrays `(0, 2)` instead of `(0,)` when no corners detected

## Test plan

- [x] Run `uv run python scripts/launch_intrinsic_calibration.py 1`
- [x] Click Calibrate → video plays, frames update with detected corners
- [x] Wait for calibration to complete → status shows RMSE and frame count
- [x] Toggle Undistort checkbox → frame updates with undistorted view
- [x] Click Recalibrate → new calibration workflow starts

Closes #835