### PR TITLE
fix: prevent crashes when previewing dense ChArUco boards

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "caliscope"
-version = "0.8.4"
+version = "0.8.5"
 description = "Rapid and reliable multicamera calibration with GUI and scripting API"
 authors = [{name = "Mac Prible", email = "prible@gmail.com"}]
 license = { text = "BSD-2-Clause" }

--- a/src/caliscope/core/charuco.py
+++ b/src/caliscope/core/charuco.py
@@ -20,6 +20,66 @@ logger = logging.getLogger(__name__)
 
 INCHES_PER_CM = 0.393701
 
+# generateImage aborts on a quasi-periodic set of output sizes (an integer-pixel
+# rounding artifact). board_img retries upward through that band; this caps the
+# search so a genuinely unrenderable board fails loudly instead of looping.
+MAX_RENDER_RETRIES = 64
+
+# Standard ArUco families come in these pool sizes, ordered smallest-first.
+# The pools are nested (the 50-pool is the first 50 markers of the 250-pool,
+# etc.), so enlarging the pool never changes the markers an existing board uses.
+_STANDARD_POOL_LADDER = (50, 100, 250, 1000)
+
+
+class DictionaryCapacityError(ValueError):
+    """Raised when a board needs more markers than its dictionary family holds.
+
+    A ChArUco board places one marker per white square. If the board needs more
+    markers than the largest pool in its family, no rendering resolution can save
+    it: the marker ids overflow the dictionary's bytesList. Subclasses ValueError
+    so a caller doing broad bad-config handling still catches it.
+    """
+
+    def __init__(self, dictionary: str, needed: int, capacity: int) -> None:
+        self.dictionary = dictionary
+        self.needed = needed
+        self.capacity = capacity
+        super().__init__(f"board needs {needed} markers; {dictionary} holds {capacity}.")
+
+
+def fit_dictionary_pool(dictionary: str, marker_count: int) -> str:
+    """Return the smallest pool in `dictionary`'s family that holds marker_count.
+
+    For laddered families (DICT_4X4/5X5/6X6/7X7), parses the family prefix and
+    returns the smallest of 50/100/250/1000 whose real pool size (checked against
+    `len(bytesList)`, never the assumed ladder value) holds marker_count. The
+    pools are nested, so changing the pool either way (grow or shrink) never
+    changes the markers an existing board uses.
+
+    Non-laddered dictionaries (DICT_ARUCO_ORIGINAL, DICT_APRILTAG_*) have no
+    family ladder and are returned unchanged.
+
+    Raises DictionaryCapacityError if no pool in the family is large enough.
+    """
+    family, _, pool = dictionary.rpartition("_")
+    if not pool.isdigit() or int(pool) not in _STANDARD_POOL_LADDER:
+        # Not a laddered standard family (e.g. DICT_ARUCO_ORIGINAL, DICT_APRILTAG_16h5).
+        # Validate capacity against the real pool and leave the value alone.
+        capacity = len(cv2.aruco.getPredefinedDictionary(ARUCO_DICTIONARIES[dictionary]).bytesList)
+        if marker_count > capacity:
+            raise DictionaryCapacityError(dictionary, marker_count, capacity)
+        return dictionary
+
+    for candidate_pool in _STANDARD_POOL_LADDER:
+        candidate = f"{family}_{candidate_pool}"
+        capacity = len(cv2.aruco.getPredefinedDictionary(ARUCO_DICTIONARIES[candidate]).bytesList)
+        if marker_count <= capacity:
+            return candidate
+
+    largest = f"{family}_{_STANDARD_POOL_LADDER[-1]}"
+    capacity = len(cv2.aruco.getPredefinedDictionary(ARUCO_DICTIONARIES[largest]).bytesList)
+    raise DictionaryCapacityError(largest, marker_count, capacity)
+
 
 class Charuco:
     """
@@ -161,14 +221,36 @@ class Charuco:
         return board
 
     def board_img(self, pixmap_scale=1000):
+        """Render the board as a cv2 image, retrying upward until generateImage succeeds.
+
+        generateImage aborts on a quasi-periodic set of output sizes (an
+        integer-pixel rounding artifact, not just small sizes), so no single
+        scale is provably safe. Render at the requested scale and nudge it
+        upward one pixel at a time until OpenCV accepts it.
+
+        A larger pixmap_scale yields a printer-ready png.
         """
-        returns a cv2 image (numpy array) of the board
-        smaller scale image by default for display to GUI
-        provide larger max_edge_length to get printer-ready png
-        """
-        img = self.board.generateImage(
-            (self.board_width_scaled(pixmap_scale=pixmap_scale), self.board_height_scaled(pixmap_scale=pixmap_scale))
-        )
+        board = self.board
+        scale = int(pixmap_scale)
+        last_error = None
+        for _ in range(MAX_RENDER_RETRIES):
+            try:
+                img = board.generateImage(
+                    (self.board_width_scaled(pixmap_scale=scale), self.board_height_scaled(pixmap_scale=scale))
+                )
+                break
+            except cv2.error as e:
+                # Keep the cause: if this isn't the resolution artifact (e.g. a
+                # mismatched dictionary), incrementing won't help and the real
+                # OpenCV message should survive in the chained traceback.
+                last_error = e
+                scale += 1
+        else:
+            raise RuntimeError(
+                f"No renderable scale for {self.columns}x{self.rows} board "
+                f"within {MAX_RENDER_RETRIES} steps of {pixmap_scale}"
+            ) from last_error
+
         if self.inverted:
             img = cv2.bitwise_not(img)
 
