### PR TITLE
refactor: rename Controller to WorkspaceCoordinator

### DIFF
--- a/scripts/demo/demo_gui_capture_volume.py
+++ b/scripts/demo/demo_gui_capture_volume.py
@@ -1,7 +1,7 @@
 from PySide6.QtWidgets import QApplication
 import sys
 from pathlib import Path
-from caliscope.controller import Controller
+from caliscope.workspace_coordinator import WorkspaceCoordinator
 from caliscope.gui.vizualize.calibration.capture_volume_widget import CaptureVolumeWidget
 import logging
 import caliscope.logger
@@ -17,16 +17,16 @@ root = Path(__file__).parent.parent.parent
 workspace_dir = Path(root, "tests", "sessions_copy_delete", "capture_volume_pre_quality_control")
 
 workspace_dir = Path(__root__, "tests", "sessions_copy_delete", "post_optimization")
-controller = Controller(workspace_dir)
+coordinator = WorkspaceCoordinator(workspace_dir)
 
-controller.load_camera_array()
-controller.load_estimated_capture_volume()
+coordinator.load_camera_array()
+coordinator.load_estimated_capture_volume()
 
-window = CaptureVolumeWidget(controller)
+window = CaptureVolumeWidget(coordinator)
 # After filtering - log filtered point counts
 
 logger.info("Point counts loaded into Capture Volume Widget:")
-capture_volume = controller.capture_volume
+capture_volume = coordinator.capture_volume
 assert capture_volume is not None  # Widget requires capture volume to exist
 logger.info(f"  3D points (obj.shape[0]): {capture_volume.point_estimates.obj.shape[0]}")
 logger.info(f"  2D observations (img.shape[0]): {capture_volume.point_estimates.img.shape[0]}")

--- a/scripts/demo/demo_gui_post_processing.py
+++ b/scripts/demo/demo_gui_post_processing.py
@@ -1,16 +1,16 @@
 from PySide6.QtWidgets import QApplication
 import sys
 from pathlib import Path
-from caliscope.controller import Controller
+from caliscope.workspace_coordinator import WorkspaceCoordinator
 from caliscope.gui.post_processing_widget import PostProcessingWidget
 
 app = QApplication(sys.argv)
 
 workspace_dir = Path("/home/mprib/caliscope_projects/markerless_calibration_data/caliscope_version")
 
-controller = Controller(workspace_dir)
-controller.load_camera_array()
-window = PostProcessingWidget(controller)
+coordinator = WorkspaceCoordinator(workspace_dir)
+coordinator.load_camera_array()
+window = PostProcessingWidget(coordinator)
 
 
 window.show()

--- a/scripts/demo/demo_gui_triangulation_visualizer.py
+++ b/scripts/demo/demo_gui_triangulation_visualizer.py
@@ -1,7 +1,7 @@
 from PySide6.QtWidgets import QApplication
 import sys
 from pathlib import Path
-from caliscope.controller import Controller
+from caliscope.workspace_coordinator import WorkspaceCoordinator
 from caliscope.gui.vizualize.playback_triangulation_widget import PlaybackTriangulationWidget
 from caliscope.trackers.holistic.holistic_tracker import HolisticTracker
 from caliscope import __root__
@@ -9,9 +9,9 @@ from caliscope import __root__
 app = QApplication(sys.argv)
 workspace_dir = Path(__root__, "tests", "sessions_copy_delete", "post_optimization")
 
-controller = Controller(workspace_dir)
-controller.load_camera_array()
-camera_array = controller.camera_array
+coordinator = WorkspaceCoordinator(workspace_dir)
+coordinator.load_camera_array()
+camera_array = coordinator.camera_array
 tracker = HolisticTracker()
 
 xyz_history = Path(workspace_dir, "calibration", "extrinsic", "xyz_CHARUCO.csv")

--- a/scripts/demo/demo_synched_frames_widget.py
+++ b/scripts/demo/demo_synched_frames_widget.py
@@ -3,7 +3,7 @@ from PySide6.QtWidgets import QApplication
 import sys
 
 from caliscope.gui.synched_frames_display import SyncedFramesDisplay
