### PR TITLE
feat(recording): extract FrameSource from RecordedStream

### DIFF
--- a/src/caliscope/recording/frame_source.py
+++ b/src/caliscope/recording/frame_source.py
@@ -1,0 +1,223 @@
+"""Raw frame access for recorded video files.
+
+FrameSource provides synchronous frame reading and seeking with no threading,
+queues, or tracking. It wraps PyAV for efficient video decoding.
+
+This is infrastructure (I/O), not domain logic - hence placement in recording/
+rather than core/.
+"""
+
+import logging
+from pathlib import Path
+from threading import Lock
+from typing import Iterator, Self
+
+import av
+import numpy as np
+from av.video.frame import VideoFrame
+
+logger = logging.getLogger(__name__)
+
+
+class FrameSource:
+    """Raw frame access for recorded video files.
+
+    Provides synchronous frame reading and seeking. Thread-safe for concurrent
+    method calls (internal state protected by lock), but NOT thread-safe for
+    access patterns: if multiple threads share a FrameSource, they must
+    coordinate externally to avoid interleaved seek/read sequences.
+
+    Typical usage: one owner thread, or explicit external synchronization.
+
+    Note: get_frame() and get_frame_fast() invalidate the sequential read
+    position. After calling either, read_frame() behavior is undefined until
+    the internal iterator is naturally exhausted or a new FrameSource is created.
+    """
+
+    def __init__(self, video_path: Path) -> None:
+        """Open a video file for frame access.
+
+        Args:
+            video_path: Path to the video file to open.
+
+        Raises:
+            ValueError: If the video stream lacks required metadata.
+        """
+        self.video_path = video_path
+
+        self._container = av.open(str(video_path))
+        self._video_stream = self._container.streams.video[0]
+        self._lock = Lock()
+        self._frame_iterator: Iterator[VideoFrame] | None = None
+
+        # Validate stream metadata
+        if self._video_stream.time_base is None:
+            raise ValueError(f"Video stream has no time_base: {video_path}")
+        if self._video_stream.average_rate is None:
+            raise ValueError(f"Video stream has no average_rate: {video_path}")
+
+        self._time_base = float(self._video_stream.time_base)
+        self.fps = float(self._video_stream.average_rate)
+        self.size = (self._video_stream.width, self._video_stream.height)
+
+        # Compute frame count - stream.frames may be 0 if unknown
+        frame_count = self._video_stream.frames
+        if frame_count == 0 and self._container.duration is not None:
+            # duration is in microseconds
+            duration_seconds = self._container.duration / 1_000_000
+            frame_count = int(duration_seconds * self.fps)
+        self.frame_count = frame_count
+
+        # Mark as successfully initialized - must be last line of __init__
+        # If init fails, _closed won't exist and __del__ won't warn
+        self._closed = False
+
+    @property
+    def start_frame_index(self) -> int:
+        """First valid frame index (always 0 for raw video)."""
+        return 0
+
+    @property
+    def last_frame_index(self) -> int:
+        """Last valid frame index (frame_count - 1)."""
+        return self.frame_count - 1
+
+    def get_frame(self, frame_index: int) -> np.ndarray | None:
+        """Seek to exact frame and return it as BGR numpy array.
+
+        Uses PyAV's seek to nearest keyframe, then decodes forward to exact frame.
+        O(keyframe_distance) complexity for compressed video.
+
+        Args:
+            frame_index: Target frame index to retrieve.
+
+        Returns:
+            Frame as BGR numpy array, or None if frame_index is out of bounds,
+            seek fails, or frame not found.
+
+        Note:
+            Invalidates sequential read position. After calling this method,
+            read_frame() behavior is undefined.
+        """
+        with self._lock:
+            if self._container is None:
+                return None
+
+            # Bounds check - prevent PyAV's wrap-around behavior
+            if frame_index < 0 or frame_index > self.last_frame_index:
+                return None
+
+            # Convert frame index to PTS (presentation timestamp)
+            target_pts = int(frame_index / self.fps / self._time_base)
+            self._container.seek(target_pts, stream=self._video_stream)
+
+            # Decode frames until we reach or pass the target
+            for frame in self._container.decode(self._video_stream):
+                if frame.pts is None:
+                    continue  # Skip frames without PTS
+                frame_idx = int(frame.pts * self._time_base * self.fps)
+                if frame_idx >= frame_index:
+                    return frame.to_ndarray(format="bgr24")
+
+            return None
+
+    def get_frame_fast(self, frame_index: int) -> tuple[np.ndarray | None, int]:
+        """Seek to nearest keyframe and return it with actual index.
+
+        Fast seeking for scrubbing - returns the keyframe at or before target,
+        without decoding forward to the exact frame. O(1) complexity for
+        compressed video.
+
+        Args:
+            frame_index: Target frame index (will return keyframe at or before).
+
+        Returns:
+            Tuple of (frame_data, actual_frame_index).
+            - frame_data: BGR numpy array, or None if out of bounds or seek fails.
+            - actual_frame_index: Index of returned frame, or -1 if out of bounds
+              or seek fails.
+
+        Note:
+            Invalidates sequential read position. After calling this method,
+            read_frame() behavior is undefined.
+        """
+        with self._lock:
+            if self._container is None:
+                return None, -1
+
+            # Bounds check - prevent PyAV's wrap-around behavior
+            if frame_index < 0 or frame_index > self.last_frame_index:
+                return None, -1
+
+            # Convert frame index to PTS (presentation timestamp)
+            target_pts = int(frame_index / self.fps / self._time_base)
+            self._container.seek(target_pts, stream=self._video_stream)
+
+            # Return the first frame after seek (the keyframe)
+            for frame in self._container.decode(self._video_stream):
+                if frame.pts is None:
+                    continue
+                actual_idx = int(frame.pts * self._time_base * self.fps)
+                return frame.to_ndarray(format="bgr24"), actual_idx
+
+            return None, -1
+
+    def read_frame(self) -> np.ndarray | None:
+        """Read next frame sequentially, returning BGR numpy array or None at EOF.
+
+        Creates a new iterator on first call. Subsequent calls return frames
+        in sequence until EOF.
+
+        Returns:
+            Frame as BGR numpy array, or None at end of file.
+
+        Note:
+            Position is undefined after get_frame() or get_frame_fast() calls.
+            For predictable sequential reading, use a fresh FrameSource or
+            read all frames without seeking.
+        """
+        with self._lock:
+            if self._container is None:
+                return None
+
+            if self._frame_iterator is None:
+                self._frame_iterator = self._container.decode(self._video_stream)
+
+            try:
+                frame = next(self._frame_iterator)
+                return frame.to_ndarray(format="bgr24")
+            except StopIteration:
+                return None
+
+    def close(self) -> None:
+        """Release video container resources."""
+        with self._lock:
+            self._closed = True
+            if self._container is not None:
+                self._container.close()
+                self._container = None  # type: ignore[assignment]
+
+    def __enter__(self) -> Self:
+        """Context manager entry."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object,
+    ) -> None:
+        """Context manager exit - releases resources."""
+        self.close()
+
+    def __del__(self) -> None:
+        """Destructor - warns if resources were not properly released.
+
+        If _closed doesn't exist, __init__ failed and there's nothing to warn about.
+        """
+        if not getattr(self, "_closed", True):
+            logger.warning(
+                f"FrameSource for {self.video_path} was not closed properly. "
+                "Use context manager or call close() explicitly."
+            )
+            self.close()

--- a/tests/test_frame_source.py
+++ b/tests/test_frame_source.py
@@ -1,0 +1,265 @@
+"""Tests for FrameSource - raw video frame access."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from caliscope.recording.frame_source import FrameSource
+
+
+# Test video path - use existing test session data
+TEST_VIDEO = Path(__file__).parent / "sessions/4_cam_recording/calibration/extrinsic/port_0.mp4"
+
+
+@pytest.fixture
+def frame_source() -> FrameSource:
+    """Create a FrameSource for testing."""
+    source = FrameSource(TEST_VIDEO)
+    yield source
+    source.close()
+
+
+class TestFrameSourceProperties:
+    """Test FrameSource metadata properties."""
+
+    def test_opens_video_file(self, frame_source: FrameSource) -> None:
+        """FrameSource opens video and exposes basic metadata."""
+        assert frame_source.frame_count > 0
+        assert frame_source.fps > 0
+        assert frame_source.size[0] > 0  # width
+        assert frame_source.size[1] > 0  # height
+
+    def test_start_frame_index_is_zero(self, frame_source: FrameSource) -> None:
+        """start_frame_index is always 0 for raw video."""
+        assert frame_source.start_frame_index == 0
+
+    def test_last_frame_index(self, frame_source: FrameSource) -> None:
+        """last_frame_index is frame_count - 1."""
+        assert frame_source.last_frame_index == frame_source.frame_count - 1
+
+    def test_video_path_stored(self, frame_source: FrameSource) -> None:
+        """video_path is stored for reference."""
+        assert frame_source.video_path == TEST_VIDEO
+
+
+class TestSequentialReading:
+    """Test read_frame() sequential access."""
+
+    def test_read_frame_returns_numpy_array(self, frame_source: FrameSource) -> None:
+        """read_frame() returns BGR numpy array."""
+        frame = frame_source.read_frame()
+        assert frame is not None
+        assert isinstance(frame, np.ndarray)
+        assert frame.ndim == 3  # height, width, channels
+        assert frame.shape[2] == 3  # BGR
+
+    def test_read_frame_matches_video_size(self, frame_source: FrameSource) -> None:
+        """Frame dimensions match video size."""
+        frame = frame_source.read_frame()
+        assert frame is not None
+        height, width, _ = frame.shape
+        expected_width, expected_height = frame_source.size
+        assert width == expected_width
+        assert height == expected_height
+
+    def test_read_frame_returns_none_at_eof(self, frame_source: FrameSource) -> None:
+        """read_frame() returns None when video is exhausted."""
+        # Read all frames
+        frame_count = 0
+        while frame_source.read_frame() is not None:
+            frame_count += 1
+
+        # Next read should return None
+        assert frame_source.read_frame() is None
+        assert frame_count == frame_source.frame_count
+
+    def test_sequential_frames_are_different(self, frame_source: FrameSource) -> None:
+        """Sequential frames should be different (video has motion)."""
+        frame1 = frame_source.read_frame()
+        frame2 = frame_source.read_frame()
+        assert frame1 is not None
+        assert frame2 is not None
+        # Frames should not be identical (unless video is static)
+        # Using a tolerance check - at least some pixels should differ
+        diff = np.abs(frame1.astype(np.int16) - frame2.astype(np.int16))
+        assert np.max(diff) > 0, "Sequential frames should differ"
+
+
+class TestExactFrameAccess:
+    """Test get_frame() exact frame seeking."""
+
+    def test_get_frame_returns_numpy_array(self, frame_source: FrameSource) -> None:
+        """get_frame() returns BGR numpy array."""
+        frame = frame_source.get_frame(0)
+        assert frame is not None
+        assert isinstance(frame, np.ndarray)
+        assert frame.ndim == 3
+        assert frame.shape[2] == 3
+
+    def test_get_frame_at_start(self, frame_source: FrameSource) -> None:
+        """get_frame(0) returns first frame."""
+        frame = frame_source.get_frame(0)
+        assert frame is not None
+
+    def test_get_frame_at_middle(self, frame_source: FrameSource) -> None:
+        """get_frame() works for middle frames."""
+        middle = frame_source.frame_count // 2
+        frame = frame_source.get_frame(middle)
+        assert frame is not None
+
+    def test_get_frame_at_end(self, frame_source: FrameSource) -> None:
+        """get_frame() works for last frame."""
+        last = frame_source.last_frame_index
+        frame = frame_source.get_frame(last)
+        assert frame is not None
+
+    def test_get_frame_beyond_end_returns_none(self, frame_source: FrameSource) -> None:
+        """get_frame() beyond video length returns None."""
+        beyond = frame_source.frame_count + 100
+        frame = frame_source.get_frame(beyond)
+        assert frame is None
+
+    def test_get_frame_different_positions_return_different_frames(self, frame_source: FrameSource) -> None:
+        """get_frame() at different positions returns different frames."""
+        frame_start = frame_source.get_frame(0)
+        frame_middle = frame_source.get_frame(frame_source.frame_count // 2)
+        assert frame_start is not None
+        assert frame_middle is not None
+        # Should be different frames
+        assert not np.array_equal(frame_start, frame_middle)
+
+
+class TestFastFrameAccess:
+    """Test get_frame_fast() keyframe seeking."""
+
+    def test_get_frame_fast_returns_tuple(self, frame_source: FrameSource) -> None:
+        """get_frame_fast() returns (frame, actual_index) tuple."""
+        result = frame_source.get_frame_fast(10)
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        frame, actual_idx = result
+        assert frame is not None
+        assert isinstance(actual_idx, int)
+
+    def test_get_frame_fast_actual_index_at_or_before_target(self, frame_source: FrameSource) -> None:
+        """get_frame_fast() returns keyframe at or before target."""
+        target = frame_source.frame_count // 2
+        frame, actual_idx = frame_source.get_frame_fast(target)
+        assert frame is not None
+        # Actual index should be at or before target (keyframe)
+        assert actual_idx <= target
+
+    def test_get_frame_fast_returns_valid_frame(self, frame_source: FrameSource) -> None:
+        """get_frame_fast() returns valid BGR array."""
+        frame, _ = frame_source.get_frame_fast(10)
+        assert frame is not None
+        assert isinstance(frame, np.ndarray)
+        assert frame.ndim == 3
+        assert frame.shape[2] == 3
+
+    def test_get_frame_fast_beyond_end_returns_none_and_minus_one(self, frame_source: FrameSource) -> None:
+        """get_frame_fast() beyond video length returns (None, -1).
+
+        Bounds checking prevents PyAV's wrap-around behavior.
+        """
+        beyond = frame_source.frame_count + 100
+        frame, actual_idx = frame_source.get_frame_fast(beyond)
+        assert frame is None
+        assert actual_idx == -1
+
+    def test_get_frame_fast_negative_index_returns_none_and_minus_one(self, frame_source: FrameSource) -> None:
+        """get_frame_fast() with negative index returns (None, -1)."""
+        frame, actual_idx = frame_source.get_frame_fast(-1)
+        assert frame is None
+        assert actual_idx == -1
+
+
+class TestContextManager:
+    """Test context manager protocol."""
+
+    def test_context_manager_opens_and_closes(self) -> None:
+        """Context manager properly opens and closes resources."""
+        with FrameSource(TEST_VIDEO) as source:
+            frame = source.read_frame()
+            assert frame is not None
+
+    def test_context_manager_closes_on_exception(self) -> None:
+        """Context manager closes resources even on exception."""
+        try:
+            with FrameSource(TEST_VIDEO) as source:
+                _ = source.read_frame()
+                raise ValueError("Test exception")
+        except ValueError:
+            pass
+        # Source should be closed - _container should be None
+        assert source._container is None
+
+
+class TestResourceManagement:
+    """Test resource lifecycle and cleanup."""
+
+    def test_close_releases_resources(self, frame_source: FrameSource) -> None:
+        """close() releases video container resources."""
+        frame_source.close()
+        assert frame_source._container is None
+
+    def test_close_is_idempotent(self, frame_source: FrameSource) -> None:
+        """close() can be called multiple times safely."""
+        frame_source.close()
+        frame_source.close()  # Should not raise
+        assert frame_source._container is None
+
+    def test_read_after_close_returns_none(self, frame_source: FrameSource) -> None:
+        """Operations after close() return None gracefully."""
+        frame_source.close()
+        assert frame_source.read_frame() is None
+        assert frame_source.get_frame(0) is None
+        frame, idx = frame_source.get_frame_fast(0)
+        assert frame is None
+        assert idx == -1
+
+
+class TestInvalidInput:
+    """Test handling of invalid inputs."""
+
+    def test_nonexistent_file_raises(self) -> None:
+        """Opening non-existent file raises exception."""
+        with pytest.raises(Exception):  # av.AVError
+            FrameSource(Path("/nonexistent/video.mp4"))
+
+    def test_negative_frame_index_returns_none(self, frame_source: FrameSource) -> None:
+        """Negative frame index returns None (bounds checking)."""
+        frame = frame_source.get_frame(-1)
+        assert frame is None
+
+
+if __name__ == "__main__":
+    """Debug harness for running tests with debugpy."""
+    from pathlib import Path
+
+    debug_dir = Path(__file__).parent / "tmp"
+    debug_dir.mkdir(parents=True, exist_ok=True)
+
+    # Test basic functionality
+    print(f"Test video: {TEST_VIDEO}")
+    print(f"Exists: {TEST_VIDEO.exists()}")
+
+    with FrameSource(TEST_VIDEO) as source:
+        print(f"Frame count: {source.frame_count}")
+        print(f"FPS: {source.fps}")
+        print(f"Size: {source.size}")
+        print(f"Start index: {source.start_frame_index}")
+        print(f"Last index: {source.last_frame_index}")
+
+        # Test sequential read
+        frame = source.read_frame()
+        print(f"First frame shape: {frame.shape if frame is not None else None}")
+
+        # Test exact seek
+        frame = source.get_frame(50)
+        print(f"Frame 50 shape: {frame.shape if frame is not None else None}")
+
+        # Test fast seek
+        frame, idx = source.get_frame_fast(50)
+        print(f"Fast seek to 50: got frame at index {idx}")


### PR DESCRIPTION
## Summary

- Extract pure frame access abstraction from `RecordedStream` into new `FrameSource` class
- Provides synchronous reading and seeking without threading, queues, or tracking
- Adds bounds checking to prevent PyAV's confusing wrap-around behavior on out-of-range seeks

## Key Design Decisions

- `get_frame()` for exact frame access (O(keyframe distance))
- `get_frame_fast()` for keyframe scrubbing (O(1))
- Thread-safe for concurrent calls; callers coordinate access patterns
- `_closed` flag set last in `__init__` so `__del__` doesn't warn on failed init

## Test Plan

- [x] 26 new unit tests covering properties, sequential reading, exact/fast seeking, bounds checking, context manager, resource cleanup
- [x] Existing stream tests still pass
- [x] basedpyright: 0 errors
- [x] ruff: all checks passed

Closes #888