### PR TITLE
feat: add point history visualization and scrubbing

### DIFF
--- a/src/caliscope/gui/presenters/intrinsic_calibration_presenter.py
+++ b/src/caliscope/gui/presenters/intrinsic_calibration_presenter.py
@@ -26,7 +26,7 @@ from caliscope.core.calibrate_intrinsics import (
 from caliscope.core.frame_selector import FrameSelectionResult, select_calibration_frames
 from caliscope.core.point_data import ImagePoints
 from caliscope.packets import FramePacket, PointPacket
-from caliscope.recording import create_publisher
+from caliscope.recording import create_streamer
 from caliscope.task_manager.cancellation import CancellationToken
 from caliscope.task_manager.task_handle import TaskHandle
 from caliscope.task_manager.task_manager import TaskManager
@@ -56,7 +56,7 @@ class IntrinsicCalibrationPresenter(QObject):
     submission of calibration to TaskManager. Exposes a display_queue for
     the View's processing thread to consume directly (avoids GUI thread hop).
 
-    A single FramePacketPublisher lives across all states, enabling scrubbing
+    A single FramePacketStreamer lives across all states, enabling scrubbing
     in READY/CALIBRATED states and collection during COLLECTING state.
 
     Signals:
@@ -120,23 +120,23 @@ class IntrinsicCalibrationPresenter(QObject):
         # Collection state
         self._is_collecting = False
 
-        # Single publisher for all states (scrubbing + collection)
-        self._publisher = create_publisher(
+        # Single streamer for all states (scrubbing + collection)
+        self._streamer = create_streamer(
             video_directory=self._video_path.parent,
             port=self._camera.port,
             rotation_count=self._camera.rotation_count,
             tracker=self._tracker,
-            break_on_last=False,  # Pause at end instead of exit
+            end_behavior="pause",  # Pause at end for interactive scrubbing
         )
         self._frame_queue: Queue[FramePacket] = Queue()
-        self._publisher.subscribe(self._frame_queue)
+        self._streamer.subscribe(self._frame_queue)
 
-        # Start publisher worker (will read first frame, then we pause)
+        # Start streamer worker (will read first frame, then we pause)
         self._stream_handle = self._task_manager.submit(
-            self._publisher.play_worker,
-            name=f"Publisher port {self._port}",
+            self._streamer.play_worker,
+            name=f"Streamer port {self._port}",
         )
-        self._publisher.pause()  # Immediately pause for scrubbing mode
+        self._streamer.pause()  # Immediately pause for scrubbing mode
 
         # Guaranteed initial frame display (don't rely on thread timing)
         self._load_initial_frame()
@@ -184,7 +184,7 @@ class IntrinsicCalibrationPresenter(QObject):
     @property
     def frame_count(self) -> int:
         """Total frames in video."""
-        return self._publisher.last_frame_index + 1
+        return self._streamer.last_frame_index + 1
 
     @property
     def current_frame_index(self) -> int:
@@ -218,14 +218,14 @@ class IntrinsicCalibrationPresenter(QObject):
         self._load_initial_frame()
 
     def seek_to(self, frame_index: int) -> None:
-        """Seek to frame. Works in READY/CALIBRATED states via publisher's jump_to."""
+        """Seek to frame. Works in READY/CALIBRATED states via streamer's seek_to."""
         if self.state not in (PresenterState.READY, PresenterState.CALIBRATED):
             return
 
         frame_index = max(0, min(frame_index, self.frame_count - 1))
-        self._publisher.jump_to(
-            frame_index, exact=True
-        )  # exact=False would cause Fast seek, skipping between keyframes
+        self._streamer.seek_to(
+            frame_index, precise=True
+        )  # precise=False would cause Fast seek, skipping between keyframes
 
     def _load_initial_frame(self) -> None:
         """Read first frame from video and put on display queue."""
@@ -250,7 +250,7 @@ class IntrinsicCalibrationPresenter(QObject):
     def start_calibration(self) -> None:
         """Start collecting calibration frames.
 
-        Resets to beginning and unpauses the publisher.
+        Resets to beginning and unpauses the streamer.
         """
         if self.state not in (PresenterState.READY, PresenterState.CALIBRATED):
             logger.warning(f"Cannot start calibration in state {self.state}")
@@ -271,8 +271,8 @@ class IntrinsicCalibrationPresenter(QObject):
         self._emit_state_changed()
 
         # Reset to beginning and start playback
-        self._publisher.jump_to(0, exact=True)
-        self._publisher.unpause()
+        self._streamer.seek_to(0, precise=True)
+        self._streamer.unpause()
 
     def stop_calibration(self) -> None:
         """Stop collection and return to READY state.
@@ -285,7 +285,7 @@ class IntrinsicCalibrationPresenter(QObject):
 
         logger.info(f"Stopping calibration collection for port {self._port}")
 
-        self._publisher.pause()
+        self._streamer.pause()
         with self._overlay_lock:
             self._collected_points.clear()
         self._is_collecting = False
@@ -295,12 +295,12 @@ class IntrinsicCalibrationPresenter(QObject):
         """Pull frames from queue, accumulate points when collecting, emit for display.
 
         Runs continuously across all states. Exits when stop_event is set or
-        publisher is cancelled externally.
+        streamer is cancelled externally.
         """
         logger.debug(f"Consumer thread started for port {self._port}")
 
         while not self._stop_event.is_set():
-            # Exit if publisher was cancelled externally
+            # Exit if streamer was cancelled externally
             if self._stream_handle is not None and self._stream_handle.state == TaskState.CANCELLED:
                 break
 
@@ -324,14 +324,14 @@ class IntrinsicCalibrationPresenter(QObject):
             self.frame_position_changed.emit(packet.frame_index)
 
             # Detect end of video during collection
-            if self._is_collecting and packet.frame_index >= self._publisher.last_frame_index:
+            if self._is_collecting and packet.frame_index >= self._streamer.last_frame_index:
                 self._on_collection_complete()
 
         logger.debug(f"Consumer thread exiting for port {self._port}")
 
     def _on_collection_complete(self) -> None:
         """Called when video playback finishes. Submits calibration task."""
-        self._publisher.pause()
+        self._streamer.pause()
         self._is_collecting = False
 
         if len(self._collected_points) == 0:
@@ -432,8 +432,8 @@ class IntrinsicCalibrationPresenter(QObject):
         self.calibration_complete.emit(self._calibrated_camera)
         self._emit_state_changed()
 
-        # Jump to first frame so View can display with undistortion
-        self._publisher.jump_to(0, exact=True)
+        # Seek to first frame so View can display with undistortion
+        self._streamer.seek_to(0, precise=True)
 
     def _on_calibration_failed(self, exc_type: str, message: str) -> None:
         """Handle calibration failure."""
@@ -454,10 +454,10 @@ class IntrinsicCalibrationPresenter(QObject):
         if self._consumer_thread is not None:
             self._consumer_thread.join(timeout=2.0)
 
-        # Cancel publisher worker
+        # Cancel streamer worker
         if self._stream_handle is not None:
             self._stream_handle.cancel()
 
-        # Clean up publisher
-        self._publisher.unsubscribe(self._frame_queue)
-        self._publisher.close()
+        # Clean up streamer
+        self._streamer.unsubscribe(self._frame_queue)
+        self._streamer.close()

--- a/src/caliscope/recording/__init__.py
+++ b/src/caliscope/recording/__init__.py
@@ -1,15 +1,15 @@
-"""Recording module - video I/O, timing, and publishing."""
+"""Recording module - video I/O, timing, and streaming."""
 
-from caliscope.recording.frame_packet_publisher import (
-    FramePacketPublisher,
-    create_publisher,
+from caliscope.recording.frame_packet_streamer import (
+    FramePacketStreamer,
+    create_streamer,
 )
 from caliscope.recording.frame_source import FrameSource
 from caliscope.recording.frame_timestamps import FrameTimestamps
 
 __all__ = [
-    "FramePacketPublisher",
+    "FramePacketStreamer",
     "FrameSource",
     "FrameTimestamps",
-    "create_publisher",
+    "create_streamer",
 ]

--- a/src/caliscope/recording/frame_packet_streamer.py
+++ b/src/caliscope/recording/frame_packet_streamer.py
@@ -1,18 +1,18 @@
-"""Publisher for FramePackets from recorded video.
+"""Streamer for FramePackets from recorded video.
 
-FramePacketPublisher wraps a FrameSource and FrameTimestamps, adding threading,
+FramePacketStreamer wraps a FrameSource and FrameTimestamps, adding threading,
 pub/sub broadcasting, and optional tracking. It's the streaming layer on top
 of the raw video I/O.
 
 Seeking and Pause Handling (lessons learned):
 ---------------------------------------------
-1. **Seek failure must not kill the publisher**: When get_frame() returns None
+1. **Seek failure must not kill the streamer**: When get_frame() returns None
    (e.g., PyAV can't decode near EOF), we must set skip_read=True to stay at
    the current position. Otherwise, the next read_frame() call has undefined
    behavior after a seek and will likely return None, causing premature exit.
 
 2. **Condition variable for responsive pause loop**: The pause loop uses
-   _jump_condition.wait() instead of plain sleep. This allows jump_to() calls
+   _seek_condition.wait() instead of plain sleep. This allows seek_to() calls
    to wake the loop immediately via notify(), making scrubbing responsive.
    Without this, there's up to 0.1s latency on each seek while paused.
 
@@ -27,6 +27,7 @@ from pathlib import Path
 from queue import Queue
 from threading import Condition, Event, Lock, Thread
 from time import perf_counter, sleep
+from typing import Literal
 
 import numpy as np
 
@@ -40,8 +41,8 @@ from caliscope.tracker import Tracker
 logger = logging.getLogger(__name__)
 
 
-class FramePacketPublisher:
-    """Publishes FramePackets from recorded video to subscriber queues.
+class FramePacketStreamer:
+    """Streams FramePackets from recorded video to subscriber queues.
 
     Wraps FrameSource (video I/O) and FrameTimestamps (timing), adding:
     - Pub/sub broadcasting to multiple queues
@@ -64,9 +65,9 @@ class FramePacketPublisher:
         rotation_count: int = 0,
         tracker: Tracker | None = None,
         fps_target: float | None = None,
-        break_on_last: bool = True,
+        end_behavior: Literal["stop", "pause"] = "stop",
     ) -> None:
-        """Initialize the publisher.
+        """Initialize the streamer.
 
         Args:
             frame_source: Video I/O wrapper (provides frames).
@@ -74,13 +75,14 @@ class FramePacketPublisher:
             rotation_count: Camera rotation (0, 1, 2, 3 for 0/90/180/270 degrees).
             tracker: Optional tracker for landmark detection.
             fps_target: Target playback FPS. None = unlimited (as fast as possible).
-            break_on_last: If True, stop at last frame. If False, pause at last frame.
+            end_behavior: What to do at last frame. "stop" broadcasts EOF and exits,
+                "pause" auto-pauses for interactive scrubbing.
         """
         self._frame_source = frame_source
         self._frame_timestamps = frame_timestamps
         self._rotation_count = rotation_count
         self._tracker = tracker
-        self._break_on_last = break_on_last
+        self._end_behavior = end_behavior
 
         # FPS targeting
         self._fps_target = fps_target
@@ -97,10 +99,10 @@ class FramePacketPublisher:
         self._pause_event = Event()
         self._pause_event.clear()
 
-        # Jump request: (frame_index, exact) - latest wins
-        self._pending_jump: tuple[int, bool] | None = None
-        self._jump_lock = Lock()
-        self._jump_condition = Condition(self._jump_lock)
+        # Seek request: (frame_index, exact) - latest wins
+        self._pending_seek: tuple[int, bool] | None = None
+        self._seek_lock = Lock()
+        self._seek_condition = Condition(self._seek_lock)
 
         # Current position
         self._frame_index = frame_timestamps.start_frame_index
@@ -161,15 +163,15 @@ class FramePacketPublisher:
     def subscribe(self, queue: Queue) -> None:
         """Add a queue to receive FramePackets.
 
-        Thread-safe. Notifies waiting publisher if this is the first subscriber.
+        Thread-safe. Notifies waiting streamer if this is the first subscriber.
         """
         with self._subscriber_condition:
             if queue not in self._subscribers:
-                logger.info(f"Adding subscriber to publisher at port {self.port}")
+                logger.info(f"Adding subscriber to streamer at port {self.port}")
                 self._subscribers.append(queue)
                 self._subscriber_condition.notify()
             else:
-                logger.warning(f"Attempted duplicate subscription at port {self.port}")
+                logger.warning(f"Attempted duplicate subscription to streamer at port {self.port}")
 
     def unsubscribe(self, queue: Queue) -> None:
         """Remove a queue from receiving FramePackets.
@@ -178,7 +180,7 @@ class FramePacketPublisher:
         """
         with self._subscriber_lock:
             if queue in self._subscribers:
-                logger.info(f"Removing subscriber from publisher at port {self.port}")
+                logger.info(f"Removing subscriber from streamer at port {self.port}")
                 self._subscribers.remove(queue)
             else:
                 logger.warning(f"Attempted to unsubscribe non-existent queue at port {self.port}")
@@ -218,41 +220,41 @@ class FramePacketPublisher:
 
     def pause(self) -> None:
         """Pause playback."""
-        logger.info(f"Pausing publisher at port {self.port}")
+        logger.info(f"Pausing streamer at port {self.port}")
         self._pause_event.set()
 
     def unpause(self) -> None:
         """Resume playback."""
-        logger.info(f"Unpausing publisher at port {self.port}")
+        logger.info(f"Unpausing streamer at port {self.port}")
         self._pause_event.clear()
 
-    def jump_to(self, frame_index: int, exact: bool = True) -> None:
+    def seek_to(self, frame_index: int, precise: bool = True) -> None:
         """Request a seek to the specified frame.
 
         Args:
             frame_index: Target frame to seek to.
-            exact: If True, decode to exact frame. If False, seek to nearest
-                   keyframe only (faster for scrubbing).
+            precise: If True, decode to exact frame (slower). If False, seek to
+                nearest keyframe only (faster for scrubbing).
 
-        Note: If multiple jump requests arrive before processing, only the
-        latest is honored (previous pending jumps are dropped).
+        Note: If multiple seek requests arrive before processing, only the
+        latest is honored (previous pending seeks are dropped).
         """
-        with self._jump_condition:
-            logger.info(f"Setting pending jump to frame {frame_index} (exact={exact})")
-            self._pending_jump = (frame_index, exact)
-            self._jump_condition.notify()
+        with self._seek_condition:
+            logger.info(f"Setting pending seek to frame {frame_index} (precise={precise})")
+            self._pending_seek = (frame_index, precise)
+            self._seek_condition.notify()
 
-    def _has_pending_jump(self) -> bool:
-        """Check for pending jump request."""
-        with self._jump_lock:
-            return self._pending_jump is not None
+    def _has_pending_seek(self) -> bool:
+        """Check for pending seek request."""
+        with self._seek_lock:
+            return self._pending_seek is not None
 
-    def _take_pending_jump(self) -> tuple[int, bool] | None:
-        """Take and clear the pending jump request."""
-        with self._jump_lock:
-            jump = self._pending_jump
-            self._pending_jump = None
-            return jump
+    def _take_pending_seek(self) -> tuple[int, bool] | None:
+        """Take and clear the pending seek request."""
+        with self._seek_lock:
+            seek = self._pending_seek
+            self._pending_seek = None
+            return seek
 
     # -------------------------------------------------------------------------
     # FPS Timing
@@ -278,7 +280,7 @@ class FramePacketPublisher:
 
     def start(self) -> None:
         """Start playback in a new thread. Call stop() to terminate."""
-        logger.info(f"Starting publisher for port {self.port}")
+        logger.info(f"Starting streamer for port {self.port}")
         self._internal_token = CancellationToken()
         self._thread = Thread(
             target=self.play_worker,
@@ -294,7 +296,7 @@ class FramePacketPublisher:
         if self._thread is not None:
             self._thread.join(timeout=2.0)
             self._thread = None
-        logger.info(f"Stopped publisher for port {self.port}")
+        logger.info(f"Stopped streamer for port {self.port}")
 
     def close(self) -> None:
         """Release all resources."""
@@ -379,7 +381,7 @@ class FramePacketPublisher:
 
                 # Handle last frame
                 if self._frame_index == self.last_frame_index:
-                    if self._break_on_last:
+                    if self._end_behavior == "stop":
                         logger.info(f"Reached last frame at port {self.port}")
                         eof_packet = FramePacket(
                             port=self.port,
@@ -394,21 +396,21 @@ class FramePacketPublisher:
                         # Auto-pause at end for interactive mode
                         self._pause_event.set()
 
-                # Handle pause (check for jumps while paused)
+                # Handle pause (check for seeks while paused)
                 while self._pause_event.is_set() and not token.is_cancelled:
-                    if self._has_pending_jump():
+                    if self._has_pending_seek():
                         break
-                    # Wait on condition variable - wakes immediately when jump_to() calls notify()
-                    with self._jump_condition:
-                        self._jump_condition.wait(timeout=0.1)
+                    # Wait on condition variable - wakes immediately when seek_to() calls notify()
+                    with self._seek_condition:
+                        self._seek_condition.wait(timeout=0.1)
 
-                # Process pending jump
-                pending = self._take_pending_jump()
+                # Process pending seek
+                pending = self._take_pending_seek()
                 if pending is not None:
-                    target_index, exact = pending
-                    logger.info(f"Processing jump to frame {target_index} (exact={exact}) at port {self.port}")
+                    target_index, precise = pending
+                    logger.info(f"Processing seek to frame {target_index} (precise={precise}) at port {self.port}")
 
-                    if exact:
+                    if precise:
                         frame = self._frame_source.get_frame(target_index)
                         if frame is not None:
                             current_frame = frame
@@ -419,7 +421,7 @@ class FramePacketPublisher:
                             logger.warning(f"Seek to frame {target_index} failed at port {self.port}")
                             skip_read = True
                     else:
-                        frame, actual_index = self._frame_source.get_frame_fast(target_index)
+                        frame, actual_index = self._frame_source.get_nearest_keyframe(target_index)
                         if frame is not None:
                             current_frame = frame
                             self._frame_index = actual_index
@@ -429,22 +431,22 @@ class FramePacketPublisher:
                             logger.warning(f"Fast seek to frame {target_index} failed at port {self.port}")
                             skip_read = True
                 else:
-                    # Increment for next iteration (only if not jumping)
+                    # Increment for next iteration (only if not seeking)
                     self._frame_index += 1
 
         finally:
-            logger.info(f"Publisher worker exiting for port {self.port}")
+            logger.info(f"Streamer worker exiting for port {self.port}")
 
 
-def create_publisher(
+def create_streamer(
     video_directory: Path,
     port: int,
     rotation_count: int = 0,
     tracker: Tracker | None = None,
     fps_target: float | None = None,
-    break_on_last: bool = True,
-) -> FramePacketPublisher:
-    """Factory function to create a FramePacketPublisher.
+    end_behavior: Literal["stop", "pause"] = "stop",
+) -> FramePacketStreamer:
+    """Factory function to create a FramePacketStreamer.
 
     Convenience function that handles FrameSource and FrameTimestamps creation.
 
@@ -454,10 +456,10 @@ def create_publisher(
         rotation_count: Camera rotation (0, 1, 2, 3).
         tracker: Optional tracker for landmark detection.
         fps_target: Target FPS. None = unlimited.
-        break_on_last: If True, stop at last frame. If False, pause.
+        end_behavior: What to do at last frame. "stop" or "pause".
 
     Returns:
-        Configured FramePacketPublisher ready to start().
+        Configured FramePacketStreamer ready to start().
     """
     frame_source = FrameSource(video_directory, port)
 
@@ -467,11 +469,11 @@ def create_publisher(
     else:
         frame_timestamps = FrameTimestamps.inferred(frame_source.fps, frame_source.frame_count)
 
-    return FramePacketPublisher(
+    return FramePacketStreamer(
         frame_source=frame_source,
         frame_timestamps=frame_timestamps,
         rotation_count=rotation_count,
         tracker=tracker,
         fps_target=fps_target,
-        break_on_last=break_on_last,
+        end_behavior=end_behavior,
     )

--- a/src/caliscope/recording/frame_source.py
+++ b/src/caliscope/recording/frame_source.py
@@ -49,7 +49,7 @@ class FrameSource:
 
     Typical usage: one owner thread, or explicit external synchronization.
 
-    Note: get_frame() and get_frame_fast() invalidate the sequential read
+    Note: get_frame() and get_nearest_keyframe() invalidate the sequential read
     position. After calling either, read_frame() behavior is undefined until
     the internal iterator is naturally exhausted or a new FrameSource is created.
     """
@@ -216,8 +216,8 @@ class FrameSource:
 
             return None
 
-    def get_frame_fast(self, frame_index: int) -> tuple[np.ndarray | None, int]:
-        """Seek to nearest keyframe and return it with actual index.
+    def get_nearest_keyframe(self, frame_index: int) -> tuple[np.ndarray | None, int]:
+        """Seek to nearest keyframe at or before target.
 
         Fast seeking for scrubbing - returns the keyframe at or before target,
         without decoding forward to the exact frame. O(1) complexity for
@@ -267,7 +267,7 @@ class FrameSource:
             Frame as BGR numpy array, or None at end of file.
 
         Note:
-            Position is undefined after get_frame() or get_frame_fast() calls.
+            Position is undefined after get_frame() or get_nearest_keyframe() calls.
             For predictable sequential reading, use a fresh FrameSource or
             read all frames without seeking.
         """

--- a/tests/test_frame_source.py
+++ b/tests/test_frame_source.py
@@ -141,47 +141,47 @@ class TestExactFrameAccess:
         assert not np.array_equal(frame_start, frame_middle)
 
 
-class TestFastFrameAccess:
-    """Test get_frame_fast() keyframe seeking."""
+class TestKeyframeAccess:
+    """Test get_nearest_keyframe() keyframe seeking."""
 
-    def test_get_frame_fast_returns_tuple(self, frame_source: FrameSource) -> None:
-        """get_frame_fast() returns (frame, actual_index) tuple."""
-        result = frame_source.get_frame_fast(10)
+    def test_get_nearest_keyframe_returns_tuple(self, frame_source: FrameSource) -> None:
+        """get_nearest_keyframe() returns (frame, actual_index) tuple."""
+        result = frame_source.get_nearest_keyframe(10)
         assert isinstance(result, tuple)
         assert len(result) == 2
         frame, actual_idx = result
         assert frame is not None
         assert isinstance(actual_idx, int)
 
-    def test_get_frame_fast_actual_index_at_or_before_target(self, frame_source: FrameSource) -> None:
-        """get_frame_fast() returns keyframe at or before target."""
+    def test_get_nearest_keyframe_actual_index_at_or_before_target(self, frame_source: FrameSource) -> None:
+        """get_nearest_keyframe() returns keyframe at or before target."""
         target = frame_source.frame_count // 2
-        frame, actual_idx = frame_source.get_frame_fast(target)
+        frame, actual_idx = frame_source.get_nearest_keyframe(target)
         assert frame is not None
         # Actual index should be at or before target (keyframe)
         assert actual_idx <= target
 
-    def test_get_frame_fast_returns_valid_frame(self, frame_source: FrameSource) -> None:
-        """get_frame_fast() returns valid BGR array."""
-        frame, _ = frame_source.get_frame_fast(10)
+    def test_get_nearest_keyframe_returns_valid_frame(self, frame_source: FrameSource) -> None:
+        """get_nearest_keyframe() returns valid BGR array."""
+        frame, _ = frame_source.get_nearest_keyframe(10)
         assert frame is not None
         assert isinstance(frame, np.ndarray)
         assert frame.ndim == 3
         assert frame.shape[2] == 3
 
-    def test_get_frame_fast_beyond_end_returns_none_and_minus_one(self, frame_source: FrameSource) -> None:
-        """get_frame_fast() beyond video length returns (None, -1).
+    def test_get_nearest_keyframe_beyond_end_returns_none_and_minus_one(self, frame_source: FrameSource) -> None:
+        """get_nearest_keyframe() beyond video length returns (None, -1).
 
         Bounds checking prevents PyAV's wrap-around behavior.
         """
         beyond = frame_source.frame_count + 100
-        frame, actual_idx = frame_source.get_frame_fast(beyond)
+        frame, actual_idx = frame_source.get_nearest_keyframe(beyond)
         assert frame is None
         assert actual_idx == -1
 
-    def test_get_frame_fast_negative_index_returns_none_and_minus_one(self, frame_source: FrameSource) -> None:
-        """get_frame_fast() with negative index returns (None, -1)."""
-        frame, actual_idx = frame_source.get_frame_fast(-1)
+    def test_get_nearest_keyframe_negative_index_returns_none_and_minus_one(self, frame_source: FrameSource) -> None:
+        """get_nearest_keyframe() with negative index returns (None, -1)."""
+        frame, actual_idx = frame_source.get_nearest_keyframe(-1)
         assert frame is None
         assert actual_idx == -1
 
@@ -226,7 +226,7 @@ class TestResourceManagement:
         frame_source.close()
         assert frame_source.read_frame() is None
         assert frame_source.get_frame(0) is None
-        frame, idx = frame_source.get_frame_fast(0)
+        frame, idx = frame_source.get_nearest_keyframe(0)
         assert frame is None
         assert idx == -1
 
@@ -278,6 +278,6 @@ if __name__ == "__main__":
         frame = source.get_frame(50)
         print(f"Frame 50 shape: {frame.shape if frame is not None else None}")
 
-        # Test fast seek
-        frame, idx = source.get_frame_fast(50)
-        print(f"Fast seek to 50: got frame at index {idx}")
+        # Test keyframe seek
+        frame, idx = source.get_nearest_keyframe(50)
+        print(f"Keyframe seek to 50: got frame at index {idx}")

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -5,36 +5,36 @@ from time import sleep
 
 from caliscope import __root__
 from caliscope.core.charuco import Charuco
-from caliscope.recording import create_publisher
+from caliscope.recording import create_streamer
 from caliscope.trackers.charuco_tracker import CharucoTracker
 
 logger = logging.getLogger(__name__)
 
 
-def test_publisher():
+def test_streamer():
     recording_directory = Path(__root__, "tests", "sessions", "post_monocal", "calibration", "extrinsic")
 
     charuco = Charuco(4, 5, 11, 8.5, aruco_scale=0.75, square_size_overide_cm=5.25, inverted=True)
 
     charuco_tracker = CharucoTracker(charuco)
 
-    publisher = create_publisher(
+    streamer = create_streamer(
         video_directory=recording_directory,
         port=1,
         tracker=charuco_tracker,
         fps_target=6,
     )
     frame_q = Queue()
-    publisher.subscribe(frame_q)
-    publisher.start()
-    publisher.pause()
+    streamer.subscribe(frame_q)
+    streamer.start()
+    streamer.pause()
 
     sleep(1)
-    logger.info(f"Publisher frame index is {publisher.frame_index}")
+    logger.info(f"Publisher frame index is {streamer.frame_index}")
     sleep(1)
-    logger.info(f"Publisher frame index is {publisher.frame_index}")
+    logger.info(f"Publisher frame index is {streamer.frame_index}")
 
-    publisher.unpause()
+    streamer.unpause()
 
     while True:
         frame_packet = frame_q.get()
@@ -42,29 +42,29 @@ def test_publisher():
         if frame_packet.frame is None:
             break
 
-        if publisher.frame_index == 10:
+        if streamer.frame_index == 10:
             logger.info("Testing pause/unpause functionality")
-            publisher.pause()
+            streamer.pause()
             sleep(0.5)
-            test_index = publisher.frame_index
+            test_index = streamer.frame_index
             sleep(0.5)
-            # make sure that publisher doesn't advance with pause
-            assert test_index == publisher.frame_index
-            publisher.unpause()
+            # make sure that streamer doesn't advance with pause
+            assert test_index == streamer.frame_index
+            streamer.unpause()
 
-        if publisher.frame_index == 15:
+        if streamer.frame_index == 15:
             logger.info("Testing ability to jump forward")
             target_frame = 20
-            publisher.pause()
+            streamer.pause()
             sleep(1)  # need to make sure fps_target wait plays out
-            publisher.jump_to(target_frame)
+            streamer.seek_to(target_frame)
             sleep(1)  # need to make sure fps_target wait plays out
             # frame_index should match the jump target (the frame we just displayed)
-            assert publisher.frame_index == 20
+            assert streamer.frame_index == 20
 
             logger.info(f"After attempting to jump to target frame {target_frame}")
-            publisher.unpause()
+            streamer.unpause()
 
 
 if __name__ == "__main__":
-    test_publisher()
+    test_streamer()

--- a/tests/test_triangulator.py
+++ b/tests/test_triangulator.py
@@ -18,7 +18,7 @@ import pandas as pd
 from caliscope import __root__
 from caliscope.cameras.synchronizer import Synchronizer
 from caliscope.helper import copy_contents_to_clean_dest
-from caliscope.recording import create_publisher
+from caliscope.recording import create_streamer
 from caliscope.trackers.charuco_tracker import CharucoTracker
 from caliscope.triangulate.sync_packet_triangulator import SyncPacketTriangulator
 from caliscope import persistence
@@ -41,11 +41,11 @@ def test_triangulator(tmp_path: Path):
     charuco = persistence.load_charuco(tmp_path / "charuco.toml")
     charuco_tracker = CharucoTracker(charuco)
 
-    logger.info("Creating publishers based on calibration recordings")
+    logger.info("Creating streamers based on calibration recordings")
 
-    publishers = {}
+    streamers = {}
     for port, camera in camera_array.cameras.items():
-        publishers[port] = create_publisher(
+        streamers[port] = create_streamer(
             video_directory=recording_directory,
             port=port,
             rotation_count=camera.rotation_count,
@@ -54,7 +54,7 @@ def test_triangulator(tmp_path: Path):
         )
 
     logger.info("Creating Synchronizer")
-    syncr = Synchronizer(publishers)
+    syncr = Synchronizer(streamers)
 
     #### Basic code for interfacing with in-progress RealTimeTriangulator
     #### Just run off of saved point_data.csv for development/testing
@@ -65,7 +65,7 @@ def test_triangulator(tmp_path: Path):
         tracker_name=charuco_tracker.name,
     )
 
-    for port, publisher in publishers.items():
+    for port, publisher in streamers.items():
         publisher.start()
 
     while real_time_triangulator.running:


### PR DESCRIPTION
## Summary

- Add toggleable overlay layers for intrinsic calibration visualization
- Fix scrubbing failure near end of video  
- Rename streaming components for clarity

## Changes

### Point History Visualization
- Current frame points (red) - from FramePacket.points
- Accumulated points (teal, 50% opacity) - all detected points
- Selected board grids (cyan) - frames used in calibration

### Scrubbing Bug Fix
Root cause: PTS-to-frame-index calculation used `int()` which truncated incorrectly due to floating point precision. Fixed with `round()`.

### Naming Cleanup
| Before | After |
|--------|-------|
| `FramePacketPublisher` | `FramePacketStreamer` |
| `jump_to()` | `seek_to()` |
| `exact` param | `precise` param |
| `break_on_last` | `end_behavior: Literal["stop", "pause"]` |
| `get_frame_fast()` | `get_nearest_keyframe()` |
| `FrameProcessingThread` | `FrameRenderThread` |

## Test plan

- [x] All 128 tests pass
- [x] Manual verification of scrubbing through entire video
- [x] Overlay toggles work in intrinsic calibration view

Closes #869