-from caliscope.controller import Controller
+from caliscope.workspace_coordinator import WorkspaceCoordinator
 from caliscope.managers.synchronized_stream_manager import SynchronizedStreamManager
 
 from pathlib import Path
@@ -18,9 +18,10 @@ app = QApplication(sys.argv)
 demo_workspace = Path("/home/mprib/caliscope_projects/minimal_project")
 # video_dir = demo_workspace / "calibration/extrinsic"
 video_dir = demo_workspace / "recordings/sitting"
-controller = Controller(demo_workspace)
-camera_array = controller.config.get_camera_array()
-# charuco = controller.config.get_charuco()
+coordinator = WorkspaceCoordinator(demo_workspace)
+coordinator.load_camera_array()
+camera_array = coordinator.camera_array
+# charuco = coordinator.config.get_charuco()
 # tracker = CharucoTracker(charuco)
 tracker = HolisticTracker()
 sync_stream_manager = SynchronizedStreamManager(video_dir, camera_array.cameras, tracker=tracker)

--- a/scripts/keypoints_from_face/generate_keypoints_from_tracker.py
+++ b/scripts/keypoints_from_face/generate_keypoints_from_tracker.py
@@ -12,7 +12,7 @@ from PySide6.QtWidgets import QApplication
 import sys
 
 from caliscope.cameras.camera_array import CameraArray
-from caliscope.controller import Controller
+from caliscope.workspace_coordinator import WorkspaceCoordinator
 from caliscope.trackers.skull_tracker.skull_tracker import SkullTracker
 from caliscope.logger import setup_logging
 from caliscope.managers.synchronized_stream_manager import SynchronizedStreamManager
@@ -140,7 +140,7 @@ if __name__ == "__main__":
     toc = time.time()
     triangulation_time = toc - tic
 
-    # Save data to load into controller layer for visualization
+    # Save data to load into coordinator layer for visualization
     persistence.save_camera_array(optimized_camera_array, camera_array_toml)
 
     point_estimates_path = working_project_dir / "point_estimates.toml"
@@ -157,15 +157,15 @@ if __name__ == "__main__":
 
     app = QApplication(sys.argv)
 
-    controller = Controller(working_project_dir)
-    controller.load_camera_array()
-    controller.load_estimated_capture_volume()
+    coordinator = WorkspaceCoordinator(working_project_dir)
+    coordinator.load_camera_array()
+    coordinator.load_estimated_capture_volume()
 
-    window = CaptureVolumeWidget(controller)
+    window = CaptureVolumeWidget(coordinator)
     # After filtering - log filtered point counts
 
     logger.info("Point counts loaded into Capture Volume Widget:")
-    capture_volume = controller.capture_volume
+    capture_volume = coordinator.capture_volume
     assert capture_volume is not None  # Widget requires capture volume to exist
     logger.info(f"  3D points (obj.shape[0]): {capture_volume.point_estimates.obj.shape[0]}")
     logger.info(f"  2D observations (img.shape[0]): {capture_volume.point_estimates.img.shape[0]}")

--- a/scripts/widget_visualization/wv_charuco_widget.py
+++ b/scripts/widget_visualization/wv_charuco_widget.py
@@ -20,7 +20,7 @@ sys.path.insert(0, str(PROJECT_ROOT / "src"))
 
 from PySide6.QtWidgets import QApplication  # noqa: E402
 
-from caliscope.controller import Controller  # noqa: E402
+from caliscope.workspace_coordinator import WorkspaceCoordinator  # noqa: E402
 from caliscope.gui.charuco_widget import CharucoWidget  # noqa: E402
 
 from utils import capture_widget, clear_output_dir, process_events_for  # noqa: E402
@@ -41,11 +41,11 @@ def main():
     # Initialize Qt application
     QApplication(sys.argv)
 
-    # Create controller (loads charuco config from project)
-    controller = Controller(SAMPLE_PROJECT)
+    # Create coordinator (loads charuco config from project)
+    coordinator = WorkspaceCoordinator(SAMPLE_PROJECT)
 
     # Create the CharucoWidget
