### PR TITLE
Migrate RecordedStream to PyAV

### DIFF
--- a/src/caliscope/gui/presenters/intrinsic_calibration_presenter.py
+++ b/src/caliscope/gui/presenters/intrinsic_calibration_presenter.py
@@ -244,7 +244,7 @@ class IntrinsicCalibrationPresenter(QObject):
         # Clean up stream
         if self._stream is not None:
             self._stream.unsubscribe(self._frame_queue)
-            self._stream.capture.release()
+            self._stream.close()
             self._stream = None
 
         # Drain queue

--- a/src/caliscope/recording/recorded_stream.py
+++ b/src/caliscope/recording/recorded_stream.py
@@ -1,13 +1,15 @@
 import logging
 from pathlib import Path
 from queue import Queue
-from threading import Event, Thread
+from threading import Condition, Event, Lock, Thread
+from typing import Iterator
 
 from caliscope.task_manager.cancellation import CancellationToken
 from caliscope.task_manager.task_handle import TaskHandle
 from time import perf_counter, sleep
 
-import cv2
+import av
+from av.video.frame import VideoFrame
 import numpy as np
 import pandas as pd
 from caliscope.cameras.camera_array import CameraData
@@ -45,21 +47,38 @@ class RecordedStream:
         self.tracker = tracker
 
         video_path = str(Path(self.directory, f"port_{self.port}.mp4"))
-        self.capture = cv2.VideoCapture(video_path)
+
+        # PyAV container and stream
+        self._container = av.open(video_path)
+        self._video_stream = self._container.streams.video[0]
+        self._container_lock = Lock()
+        self._frame_iterator: Iterator[VideoFrame] | None = None
+
+        # These should always be set for a valid video stream
+        if self._video_stream.time_base is None:
+            raise ValueError(f"Video stream has no time_base: {video_path}")
+        if self._video_stream.average_rate is None:
+            raise ValueError(f"Video stream has no average_rate: {video_path}")
+
+        self._time_base = float(self._video_stream.time_base)
 
         # for playback, set the fps target to the actual
-        self.original_fps = int(self.capture.get(cv2.CAP_PROP_FPS))
+        self.original_fps = int(float(self._video_stream.average_rate))
         if fps_target is None:
             fps_target = self.original_fps
 