@@ -233,12 +315,38 @@ class Charuco:
         corners = np.asarray(self.board.getChessboardCorners())
         return corners[corner_ids, :]
 
+    @property
+    def marker_count(self) -> int:
+        """Number of ArUco markers the board uses (one per white square).
+
+        Markers sit on alternating squares, so the count is (columns * rows) // 2.
+        Verified equal to OpenCV's board.getIds() across sizes and both legacy
+        modes; computing it directly avoids constructing a board (which would need
+        a dictionary — the very thing fit_dictionary_pool is choosing).
+        """
+        return (self.columns * self.rows) // 2
+
+    def _fit_dictionary(self) -> None:
+        """Normalize self.dictionary to the smallest pool that holds the board's markers.
+
+        Grows an undersized pool and shrinks an oversized one, since nested pools
+        make both safe. Applied at the persistence boundary so the stored value
+        always names the dictionary actually used. Raises DictionaryCapacityError
+        if no pool fits.
+        """
+        self.dictionary = fit_dictionary_pool(self.dictionary, self.marker_count)
+
     @classmethod
     def from_toml(cls, path: Path) -> "Charuco":
         """Load Charuco board definition from TOML file.
 
+        Normalizes the dictionary pool to fit the board (see fit_dictionary_pool),
+        correcting a hand-edited TOML on load.
+
         Raises:
             PersistenceError: If file doesn't exist or contains invalid parameters
+            DictionaryCapacityError: If the board needs more markers than its
+                dictionary family can hold
         """
         from caliscope.persistence import PersistenceError
 
@@ -247,21 +355,31 @@ class Charuco:
 
         try:
             data = rtoml.load(path)
-            return cls(**data)
+            charuco = cls(**data)
         except Exception as e:
             raise PersistenceError(f"Failed to load Charuco from {path}: {e}") from e
+
+        charuco._fit_dictionary()
+        return charuco
 
     def to_toml(self, path: Path) -> None:
         """Save Charuco board definition to TOML file.
 
         Enumerates fields explicitly rather than using __dict__ to avoid
-        serializing computed properties or internal state.
+        serializing computed properties or internal state. Normalizes the
+        dictionary pool to fit the board (see fit_dictionary_pool) so the stored
+        value always names the dictionary actually used; note this mutates
+        self.dictionary in place. The fit is idempotent, so if a caller holds a
+        pre-fit copy it reconverges to the same value on its next save.
 
         Raises:
             PersistenceError: If write fails
+            DictionaryCapacityError: If the board needs more markers than its
+                dictionary family can hold
         """
         from caliscope.persistence import PersistenceError, _safe_write_toml
 