-    widget = CharucoWidget(controller)
+    widget = CharucoWidget(coordinator)
     widget.resize(600, 700)
     widget.show()
 

--- a/src/caliscope/gui/camera_management/camera_display_widget.py
+++ b/src/caliscope/gui/camera_management/camera_display_widget.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 
 from PySide6.QtWidgets import QApplication, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
 
-from caliscope.controller import Controller
+from caliscope.workspace_coordinator import WorkspaceCoordinator
 
 logger = logging.getLogger(__name__)
 
@@ -14,17 +14,17 @@ class CameraDataDisplayWidget(QWidget):
     This receives a dictionary that displays the characteristics of a given camera
     """
 
-    def __init__(self, port: int, controller: Controller):
+    def __init__(self, port: int, coordinator: WorkspaceCoordinator):
         super().__init__()
         self.port = port
-        self.controller = controller
+        self.coordinator = coordinator
         self.tree = QTreeWidget()
 
         self.place_widgets()
         self.connect_widgets()
 
         # make sure you populate whatever is there on load
-        self.controller.push_camera_data(self.port)
+        self.coordinator.push_camera_data(self.port)
 
     def place_widgets(self):
         layout = QVBoxLayout()
@@ -33,7 +33,7 @@ class CameraDataDisplayWidget(QWidget):
         self.tree.setHeaderLabels(["Parameter", "Value"])
 
     def connect_widgets(self):
-        self.controller.new_camera_data.connect(self.update_tree)
+        self.coordinator.new_camera_data.connect(self.update_tree)
 
     def update_tree(self, port, camera_display_dict):
         # logger.info(f"Updating display tree for port {port} with camera data {camera_display_dict}")
@@ -118,9 +118,9 @@ if __name__ == "__main__":
     )
 
     test_path = Path(__root__, "tests", "sessions", "prerecorded_calibration")
-    controller = Controller(test_path)
-    controller.config.dict["camera_count"] = 1
-    ex = CameraDataDisplayWidget(port=0, controller=controller)
-    controller.new_camera_data.emit(0, camera_data)
+    coordinator = WorkspaceCoordinator(test_path)
+    coordinator.set_camera_count(1)
+    ex = CameraDataDisplayWidget(port=0, coordinator=coordinator)
+    coordinator.new_camera_data.emit(0, camera_data)
     ex.show()
     sys.exit(app.exec())

--- a/src/caliscope/gui/extrinsic_playback_widget.py
+++ b/src/caliscope/gui/extrinsic_playback_widget.py
@@ -17,21 +17,21 @@ from PySide6.QtWidgets import (
 )
 
 from caliscope.cameras.synchronizer import Synchronizer
-from caliscope.controller import Controller
+from caliscope.workspace_coordinator import WorkspaceCoordinator
 from caliscope.packets import FramePacket
 
 logger = logging.getLogger(__name__)
 
 
 class ExtrinsicPlaybackWidget(QWidget):
-    def __init__(self, controller: Controller):
+    def __init__(self, coordinator: WorkspaceCoordinator):
         super(ExtrinsicPlaybackWidget, self).__init__()
-        self.controller = controller
-        self.synchronizer: Synchronizer = self.controller.synchronizer
+        self.coordinator = coordinator
+        self.synchronizer: Synchronizer = self.coordinator.synchronizer
         self.ports = self.synchronizer.ports
 
         # need to let synchronizer spin up before able to display frames
-        while not hasattr(controller.synchronizer, "current_sync_packet"):
+        while not hasattr(self.coordinator.synchronizer, "current_sync_packet"):
             sleep(0.25)
         # create tools to build and emit the displayed frame
         # self.unpaired_frame_builder = FramePrepper(self.synchronizer)
@@ -95,10 +95,10 @@ class ExtrinsicPlaybackWidget(QWidget):
 
     def connect_widgets(self):
         self.thumbnail_emitter.ThumbnailImagesBroadcast.connect(self.ImageUpdateSlot)
-        self.frame_rate_spin.valueChanged.connect(self.controller.set_active_mode_fps)
+        self.frame_rate_spin.valueChanged.connect(self.coordinator.set_active_mode_fps)
         self.thumbnail_emitter.dropped_fps.connect(self.update_dropped_fps)
         self.start_stop.clicked.connect(self.toggle_start_stop)
-        self.controller.qt_signaler.recording_complete_signal.connect(self.on_recording_complete)
+        self.coordinator.qt_signaler.recording_complete_signal.connect(self.on_recording_complete)
 
     @Slot(dict)
     def ImageUpdateSlot(self, q_image_dict: dict):

--- a/src/caliscope/gui/main_widget.py
+++ b/src/caliscope/gui/main_widget.py
@@ -20,7 +20,7 @@ from PySide6.QtWidgets import (
 
 from caliscope import APP_SETTINGS_PATH, LOG_DIR, __root__
 from caliscope.cameras.camera_array import CameraArray
-from caliscope.controller import Controller
+from caliscope.workspace_coordinator import WorkspaceCoordinator
 from caliscope.task_manager import TaskHandle
 from caliscope.gui.charuco_widget import CharucoWidget
 from caliscope.gui.log_widget import LogWidget
@@ -90,43 +90,45 @@ class MainWindow(QMainWindow):
         self.setCentralWidget(self.central_tab)
 
         logger.info("Building workspace summary")
-        self.workspace_summary = WorkspaceSummaryWidget(self.controller)
+        self.workspace_summary = WorkspaceSummaryWidget(self.coordinator)
         self.workspace_summary.reload_workspace_btn.clicked.connect(self.reload_workspace)
         self.central_tab.addTab(self.workspace_summary, "Workspace")
 
-        if self.controller.all_extrinsic_mp4s_available() and self.controller.camera_array.all_intrinsics_calibrated():
+        extrinsics_available = self.coordinator.all_extrinsic_mp4s_available()
+        intrinsics_calibrated = self.coordinator.camera_array.all_intrinsics_calibrated()
+        if extrinsics_available and intrinsics_calibrated:
             self.workspace_summary.calibrate_btn.setEnabled(True)
         else:
             self.workspace_summary.calibrate_btn.setEnabled(False)
 
         logger.info("Building Charuco widget")
-        self.charuco_widget = CharucoWidget(self.controller)
+        self.charuco_widget = CharucoWidget(self.coordinator)
         self.central_tab.addTab(self.charuco_widget, "Charuco")
 
         # Camera tab disabled until new architecture is wired in (epic #885)
         logger.info("Camera tab disabled until new architecture is wired in")
         self.intrinsic_cal_widget = QWidget()
         self.central_tab.addTab(self.intrinsic_cal_widget, "Cameras")
-        self.central_tab.setTabEnabled(self.find_tab_index_by_title("Cameras"), self.controller.cameras_loaded)
+        self.central_tab.setTabEnabled(self.find_tab_index_by_title("Cameras"), self.coordinator.cameras_loaded)
         logger.info("Camera tab enabled")
 
         logger.info("About to load capture volume tab")
-        if self.controller.capture_volume_loaded:
+        if self.coordinator.capture_volume_loaded:
             logger.info("Creating capture Volume Widget")
-            self.capture_volume_widget = CaptureVolumeWidget(self.controller)
+            self.capture_volume_widget = CaptureVolumeWidget(self.coordinator)
         else:
             logger.info("Creating dummy widget")
             self.capture_volume_widget = QWidget()
         self.central_tab.addTab(self.capture_volume_widget, "Capture Volume")
         self.central_tab.setTabEnabled(
-            self.find_tab_index_by_title("Capture Volume"), self.controller.capture_volume_loaded
+            self.find_tab_index_by_title("Capture Volume"), self.coordinator.capture_volume_loaded
         )
 
         logger.info("About to load post-processing tab")
-        if self.controller.capture_volume_loaded and self.controller.recordings_available():
+        if self.coordinator.capture_volume_loaded and self.coordinator.recordings_available():
             logger.info("Creating post processing widget")
-            self.post_processing_widget = PostProcessingWidget(self.controller)
-            self.controller.capture_volume_shifted.connect(self.post_processing_widget.refresh_visualizer)
+            self.post_processing_widget = PostProcessingWidget(self.coordinator)
+            self.coordinator.capture_volume_shifted.connect(self.post_processing_widget.refresh_visualizer)
             post_processing_enabled = True
         else:
             logger.info("Creating dummy widget")
@@ -152,10 +154,10 @@ class MainWindow(QMainWindow):
             TaskHandle for connecting additional completion callbacks.
         """
         logger.info(f"Launching session with config file stored in {path_to_workspace}")