-        width = int(self.capture.get(cv2.CAP_PROP_FRAME_WIDTH))
-        height = int(self.capture.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        width = self._video_stream.width
+        height = self._video_stream.height
         self.size = (width, height)
 
-        self._jump_q = Queue(maxsize=1)
+        # Jump request: (frame_index, exact) - latest value wins, overwrites pending
+        self._pending_jump: tuple[int, bool] | None = None
+        self._jump_lock = Lock()
+        self._jump_condition = Condition(self._jump_lock)
+
         self._pause_event = Event()
         self._pause_event.clear()
-        self.subscribers = []
+        self.subscribers: list[Queue] = []
 
         # For play_video() convenience wrapper
         self._internal_token: CancellationToken | None = None
@@ -78,7 +97,12 @@ class RecordedStream:
         ########### INFER TIME STAMP IF NOT AVAILABLE ####################################
         else:
             logger.info("Infering time stamps for frames based on capture data")
-            frame_count = int(self.capture.get(cv2.CAP_PROP_FRAME_COUNT))
+            # stream.frames may return 0 if unknown; fall back to duration-based estimate
+            frame_count = self._video_stream.frames
+            if frame_count == 0 and self._container.duration is not None:
+                # duration is in microseconds
+                duration_seconds = self._container.duration / 1_000_000
+                frame_count = int(duration_seconds * self.original_fps)
             mocked_port_history = {
                 "frame_index": [i for i in range(0, frame_count)],
                 "frame_time": [i / self.original_fps for i in range(0, frame_count)],
@@ -95,18 +119,17 @@ class RecordedStream:
 
         # initialize properties
         self.frame_index = 0
-        self.frame_time = 0
+        self.frame_time = 0.0
         self.set_fps_target(fps_target)
 
-    # def set_tracking_on(self, track: bool):
-    #     if track:
-    #         logger.info(f"Turning tracking on for recorded stream {self.port}")
-    #         self.track_points =
-    #     else:
-    #         logger.info(f"Turning tracking off for recorded stream {self.port}")
-    #         self.track_points.clear()
+    def close(self) -> None:
+        """Release video container resources."""
+        with self._container_lock:
+            if self._container is not None:
+                self._container.close()
+                self._container = None  # type: ignore[assignment]
 
-    def subscribe(self, queue: Queue):
+    def subscribe(self, queue: Queue) -> None:
         if queue not in self.subscribers:
             logger.info(f"Adding queue to subscribers at recorded stream {self.port}")
             self.subscribers.append(queue)
@@ -114,7 +137,7 @@ class RecordedStream:
         else:
             logger.warning(f"Attempted to subscribe to recorded stream at port {self.port} twice")
 
-    def unsubscribe(self, queue: Queue):
+    def unsubscribe(self, queue: Queue) -> None:
         if queue in self.subscribers:
             logger.info(f"Removing subscriber from queue at recorded stream {self.port}")
             self.subscribers.remove(queue)
@@ -125,14 +148,14 @@ class RecordedStream:
                 at port {self.port} twice"
             )
 
-    def set_fps_target(self, fps):
+    def set_fps_target(self, fps: int | None) -> None:
         self.fps = fps
         if self.fps is None:
             self.milestones = None
         else:
             milestones = []
-            for i in range(0, fps):
-                milestones.append(i / fps)
+            for i in range(0, self.fps):
+                milestones.append(i / self.fps)
             logger.info(f"Setting fps to {self.fps}")
             self.milestones = np.array(milestones)
 
@@ -153,15 +176,39 @@ class RecordedStream:
         else:
             return future_wait_times[0]
 
-    def jump_to(self, frame_index: int):
-        logger.info(f"Placing {frame_index} on jump q to reset capture position")
-        self._jump_q.put(frame_index)
+    def jump_to(self, frame_index: int, exact: bool = True) -> None:
+        """Request a seek to the specified frame.
 
-    def pause(self):
+        Args:
+            frame_index: Target frame to seek to.
+            exact: If True (default), decode to exact frame. If False, seek to
+                   nearest keyframe only (faster, good for scrubbing during drag).
+
+        Note: If multiple jump requests arrive before the worker processes them,
+        only the latest request is honored (previous pending jumps are dropped).
+        """
+        with self._jump_condition:
+            logger.info(f"Setting pending jump to frame {frame_index} (exact={exact})")
+            self._pending_jump = (frame_index, exact)
+            self._jump_condition.notify()
+
+    def _has_pending_jump(self) -> bool:
+        """Check if there's a pending jump request."""
+        with self._jump_lock:
+            return self._pending_jump is not None
+
+    def _take_pending_jump(self) -> tuple[int, bool] | None:
+        """Take and clear the pending jump request."""
+        with self._jump_lock:
+            jump = self._pending_jump
+            self._pending_jump = None
+            return jump
+
+    def pause(self) -> None:
         logger.info(f"Pausing recorded stream at port {self.port}")
         self._pause_event.set()
 
-    def unpause(self):
+    def unpause(self) -> None:
         logger.info(f"Unpausing recorded stream at port {self.port}")
         self._pause_event.clear()
 
@@ -181,97 +228,213 @@ class RecordedStream:
             self.thread = None
         logger.info(f"Stopped playback for port {self.port}")
 
+    def _seek_to_frame(self, target_frame_index: int) -> np.ndarray | None:
+        """Seek to exact frame and return it as BGR numpy array.
+
+        Uses PyAV's seek to nearest keyframe, then decodes forward to exact frame.
+        Returns None if seek fails or frame not found.
+        """
+        with self._container_lock:
+            if self._container is None:
+                return None
+
+            # Convert frame index to PTS (presentation timestamp)
+            target_pts = int(target_frame_index / self.original_fps / self._time_base)
+            self._container.seek(target_pts, stream=self._video_stream)
+
+            # Decode frames until we reach or pass the target
+            for frame in self._container.decode(self._video_stream):
+                if frame.pts is None:
+                    continue  # Skip frames without PTS
+                frame_idx = int(frame.pts * self._time_base * self.original_fps)
+                if frame_idx >= target_frame_index:
+                    return frame.to_ndarray(format="bgr24")
+
+            return None
+
+    def _seek_to_keyframe(self, target_frame_index: int) -> tuple[np.ndarray | None, int]:
+        """Seek to nearest keyframe and return it with actual frame index.
+
+        Fast seeking for scrubbing - returns the keyframe at or before target,
+        without decoding forward to the exact frame.
+
+        Returns:
+            Tuple of (frame_data, actual_frame_index). Frame data is None if seek fails.
+        """
+        with self._container_lock:
+            if self._container is None:
+                return None, target_frame_index
+
+            # Convert frame index to PTS (presentation timestamp)
+            target_pts = int(target_frame_index / self.original_fps / self._time_base)
+            self._container.seek(target_pts, stream=self._video_stream)
+
+            # Return the first frame after seek (the keyframe)
+            for frame in self._container.decode(self._video_stream):
+                if frame.pts is None:
+                    continue
+                actual_idx = int(frame.pts * self._time_base * self.original_fps)
+                return frame.to_ndarray(format="bgr24"), actual_idx
+
+            return None, target_frame_index
+
+    def _read_next_frame(self) -> np.ndarray | None:
+        """Read the next frame from the iterator, returning BGR numpy array or None at EOF."""
+        with self._container_lock:
+            if self._container is None:
+                return None
+
+            if self._frame_iterator is None:
+                self._frame_iterator = self._container.decode(self._video_stream)
+
+            try:
+                frame = next(self._frame_iterator)
+                return frame.to_ndarray(format="bgr24")
+            except StopIteration:
+                return None
+
+    def _reset_iterator(self) -> None:
+        """Reset the frame iterator after a seek."""
+        with self._container_lock:
+            if self._container is not None:
+                self._frame_iterator = self._container.decode(self._video_stream)
+
     def play_worker(self, token: CancellationToken, handle: TaskHandle | None = None) -> None:
         """
         Places FramePacket on the out_q, mimicking the behaviour of the LiveStream.
         """
+        try:
+            self.frame_index = self.start_frame_index
 
-        self.frame_index = self.start_frame_index
-        logger.info(f"Beginning playback of video for port {self.port}")
+            # Seek to start frame if not starting at 0
+            if self.start_frame_index > 0:
+                self._seek_to_frame(self.start_frame_index)
+            self._reset_iterator()
 
-        while not token.is_cancelled:
-            current_frame = self.port_history["frame_index"] == self.frame_index
-            self.frame_time = self.port_history[current_frame]["frame_time"]
-            self.frame_time = float(self.frame_time.iloc[0])
+            logger.info(f"Beginning playback of video for port {self.port}")
 
-            ########## BEGIN NO SUBSCRIBERS SPINLOCK ##################
-            spinlock_looped = False
-            while len(self.subscribers) == 0 and not token.is_cancelled:
-                if not spinlock_looped:
-                    logger.info(f"Spinlock initiated at port {self.port}")
-                    spinlock_looped = True
-                token.sleep_unless_cancelled(0.5)
-            if spinlock_looped:
-                logger.info(f"Spinlock released at port {self.port}")
-            ########## END NO SUBSCRIBERS SPINLOCK ##################
+            # Flag to skip read when we already have the frame from a seek
+            skip_read = False
 
-            if self.milestones is not None:
-                sleep(self.wait_to_next_frame())
-            # logger.info(f"about to read frame {self.frame_index} from capture at port {self.port}")
-            success, self.frame = self.capture.read()
+            while not token.is_cancelled:
+                current_frame = self.port_history["frame_index"] == self.frame_index
+                self.frame_time = self.port_history[current_frame]["frame_time"]
+                self.frame_time = float(self.frame_time.iloc[0])
 
-            if not success:
-                break
+                ########## BEGIN NO SUBSCRIBERS SPINLOCK ##################
+                spinlock_looped = False
+                while len(self.subscribers) == 0 and not token.is_cancelled:
+                    if not spinlock_looped:
+                        logger.info(f"Spinlock initiated at port {self.port}")
+                        spinlock_looped = True
+                    token.sleep_unless_cancelled(0.5)
+                if spinlock_looped:
+                    logger.info(f"Spinlock released at port {self.port}")
+                ########## END NO SUBSCRIBERS SPINLOCK ##################
 
-            if self.tracker is not None:
-                self.point_data = self.tracker.get_points(self.frame, self.port, self.rotation_count)
-                draw_instructions = self.tracker.scatter_draw_instructions
-            else:
-                self.point_data = None
-                draw_instructions = None
+                if self.milestones is not None:
+                    sleep(self.wait_to_next_frame())
 
-            frame_packet = FramePacket(
-                port=self.port,
-                frame_index=self.frame_index,
-                frame_time=self.frame_time,
-                frame=self.frame,
-                points=self.point_data,
-                draw_instructions=draw_instructions,
-            )
+                # Read next frame unless we already have it from a seek
+                if skip_read:
+                    skip_read = False
+                else:
+                    self.frame = self._read_next_frame()
 
-            logger.debug(
-                f"Placing frame on q {self.port} for frame time: {self.frame_time} and frame index: {self.frame_index}"
-            )
+                if self.frame is None:
+                    # Iterator exhausted - send EOF marker before exiting
+                    logger.info(f"Iterator exhausted at port {self.port}")
+                    eof_packet = FramePacket(
+                        port=self.port,
+                        frame_index=-1,
+                        frame_time=-1,
+                        frame=None,
+                        points=None,
+                    )
+                    for q in self.subscribers:
+                        q.put(eof_packet)
+                    break
 
-            for q in self.subscribers:
-                q.put(frame_packet)
+                if self.tracker is not None:
+                    self.point_data = self.tracker.get_points(self.frame, self.port, self.rotation_count)
+                    draw_instructions = self.tracker.scatter_draw_instructions
+                else:
+                    self.point_data = None
+                    draw_instructions = None
 
-            if self.frame_index == self.last_frame_index and self.break_on_last:
-                logger.info(f"Ending recorded playback at port {self.port}")
-                # time of -1 indicates end of stream
                 frame_packet = FramePacket(
                     port=self.port,
-                    frame_index=-1,
-                    frame_time=-1,
-                    frame=None,
-                    points=None,
+                    frame_index=self.frame_index,
+                    frame_time=self.frame_time,
+                    frame=self.frame,
+                    points=self.point_data,
+                    draw_instructions=draw_instructions,
+                )
+
+                logger.debug(
+                    f"Placing frame on q {self.port} for frame time: {self.frame_time} "
+                    f"and frame index: {self.frame_index}"
                 )
 
                 for q in self.subscribers:
                     q.put(frame_packet)
-                break
 
-            ############ Autopause if last frame and in playback mode (i.e. break_on_last == False)
-            if not self.break_on_last and self.frame_index == self.last_frame_index:
-                self._pause_event.set()
+                if self.frame_index == self.last_frame_index and self.break_on_last:
+                    logger.info(f"Ending recorded playback at port {self.port}")
+                    # time of -1 indicates end of stream
+                    frame_packet = FramePacket(
+                        port=self.port,
+                        frame_index=-1,
+                        frame_time=-1,
+                        frame=None,
+                        points=None,
+                    )
 
-            ############ SPIN LOCK FOR PAUSE ##################
-            pause_logged = False
-            while self._pause_event.is_set() and not token.is_cancelled:
-                if not pause_logged:
-                    logger.info("Initiating Pause")
-                    pause_logged = True
-
-                if not self._jump_q.empty():
-                    logger.info("New Value on jump queue, exiting pause spin lock")
+                    for q in self.subscribers:
+                        q.put(frame_packet)
                     break
 
-                token.sleep_unless_cancelled(0.1)
-            #######################################################
-            if not self._jump_q.empty():
-                self.frame_index = self._jump_q.get()
-                logger.info(f"Setting port {self.port} capture object to frame index {self.frame_index}")
-                self.capture.set(cv2.CAP_PROP_POS_FRAMES, self.frame_index)
-            else:
-                # Increment for next iteration (only if not jumping)
-                self.frame_index += 1
+                ############ Autopause if last frame and in playback mode (i.e. break_on_last == False)
+                if not self.break_on_last and self.frame_index == self.last_frame_index:
+                    self._pause_event.set()
+
+                ############ SPIN LOCK FOR PAUSE ##################
+                pause_logged = False
+                while self._pause_event.is_set() and not token.is_cancelled:
+                    if not pause_logged:
+                        logger.info("Initiating Pause")
+                        pause_logged = True
+
+                    if self._has_pending_jump():
+                        logger.info("Pending jump detected, exiting pause spin lock")
+                        break
+
+                    token.sleep_unless_cancelled(0.1)
+                #######################################################
+                pending = self._take_pending_jump()
+                if pending is not None:
+                    target_index, exact = pending
+                    logger.info(f"Processing jump to frame {target_index} (exact={exact}) at port {self.port}")
+
+                    if exact:
+                        # Exact seeking - decode forward to precise frame
+                        frame = self._seek_to_frame(target_index)
+                        if frame is not None:
+                            self.frame = frame
+                            self.frame_index = target_index
+                            skip_read = True
+                    else:
+                        # Keyframe seeking - fast, returns nearest keyframe
+                        frame, actual_index = self._seek_to_keyframe(target_index)
+                        if frame is not None:
+                            self.frame = frame
+                            self.frame_index = actual_index
+                            skip_read = True
+
+                    # Reset iterator to continue from current position
+                    self._reset_iterator()
+                else:
+                    # Increment for next iteration (only if not jumping)
+                    self.frame_index += 1
+        finally:
+            self.close()

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -3,8 +3,6 @@ from pathlib import Path
 from queue import Queue
 from time import sleep
 
-import cv2
-
 from caliscope import __root__
 from caliscope.cameras.camera_array import CameraData
 from caliscope.core.charuco import Charuco
@@ -61,12 +59,7 @@ def test_stream():
             # frame_index should match the jump target (the frame we just displayed)
             assert stream.frame_index == 20
 
-            logger.info(f"After attempting to jump to target frame {target_frame} ")
-            # OpenCV's CAP_PROP_POS_FRAMES returns the NEXT frame to be read
-            next_frame_position = int(stream.capture.get(cv2.CAP_PROP_POS_FRAMES))
-            logger.info(f"Next frame position is {next_frame_position}")
-            # After reading frame 20, capture position advances to 21
-            assert next_frame_position == 21
+            logger.info(f"After attempting to jump to target frame {target_frame}")
             stream.unpause()
 
         # cv2.imshow("Test", frame_packet.frame_with_points)


### PR DESCRIPTION
## Summary

- Replace `cv2.VideoCapture` with PyAV (`av.open()`) for video handling
- Implement two-tier seeking: keyframe (fast preview) vs exact (precise frame)
- Replace blocking `Queue(maxsize=1)` with "latest value wins" pattern for seeks
- Add `threading.Lock` for container access and `close()` method for cleanup

## Performance

| Scenario | Before | After |
|----------|--------|-------|
| 10 rapid seeks | 1,345ms (blocking) | 0.2ms (non-blocking) |
| Seeks processed | All queued | Only latest |

## API

```python
stream.jump_to(frame_index)              # Exact seek (default)
stream.jump_to(frame_index, exact=False) # Keyframe seek (fast)
```

## Test plan

- [x] `test_stream.py` - pause/unpause, seeking behavior
- [x] `test_synchronizer.py` - multi-stream sync
- [x] Full test suite (100 tests passing)
- [x] Manual: Test legacy intrinsic calibration slider scrubbing

Closes #882