### PR TITLE
Integrate RecordedStream with TaskManager

### DIFF
--- a/src/caliscope/managers/intrinsic_stream_manager.py
+++ b/src/caliscope/managers/intrinsic_stream_manager.py
@@ -62,11 +62,9 @@ class IntrinsicStreamManager:
             calibrator.stop()
 
         for port, stream in self.streams.items():
-            stream.stop_event.set()
             stream.unpause()
-            logger.info(f"About to wait for camera {port} to close")
-            # stream.jump_to(0)
-            stream.thread.join()
+            stream.stop()
+            logger.info(f"Stopped stream for camera {port}")
 
         logger.info("Finished closing stream tools")
 
@@ -102,8 +100,8 @@ class IntrinsicStreamManager:
         self.streams[port].jump_to(frame)
 
     def end_stream(self, port):
-        self.streams[port].stop_event.set()
         self.unpause_stream(port)
+        self.streams[port].stop()
 
     def add_calibration_grid(self, port: int, frame_index: int):
         self.calibrators[port].add_calibration_frame_index(frame_index)

--- a/tests/test_intrinsic_calibrator.py
+++ b/tests/test_intrinsic_calibrator.py
@@ -60,8 +60,8 @@ def test_intrinsic_calibrator(tmp_path: Path):
         intrinsic_calibrator.add_frame_packet(packet)
         intrinsic_calibrator.add_calibration_frame_index(packet.frame_index)
 
-    stream.stop_event.set()
     stream.unpause()
+    stream.stop()
     intrinsic_calibrator.stop_event.set()
 
     logger.info(camera.get_display_data())


### PR DESCRIPTION
## Summary

- Replace `stop_event` with `CancellationToken` pattern for centralized task lifecycle management
- Fix pause spinlock bug that caused hangs when cancelling during pause
- Update `IntrinsicCalibrationPresenter` to use `TaskManager.submit()` for stream playback
- Add `stop()` method to `RecordedStream` for clean shutdown

## Changes

| File | Change |
|------|--------|
| `recorded_stream.py` | Add `play_worker(token, handle)`, `stop()`, fix pause spinlock |
| `intrinsic_calibration_presenter.py` | Use TaskManager for stream, add `cleanup()` |
| `intrinsic_stream_manager.py` | Use `stop()` instead of `stop_event.set()` |
| `test_intrinsic_calibrator.py` | Update to use `stop()` |

## Test plan

- [x] `test_stream.py` passes
- [x] `test_intrinsic_calibrator.py` passes
- [x] Full test suite (99 tests) passes
- [ ] GHA CI

Closes #871