-        self.controller = Controller(Path(path_to_workspace))
-        logger.info("Initiate controller loading")
+        self.coordinator = WorkspaceCoordinator(Path(path_to_workspace))
+        logger.info("Initiate coordinator loading")
         # TaskHandle.completed safe to connect after start - Qt queues cross-thread signals
-        handle = self.controller.load_workspace()
+        handle = self.coordinator.load_workspace()
         handle.completed.connect(self.build_central_tabs)
 
         self.open_project_action.setEnabled(False)
@@ -182,10 +184,10 @@ class MainWindow(QMainWindow):
 
             self.central_tab.clear()
 
-        workspace = self.controller.workspace
-        del self.controller
-        self.controller = Controller(workspace_dir=workspace)
-        handle = self.controller.load_workspace()
+        workspace = self.coordinator.workspace
+        del self.coordinator
+        self.coordinator = WorkspaceCoordinator(workspace_dir=workspace)
+        handle = self.coordinator.load_workspace()
         handle.completed.connect(self.build_central_tabs)
 
     def add_to_recent_project(self, project_path: str):

--- a/src/caliscope/gui/synched_frames_display.py
+++ b/src/caliscope/gui/synched_frames_display.py
@@ -23,7 +23,7 @@ class SyncedFramesDisplay(QWidget):
     This widget is not intended to have any interactive functionality at all and to only
     provide a window to the user of the current landmark tracking
 
