### PR TITLE
test(startup): verify smoke test catches Windows failure

### DIFF
--- a/src/caliscope/__main__.py
+++ b/src/caliscope/__main__.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 import faulthandler
 import os
 import sys
+import tempfile
 from pathlib import Path
 
 # Write faulthandler trace to a file that survives the segfault
 # (pipe buffers don't flush on SIGSEGV)
-_faulthandler_file = open("/tmp/faulthandler.log", "w")  # noqa: SIM115
+_faulthandler_file = open(  # noqa: SIM115
+    os.path.join(tempfile.gettempdir(), "caliscope_faulthandler.log"), "w"
+)
 faulthandler.enable(file=_faulthandler_file, all_threads=True)
 
 from caliscope import MODELS_DIR  # noqa: E402

--- a/src/caliscope/__main__.py
+++ b/src/caliscope/__main__.py
@@ -3,14 +3,11 @@ from __future__ import annotations
 import faulthandler
 import os
 import sys
-import tempfile
 from pathlib import Path
 
 # Write faulthandler trace to a file that survives the segfault
 # (pipe buffers don't flush on SIGSEGV)
-_faulthandler_file = open(  # noqa: SIM115
-    os.path.join(tempfile.gettempdir(), "caliscope_faulthandler.log"), "w"
-)
+_faulthandler_file = open("/tmp/faulthandler.log", "w")  # noqa: SIM115
 faulthandler.enable(file=_faulthandler_file, all_threads=True)
 
 from caliscope import MODELS_DIR  # noqa: E402

--- a/tests/test_startup_smoke.py
+++ b/tests/test_startup_smoke.py
@@ -1,0 +1,26 @@
+"""Smoke test: verify the entry point module loads on all platforms.
+
+The __main__ module runs code at import time (faulthandler setup, path
+resolution). A hardcoded Unix path once crashed the app on Windows.
+This test catches that class of platform-specific startup failure.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_entry_point_module_imports():
+    result = subprocess.run(
+        [sys.executable, "-c", "import caliscope.__main__"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"Entry point module failed to import:\n{result.stderr}"
+
+
+if __name__ == "__main__":
+    test_entry_point_module_imports()
+    print("Smoke test passed.")


### PR DESCRIPTION
## Summary

- Adds a cross-platform smoke test that imports the entry point module in a subprocess
- Deliberately reverts the faulthandler fix to prove the test catches the `/tmp` crash on Windows

**Do not merge.** This PR exists to verify CI behavior. Once the Windows runner fails as expected, I'll restore the fix and push again.

## Expected result

- Linux: pass
- macOS: pass (has `/tmp`)
- Windows: **fail** with `FileNotFoundError: [Errno 2] No such file or directory: '/tmp/faulthandler.log'`