### PR TITLE
fix(deps): declare typing_extensions as direct dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "caliscope"
-version = "0.8.1"
+version = "0.8.2"
 description = "Rapid and reliable multicamera calibration with GUI and scripting API"
 authors = [{name = "Mac Prible", email = "prible@gmail.com"}]
 license = { text = "BSD-2-Clause" }
@@ -16,6 +16,7 @@ dependencies = [
     "platformdirs>=4.3.8",
     "av>=16.0.0,<16.1.0",  # 16.1.0 lacks Linux wheels as of 2025-01 - revisit
     "onnxruntime>=1.16.0",
+    "typing_extensions>=4.0.0",
     "rich>=13.0.0",
     # Security floor constraints for transitive dependencies (dependabot alerts)
     "urllib3>=2.6.3",    # CVE fixes: decompression bomb, streaming API

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "caliscope"
-version = "0.8.2"
+version = "0.8.3"
 description = "Rapid and reliable multicamera calibration with GUI and scripting API"
 authors = [{name = "Mac Prible", email = "prible@gmail.com"}]
 license = { text = "BSD-2-Clause" }

--- a/uv.lock
+++ b/uv.lock
@@ -113,7 +113,7 @@ wheels = [
 
 [[package]]
 name = "caliscope"
-version = "0.8.2"
+version = "0.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "av" },

--- a/uv.lock
+++ b/uv.lock
@@ -113,7 +113,7 @@ wheels = [
 
 [[package]]
 name = "caliscope"
-version = "0.8.1"
+version = "0.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "av" },
@@ -130,6 +130,7 @@ dependencies = [
     { name = "rtoml" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions" },
     { name = "urllib3" },
 ]
 
@@ -178,6 +179,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.0.0" },
     { name = "rtoml", specifier = ">=0.9.0" },
     { name = "scipy", specifier = ">=1.10.1" },
+    { name = "typing-extensions", specifier = ">=4.0.0" },
     { name = "urllib3", specifier = ">=2.6.3" },
 ]
 provides-extras = ["gui"]


### PR DESCRIPTION
## Summary

- Add `typing_extensions>=4.0.0` as a declared dependency in `pyproject.toml`
- `pose_network_builder.py` imports `typing_extensions.Self` at runtime, but the package was only present through transitive dependencies not guaranteed on Windows
- Bump version to 0.8.2

## Context

Reported in #973. On a clean Windows install, `typing_extensions` was missing because the transitive paths that provide it on Linux (`ewmhlib`, `pywinctl`) and in dev environments (`onnx`) are not present.

## Test plan

- [x] CI passes on all three platforms
- [x] `uv pip install caliscope[gui]` in a clean venv resolves `typing_extensions`