-    This is why the primary input is the sync stream manager directly and not the controller
+    This is why the primary input is the sync stream manager directly and not the coordinator
     Apologies to Future Mac who is reading this and regretting my decisions.
     """
 

--- a/src/caliscope/gui/vizualize/calibration/capture_volume_widget.py
+++ b/src/caliscope/gui/vizualize/calibration/capture_volume_widget.py
@@ -12,7 +12,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from caliscope.controller import Controller
+from caliscope.workspace_coordinator import WorkspaceCoordinator
 from caliscope.gui.vizualize.calibration.capture_volume_visualizer import (
     CaptureVolumeVisualizer,
 )
@@ -21,17 +21,17 @@ logger = logging.getLogger(__name__)
 
 
 class CaptureVolumeWidget(QWidget):
-    def __init__(self, controller: Controller):
+    def __init__(self, coordinator: WorkspaceCoordinator):
         super(CaptureVolumeWidget, self).__init__()
 
-        self.controller = controller
+        self.coordinator = coordinator
 
-        if not hasattr(self.controller, "capture_volume"):
-            self.controller.load_estimated_capture_volume()
+        if not hasattr(self.coordinator, "capture_volume"):
+            self.coordinator.load_estimated_capture_volume()
 
         # Widget requires capture_volume to exist - load above should ensure this
-        assert self.controller.capture_volume is not None
-        self.visualizer = CaptureVolumeVisualizer(self.controller.capture_volume)
+        assert self.coordinator.capture_volume is not None
+        self.visualizer = CaptureVolumeVisualizer(self.coordinator.capture_volume)
         # self.visualizer.scene.show()
         self.slider = QSlider(Qt.Orientation.Horizontal)
         self.slider.setMinimum(self.visualizer.min_sync_index)
@@ -48,7 +48,7 @@ class CaptureVolumeWidget(QWidget):
         self.rotate_z_minus_btn = QPushButton("Z-")
 
         # capture_volume guaranteed non-None by assertion in __init__
-        capture_volume = self.controller.capture_volume
+        capture_volume = self.coordinator.capture_volume
         assert capture_volume is not None
         self.rmse_summary = QLabel(capture_volume.get_rmse_summary())
 
@@ -100,13 +100,13 @@ class CaptureVolumeWidget(QWidget):
     def set_origin_to_board(self):
         logger.info("Setting origin to board...")
         origin_index = self.slider.value()
-        self.controller.set_capture_volume_origin_to_board(origin_index)
+        self.coordinator.set_capture_volume_origin_to_board(origin_index)
         self.visualizer.refresh_scene()
 
     def rotate_capture_volume(self, direction):
         logger.info(f"Rotating capture volume: {direction}")
 
-        self.controller.rotate_capture_volume(direction)
+        self.coordinator.rotate_capture_volume(direction)
         self.visualizer.refresh_scene()
 
     def update_board(self, sync_index):

--- a/src/caliscope/task_manager/task_manager.py
+++ b/src/caliscope/task_manager/task_manager.py
@@ -49,7 +49,7 @@ class _WorkerThread(QThread):
 class TaskManager(QObject):
     """Centralized manager for background task lifecycle.
 