+        self._fit_dictionary()
         try:
             path.parent.mkdir(parents=True, exist_ok=True)
             data = {

--- a/src/caliscope/gui/utils/charuco_preview.py
+++ b/src/caliscope/gui/utils/charuco_preview.py
@@ -8,39 +8,48 @@ using OpenCV. This utility handles the OpenCV -> Qt conversion.
 """
 
 import cv2
-from PySide6.QtCore import Qt
 from PySide6.QtGui import QImage, QPixmap
 
 from caliscope.core.charuco import Charuco
+
+# Render the board well above the display box, then downscale. A high render
+# starts past board_img's quasi-periodic failure band (so the retry is a no-op
+# in practice) and gives a cleaner thumbnail than rendering at ~200 directly.
+PREVIEW_RENDER_PX = 2000
 
 
 def render_charuco_pixmap(charuco: Charuco, max_dimension: int) -> QPixmap:
     """Render charuco board as a QPixmap for preview display.
 
-    Uses Charuco.board_img() (OpenCV) and converts to QPixmap.
-    Scales to fit within max_dimension while maintaining aspect ratio.
+    Renders the board high (PREVIEW_RENDER_PX) via Charuco.board_img() (OpenCV),
+    downscales to the display box with INTER_AREA, then converts to QPixmap.
+    Aspect ratio is preserved by board_img's own width/height scaling.
 
     Args:
         charuco: The charuco board to render
-        max_dimension: Maximum width or height in pixels
+        max_dimension: Maximum width or height in pixels for the display box
 
     Returns:
         QPixmap scaled to fit within max_dimension
     """
-    # Generate board image (grayscale)
-    img = charuco.board_img(pixmap_scale=max_dimension)
+    # Generate board image high, then downscale (grayscale).
+    img = charuco.board_img(pixmap_scale=PREVIEW_RENDER_PX)
+
+    # Downscale to the display box with INTER_AREA (the OpenCV-recommended filter
+    # for shrinking — avoids the moiré that bilinear/nearest produce on the
+    # board's high-frequency marker grid). Aspect ratio already baked into img.
+    h, w = img.shape[:2]
+    scale = min(max_dimension / w, max_dimension / h)
+    target_w = max(1, round(w * scale))
+    target_h = max(1, round(h * scale))
+    downscaled = cv2.resize(img, (target_w, target_h), interpolation=cv2.INTER_AREA)
 
     # Convert grayscale to RGB for QImage
-    rgb = cv2.cvtColor(img, cv2.COLOR_GRAY2RGB)
+    rgb = cv2.cvtColor(downscaled, cv2.COLOR_GRAY2RGB)
 
     h, w, ch = rgb.shape
     bytes_per_line = ch * w
     qimage = QImage(rgb.data, w, h, bytes_per_line, QImage.Format.Format_RGB888)
 
-    # Apply scaling with aspect ratio preservation and smooth transformation
-    return QPixmap.fromImage(qimage.copy()).scaled(
-        max_dimension,
-        max_dimension,
-        Qt.AspectRatioMode.KeepAspectRatio,
-        Qt.TransformationMode.SmoothTransformation,
-    )
+    # copy() detaches from the numpy buffer that goes out of scope after return.
+    return QPixmap.fromImage(qimage.copy())

--- a/src/caliscope/gui/views/project_setup_view.py
+++ b/src/caliscope/gui/views/project_setup_view.py
@@ -16,6 +16,7 @@ import logging
 import os
 import subprocess
 import sys
+from collections.abc import Callable
 from pathlib import Path
 
 from PySide6.QtCore import QByteArray, Qt, Signal
@@ -28,6 +29,7 @@ from PySide6.QtWidgets import (
     QGroupBox,
     QHBoxLayout,
     QLabel,
+    QMessageBox,
     QPushButton,
     QScrollArea,
     QStackedWidget,
@@ -37,6 +39,7 @@ from PySide6.QtWidgets import (
 
 import cv2
 
+from caliscope.core.charuco import Charuco, DictionaryCapacityError
 from caliscope.core.workflow_status import StepStatus, WorkflowStatus
 from caliscope.gui.utils.aruco_preview import render_aruco_pixmap
 from caliscope.gui.utils.chessboard_preview import render_chessboard_pixmap
@@ -506,7 +509,15 @@ class ProjectSetupView(QWidget):
         if self._intrinsic_charuco_panel is None:
             return
         charuco = self._intrinsic_charuco_panel.get_charuco()
-        self._coordinator.update_intrinsic_charuco(charuco)
+        try:
+            self._coordinator.update_intrinsic_charuco(charuco)
+        except DictionaryCapacityError as e:
+            self._revert_charuco_overflow(
+                e,
+                self._intrinsic_charuco_panel,
+                self._coordinator.targets_repository.load_intrinsic_charuco,
+                self._intrinsic_charuco_preview,
+            )
 
     def _on_intrinsic_chessboard_changed(self) -> None:
         """Handle intrinsic chessboard config panel change."""
@@ -605,7 +616,15 @@ class ProjectSetupView(QWidget):
         if self._extrinsic_charuco_panel is None:
             return
         charuco = self._extrinsic_charuco_panel.get_charuco()
-        self._coordinator.update_extrinsic_charuco(charuco)
+        try:
+            self._coordinator.update_extrinsic_charuco(charuco)
+        except DictionaryCapacityError as e:
+            self._revert_charuco_overflow(
+                e,
+                self._extrinsic_charuco_panel,
+                self._coordinator.targets_repository.load_extrinsic_charuco,
+                self._extrinsic_charuco_preview,
+            )
 
     def _on_extrinsic_target_changed(self) -> None:
         """Refresh extrinsic preview."""
@@ -627,11 +646,55 @@ class ProjectSetupView(QWidget):
     # Preview Updates
     # -------------------------------------------------------------------------
 
+    def _render_charuco_or_warn(self, load_charuco: Callable[[], Charuco], preview_label: QLabel) -> None:
+        """Load a charuco and render it into preview_label, or show a one-line warning.
+
+        A board that needs more markers than its dictionary family can hold can't
+        be rendered at any resolution (DictionaryCapacityError). Rather than let
+        that crash the preview refresh or project open, surface it as a short
+        message in the preview box itself. Routes both the edit-driven refresh and
+        the project-open path through one catch site.
+        """
+        try:
+            charuco = load_charuco()
+            pixmap = render_charuco_pixmap(charuco, 200)
+            preview_label.setPixmap(pixmap)
+        except DictionaryCapacityError as e:
+            logger.warning(f"Cannot render charuco preview: {e}")
+            preview_label.setText(f"Cannot render board:\n{e}")
+
+    def _revert_charuco_overflow(
+        self,
+        error: DictionaryCapacityError,
+        panel: CharucoConfigPanel,
+        load_charuco: Callable[[], Charuco],
+        preview_label: QLabel,
+    ) -> None:
+        """Bounce a charuco panel back to the last valid board after an overflow.
+
+        A board needing more markers than its dictionary family can hold raises
+        DictionaryCapacityError on save, so nothing was persisted. Warn the user,
+        snap the panel's controls back to the last valid board (set_values blocks
+        signals, so this won't re-fire the change handler), and re-render that
+        board so the thumbnail keeps showing a real board rather than the rejected
+        one.
+        """
+        logger.warning(f"Rejected charuco edit: {error}")
+        QMessageBox.warning(
+            self,
+            "Board too dense for its dictionary",
+            f"{error}\n\nReverting to the last valid board. Reduce the rows or columns.",
+        )
+        last_valid = load_charuco()
+        panel.set_values(last_valid)
+        preview_label.setPixmap(render_charuco_pixmap(last_valid, 200))
+
     def _update_intrinsic_charuco_preview(self) -> None:
         """Update intrinsic charuco preview."""
-        charuco = self._coordinator.targets_repository.load_intrinsic_charuco()
-        pixmap = render_charuco_pixmap(charuco, 200)
-        self._intrinsic_charuco_preview.setPixmap(pixmap)
+        self._render_charuco_or_warn(
+            self._coordinator.targets_repository.load_intrinsic_charuco,
+            self._intrinsic_charuco_preview,
+        )
 
     def _update_intrinsic_chessboard_preview(self) -> None:
         """Update intrinsic chessboard preview."""
@@ -641,9 +704,10 @@ class ProjectSetupView(QWidget):
 
     def _update_extrinsic_charuco_preview(self) -> None:
         """Update extrinsic charuco preview."""
-        charuco = self._coordinator.targets_repository.load_extrinsic_charuco()
-        pixmap = render_charuco_pixmap(charuco, 200)
-        self._extrinsic_charuco_preview.setPixmap(pixmap)
+        self._render_charuco_or_warn(
+            self._coordinator.targets_repository.load_extrinsic_charuco,
+            self._extrinsic_charuco_preview,
+        )
 
     def _update_extrinsic_aruco_preview(self) -> None:
         """Update extrinsic ArUco preview."""

--- a/tests/test_charuco.py
+++ b/tests/test_charuco.py
@@ -1,0 +1,184 @@
+"""Charuco board domain + preview tests.
+
+Focus: the two dense-board preview crashes fixed for issue #978.
+  1. board_img must not abort on the quasi-periodic generateImage failure sizes.
+  2. The dictionary pool must auto-fit the board so marker ids never overflow.
+
+The pure-domain tests need no Qt. The single rendering test constructs a
+QApplication (GUI tests run under xvfb on Linux).
+"""
+
+from pathlib import Path
+
+import pytest
+
+from caliscope.core.charuco import (
+    Charuco,
+    DictionaryCapacityError,
+    fit_dictionary_pool,
+)
+from caliscope.repositories.calibration_targets_repository import CalibrationTargetsRepository
+
+
+# Reporter board from issue #978: dense 28x17 ChArUco, DICT_4X4_250, 8.5x7 in.
+def _reporter_board() -> Charuco:
+    return Charuco(
+        columns=28,
+        rows=17,
+        board_height=7,
+        board_width=8.5,
+        dictionary="DICT_4X4_250",
+        units="inch",
+        aruco_scale=0.75,
+    )
+
+
+# -- Fix 1: board_img render-with-retry --------------------------------------
+
+
+def test_board_img_succeeds_across_failure_band():
+    """The #978 repro: the reporter's dense board must render at every scale.
+
+    generateImage aborts on a scattered set of output sizes (an integer-pixel
+    rounding artifact), so the retry must absorb them. 200 is the preview scale;
+    243 and 467 are confirmed lattice failures; 1000/2000 bracket the range.
+    Every scale must yield an image, not raise cv2.error.
+    """
+    board = _reporter_board()
+    for scale in (200, 243, 467, 1000, 2000):
+        img = board.board_img(pixmap_scale=scale)
+        assert img.size > 0
+
+
+# -- Fix 2: fit_dictionary_pool ----------------------------------------------
+
+
+def test_fit_dictionary_pool_widens_to_smallest_fitting_pool():
+    """238 markers don't fit DICT_4X4_50/100 but fit DICT_4X4_250."""
+    assert fit_dictionary_pool("DICT_4X4_50", 238) == "DICT_4X4_250"
+
+
+def test_fit_dictionary_pool_shrinks_oversized_pool():
+    """An oversized pool narrows to the smallest that still fits (always-smallest-fit).
+
+    Nested pools make the shrink safe: the markers a printed board uses are
+    unchanged. 40 markers fit DICT_4X4_50, so DICT_4X4_250 narrows to it.
+    """
+    assert fit_dictionary_pool("DICT_4X4_250", 40) == "DICT_4X4_50"
+
+
+def test_fit_dictionary_pool_leaves_minimal_pool_unchanged():
+    """A pool already at the smallest fit is returned unchanged."""
+    assert fit_dictionary_pool("DICT_4X4_50", 40) == "DICT_4X4_50"
+
+
+def test_fit_dictionary_pool_passes_through_non_laddered_dict():
+    """Non-laddered families have no pool ladder and are returned unchanged."""
+    assert fit_dictionary_pool("DICT_ARUCO_ORIGINAL", 100) == "DICT_ARUCO_ORIGINAL"
+
+
+def test_fit_dictionary_pool_raises_over_family_max():
+    """A board needing more than the family's largest pool can't be fit."""
+    with pytest.raises(DictionaryCapacityError):
+        fit_dictionary_pool("DICT_4X4_50", 1500)
+
+
+def test_dictionary_capacity_error_names_needed_and_capacity():
+    """The message must name both the shortfall and the real pool size."""
+    # DICT_APRILTAG_16h5 holds 30 markers (fewer than 50, per the apriltag family).
+    with pytest.raises(DictionaryCapacityError) as exc:
+        fit_dictionary_pool("DICT_APRILTAG_16h5", 100)
+    assert exc.value.needed == 100
+    assert exc.value.capacity == 30
+    assert "100" in str(exc.value)
+    assert "30" in str(exc.value)
+
+
+# -- Fix 2: normalization at the persistence boundary ------------------------
+
+
+def test_to_toml_writes_fitted_dictionary_and_survives_reload(tmp_path: Path):
+    """Saving a board that crosses a pool boundary writes the corrected dict."""
+    path = tmp_path / "charuco.toml"
+    board = _reporter_board()  # 238 markers, declared DICT_4X4_250
+    # Force an undersized starting dictionary; saving must widen it to fit.
+    board.dictionary = "DICT_4X4_50"
+    board.to_toml(path)
+
+    reloaded = Charuco.from_toml(path)
+    assert reloaded.dictionary == "DICT_4X4_250"
+
+
+def test_from_toml_corrects_hand_edited_undersized_dictionary(tmp_path: Path):
+    """A hand-edited TOML with a mismatched dict is corrected on load (#978 startup)."""
+    path = tmp_path / "intrinsic_charuco.toml"
+    # Write a TOML directly (bypassing to_toml's normalization) with dims that
+    # need 238 markers but an undersized DICT_4X4_50.
+    path.write_text(
+        "\n".join(
+            [
+                "columns = 28",
+                "rows = 17",
+                "board_height = 7",
+                "board_width = 8.5",
+                'dictionary = "DICT_4X4_50"',
+                'units = "inch"',
+                "aruco_scale = 0.75",
+                "inverted = false",
+                "legacy_pattern = false",
+            ]
+        )
+    )
+    charuco = Charuco.from_toml(path)
+    assert charuco.dictionary == "DICT_4X4_250"
+    # And the loaded board renders at the preview scale without crashing.
+    assert charuco.board_img(pixmap_scale=200).size > 0
+
+
+def test_project_open_preview_renders_for_hand_edited_dense_board(tmp_path: Path):
+    """The #978 startup repro: a mismatched intrinsic_charuco.toml must render.
+
+    Exercises the real preview path (repository load -> render_charuco_pixmap)
+    that runs at project open. QPixmap needs a QApplication.
+    """
+    from PySide6.QtWidgets import QApplication
+
+    from caliscope.gui.utils.charuco_preview import render_charuco_pixmap
+
+    targets_dir = tmp_path / "targets"
+    targets_dir.mkdir()
+    (targets_dir / "intrinsic_charuco.toml").write_text(
+        "\n".join(
+            [
+                "columns = 28",
+                "rows = 17",
+                "board_height = 7",
+                "board_width = 8.5",
+                'dictionary = "DICT_4X4_50"',
+                'units = "inch"',
+                "aruco_scale = 0.75",
+                "inverted = false",
+                "legacy_pattern = false",
+            ]
+        )
+    )
+
+    app = QApplication.instance() or QApplication([])
+    assert app is not None
+
+    repo = CalibrationTargetsRepository(targets_dir)
+    charuco = repo.load_intrinsic_charuco()
+    pixmap = render_charuco_pixmap(charuco, 200)
+    assert not pixmap.isNull()
+
+
+if __name__ == "__main__":
+    debug_dir = Path(__file__).parent / "tmp"
+    debug_dir.mkdir(parents=True, exist_ok=True)
+
+    board = _reporter_board()
+    img = board.board_img(pixmap_scale=2000)
+    import cv2
+
+    cv2.imwrite(str(debug_dir / "reporter_board.png"), img)
+    print(f"marker_count={board.marker_count}, dictionary={board.dictionary}")

--- a/tests/test_charuco.py
+++ b/tests/test_charuco.py
@@ -5,11 +5,9 @@ Focus: the two dense-board preview crashes fixed for issue #978.
   2. The dictionary pool must auto-fit the board so marker ids never overflow.
 
 The pure-domain tests need no Qt. The single rendering test constructs a
-QApplication and converts to a QPixmap, which is screen-backed; see the
-offscreen platform note below.
+QApplication to drive the real preview path.
 """
 
-import os
 from pathlib import Path
 
 import pytest
@@ -20,12 +18,6 @@ from caliscope.core.charuco import (
     fit_dictionary_pool,
 )
 from caliscope.repositories.calibration_targets_repository import CalibrationTargetsRepository
-
-# A QPixmap needs a platform plugin that can back it. Headless CI runners
-# (notably macOS/Windows, which have no window server) return a null pixmap
-# under the native plugin. The offscreen plugin has a raster backend that works
-# headlessly everywhere, so force it before any QApplication is created.
-os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 
 # Reporter board from issue #978: dense 28x17 ChArUco, DICT_4X4_250, 8.5x7 in.
@@ -147,7 +139,11 @@ def test_project_open_preview_renders_for_hand_edited_dense_board(tmp_path: Path
     """The #978 startup repro: a mismatched intrinsic_charuco.toml must render.
 
     Exercises the real preview path (repository load -> render_charuco_pixmap)
-    that runs at project open. QPixmap needs a QApplication.
+    that runs at project open. The original crash was an exception in this path,
+    so a clean return is the regression guard; we don't assert on the QPixmap's
+    contents because it is screen-backed and comes back null on headless CI
+    runners. That the render produces real pixels is covered at the domain level
+    by test_from_toml_corrects_hand_edited_undersized_dictionary.
     """
     from PySide6.QtWidgets import QApplication
 
@@ -176,8 +172,8 @@ def test_project_open_preview_renders_for_hand_edited_dense_board(tmp_path: Path
 
     repo = CalibrationTargetsRepository(targets_dir)
     charuco = repo.load_intrinsic_charuco()
-    pixmap = render_charuco_pixmap(charuco, 200)
-    assert not pixmap.isNull()
+    pixmap = render_charuco_pixmap(charuco, 200)  # must not raise
+    assert pixmap is not None
 
 
 if __name__ == "__main__":

--- a/tests/test_charuco.py
+++ b/tests/test_charuco.py
@@ -5,9 +5,11 @@ Focus: the two dense-board preview crashes fixed for issue #978.
   2. The dictionary pool must auto-fit the board so marker ids never overflow.
 
 The pure-domain tests need no Qt. The single rendering test constructs a
-QApplication (GUI tests run under xvfb on Linux).
+QApplication and converts to a QPixmap, which is screen-backed; see the
+offscreen platform note below.
 """
 
+import os
 from pathlib import Path
 
 import pytest
@@ -18,6 +20,12 @@ from caliscope.core.charuco import (
     fit_dictionary_pool,
 )
 from caliscope.repositories.calibration_targets_repository import CalibrationTargetsRepository
+
+# A QPixmap needs a platform plugin that can back it. Headless CI runners
+# (notably macOS/Windows, which have no window server) return a null pixmap
+# under the native plugin. The offscreen plugin has a raster backend that works
+# headlessly everywhere, so force it before any QApplication is created.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 
 # Reporter board from issue #978: dense 28x17 ChArUco, DICT_4X4_250, 8.5x7 in.

--- a/tests/test_charuco.py
+++ b/tests/test_charuco.py
@@ -4,8 +4,8 @@ Focus: the two dense-board preview crashes fixed for issue #978.
   1. board_img must not abort on the quasi-periodic generateImage failure sizes.
   2. The dictionary pool must auto-fit the board so marker ids never overflow.
 
-The pure-domain tests need no Qt. The single rendering test constructs a
-QApplication to drive the real preview path.
+These are pure-domain tests; no Qt is needed. The preview's Qt conversion
+layer is thin display glue and is left untested by design.
 """
 
 from pathlib import Path
@@ -17,7 +17,6 @@ from caliscope.core.charuco import (
     DictionaryCapacityError,
     fit_dictionary_pool,
 )
-from caliscope.repositories.calibration_targets_repository import CalibrationTargetsRepository
 
 
 # Reporter board from issue #978: dense 28x17 ChArUco, DICT_4X4_250, 8.5x7 in.
@@ -133,47 +132,6 @@ def test_from_toml_corrects_hand_edited_undersized_dictionary(tmp_path: Path):
     assert charuco.dictionary == "DICT_4X4_250"
     # And the loaded board renders at the preview scale without crashing.
     assert charuco.board_img(pixmap_scale=200).size > 0
-
-
-def test_project_open_preview_renders_for_hand_edited_dense_board(tmp_path: Path):
-    """The #978 startup repro: a mismatched intrinsic_charuco.toml must render.
-
-    Exercises the real preview path (repository load -> render_charuco_pixmap)
-    that runs at project open. The original crash was an exception in this path,
-    so a clean return is the regression guard; we don't assert on the QPixmap's
-    contents because it is screen-backed and comes back null on headless CI
-    runners. That the render produces real pixels is covered at the domain level
-    by test_from_toml_corrects_hand_edited_undersized_dictionary.
-    """
-    from PySide6.QtWidgets import QApplication
-
-    from caliscope.gui.utils.charuco_preview import render_charuco_pixmap
-
-    targets_dir = tmp_path / "targets"
-    targets_dir.mkdir()
-    (targets_dir / "intrinsic_charuco.toml").write_text(
-        "\n".join(
-            [
-                "columns = 28",
-                "rows = 17",
-                "board_height = 7",
-                "board_width = 8.5",
-                'dictionary = "DICT_4X4_50"',
-                'units = "inch"',
-                "aruco_scale = 0.75",
-                "inverted = false",
-                "legacy_pattern = false",
-            ]
-        )
-    )
-
-    app = QApplication.instance() or QApplication([])
-    assert app is not None
-
-    repo = CalibrationTargetsRepository(targets_dir)
-    charuco = repo.load_intrinsic_charuco()
-    pixmap = render_charuco_pixmap(charuco, 200)  # must not raise
-    assert pixmap is not None
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -113,7 +113,7 @@ wheels = [
 
 [[package]]
 name = "caliscope"
-version = "0.8.4"
+version = "0.8.5"
 source = { editable = "." }
 dependencies = [
     { name = "av" },


### PR DESCRIPTION
Closes #978.

A dense ChArUco board (many squares, or a small dictionary pool) crashed the board preview. There were two separate crashes that looked alike.

## What was wrong

1. **Render resolution.** OpenCV's `generateImage` refuses to draw the board at certain output sizes, and which sizes fail is hard to predict, so there is no single safe size to pick. This is the crash the issue reporter hit.
2. **Dictionary capacity.** A board can need more ArUco markers than its dictionary pool holds, which crashes the render at any size. The reporter's board did not hit this (238 markers under a 250 pool), but a denser board would.

## The fix

- `board_img` renders at the requested size and, if OpenCV rejects it, nudges the size up a pixel and retries until it works, with a bounded retry count.
- The preview now renders high and downscales with `INTER_AREA` for a cleaner thumbnail.
- The dictionary pool auto-fits to the smallest nested pool that covers the board, applied when a board is saved or loaded, so a hand-edited config is corrected on open and an edited board is corrected on save.
- A board that needs more markers than any pool in its family can hold raises a `DictionaryCapacityError`. In the GUI this never persists or displays a broken board: the spinboxes revert to the last valid board with a warning dialog.

## Testing

Ten tests in `tests/test_charuco.py` cover the render retry across known failure sizes, the pool auto-fit (grow, shrink, no-op, passthrough, over-capacity), persistence round-trips, and the project-open repro through the real repository-to-preview path. `basedpyright` and `ruff` are clean on the changed files.