-    Replaces the controller's pattern of storing threads in dictionaries
+    Replaces the coordinator's pattern of storing threads in dictionaries
     without cleanup. Tracks active tasks and provides abort functionality.
     """
 

--- a/src/caliscope/workspace_coordinator.py
+++ b/src/caliscope/workspace_coordinator.py
@@ -38,17 +38,18 @@ FILTERED_FRACTION = (
 )
 
 
-class Controller(QObject):
+class WorkspaceCoordinator(QObject):
     """
-    Thin integration layer between GUI and backend domain logic.
+    Application-level coordinator for a calibration workspace.
 
-    The Controller orchestrates the calibration workflow by coordinating between
-    managers (data persistence), stream managers (video processing), and domain
-    objects (CameraArray, CaptureVolume). It maintains no business logic itself
-    beyond workflow state management.
+    Orchestrates the calibration workflow by coordinating between repositories
+    (persistence), stream managers (video processing), and domain objects
+    (CameraArray, CaptureVolume). Maintains no business logic itself beyond
+    workflow state management.
 
-    All data access is delegated to typed manager classes, eliminating coupling
-    between the GUI and persistence implementation details.
+    This is session-scoped to a workspace directory. All data access is delegated
+    to typed repository classes, eliminating coupling between the GUI and
+    persistence implementation details.
     """
 
     new_camera_data = Signal(int, OrderedDict)  # port, camera_display_dictionary

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -19,7 +19,7 @@ from caliscope.core.capture_volume.quality_controller import QualityController
 
 
 # from caliscope.cameras.camera_array_initializer import CameraArrayInitializer
-from caliscope.controller import FILTERED_FRACTION
+from caliscope.workspace_coordinator import FILTERED_FRACTION
 from caliscope.helper import copy_contents_to_clean_dest
 from caliscope.core.point_data import ImagePoints
 from caliscope.managers.synchronized_stream_manager import SynchronizedStreamManager


### PR DESCRIPTION
## Summary

- Rename `Controller` class to `WorkspaceCoordinator` to better communicate its architectural role
- The term "Controller" carried MVC baggage that didn't match this session-scoped coordinator pattern
- Fix `charuco_widget` to use `update_charuco()` instead of direct assignment (original #834 issue)
- Update CLAUDE.md documentation to reflect the new naming

## Original Issue

Widgets were reaching through controller to access internals. The specific issues addressed:

| Pattern | Status |
|---------|--------|
| `playback_widget.py` direct stream manager access | Deleted in #887 |
| `capture_volume_widget.py` hasattr() checks | Deferred - widget being rebuilt |
| `extrinsic_playback_widget.py` hasattr() polling | Deferred - widget being rebuilt |
| `charuco_widget.py` bypassing update_charuco() | **Fixed** |

The rename also signals architectural intent - this is a coordinator, not an MVC controller.

Closes #834

## Test plan

- [x] CI passes
- [x] Application launches and basic navigation works