### PR TITLE
refactor(packets): rename FramePacket to TrackedFrame, introduce raw FramePacket

### DIFF
--- a/src/caliscope/api.py
+++ b/src/caliscope/api.py
@@ -308,18 +308,17 @@ def extract_image_points_multicam(
 
                 rows: list[dict] = []
                 processed = 0
-                while (result := frame_source.next_frame()) is not None:
-                    frame_index, _frame_time, bgr = result
-                    point_packet = tracker.get_points(bgr, cam_id=cam_id, rotation_count=0)
+                while (raw := frame_source.next_frame()) is not None:
+                    point_packet = tracker.get_points(raw.frame, cam_id=cam_id, rotation_count=0)
                     n_points = len(point_packet.point_id)
-                    sync_index = sync_for[frame_index]
-                    frame_time = synced.time_for(cam_id, frame_index)
+                    sync_index = sync_for[raw.frame_index]
+                    frame_time = synced.time_for(cam_id, raw.frame_index)
                     if n_points > 0:
                         rows.append(
                             {
                                 "sync_index": [sync_index] * n_points,
                                 "cam_id": [cam_id] * n_points,
-                                "frame_index": [frame_index] * n_points,
+                                "frame_index": [raw.frame_index] * n_points,
                                 "frame_time": [frame_time] * n_points,
                                 "point_id": point_packet.point_id.tolist(),
                                 "img_loc_x": point_packet.img_loc[:, 0].tolist(),

--- a/src/caliscope/cameras/synchronizer.py
+++ b/src/caliscope/cameras/synchronizer.py
@@ -26,16 +26,16 @@ class Synchronizer:
 
         self.synched_frames_subscribers = []  # queues that will receive actual frame data
 
-        self.all_frame_packets = {}
+        self.all_tracked_frames = {}
         self.stop_event = Event()
         self.frames_complete = False  # only relevant for video playback, but provides a way to wrap up the thread
 
         self.cam_ids = []
-        self.frame_packet_queues = {}
+        self.tracked_frame_queues = {}
         for cam_id, stream in self.streams.items():
             self.cam_ids.append(cam_id)
             q = Queue(-1)
-            self.frame_packet_queues[cam_id] = q
+            self.tracked_frame_queues[cam_id] = q
 
         self.subscribed_to_streams = False  # not subscribed yet
         self.subscribe_to_streams()
@@ -72,13 +72,13 @@ class Synchronizer:
     def subscribe_to_streams(self):
         for cam_id, stream in self.streams.items():
             logger.info(f"Subscribing synchronizer to stream from cam_id {cam_id}")
-            stream.subscribe(self.frame_packet_queues[cam_id])
+            stream.subscribe(self.tracked_frame_queues[cam_id])
         self.subscribed_to_streams = True
 
     def unsubscribe_from_streams(self):
         for cam_id, stream in self.streams.items():
             logger.info(f"unsubscribe synchronizer from cam_id {cam_id}")
-            stream.unsubscribe(self.frame_packet_queues[cam_id])
+            stream.unsubscribe(self.tracked_frame_queues[cam_id])
         self.subscribed_to_streams = False
 
     def stop(self):
@@ -119,7 +119,7 @@ class Synchronizer:
         logger.info("About to submit Threadpool of frame Harvesters")
         self.threads = []
         for cam_id, stream in self.streams.items():
-            t = Thread(target=self.harvest_frame_packets, args=(stream,), daemon=True)
+            t = Thread(target=self.harvest_tracked_frames, args=(stream,), daemon=True)
             t.start()
             self.threads.append(t)
         logger.info("Frame harvesters just submitted")
@@ -136,8 +136,8 @@ class Synchronizer:
         logger.info("Releasing record queue")
         self.synched_frames_subscribers.remove(q)
 
-    def harvest_frame_packets(self, stream):
-        """Harvest frame packets from a stream and store them.
+    def harvest_tracked_frames(self, stream):
+        """Harvest tracked frames from a stream and store them.
 
         Uses timeout on queue.get() to periodically check stop_event,
         allowing clean shutdown when stop() is called.
@@ -149,18 +149,18 @@ class Synchronizer:
         while not self.stop_event.is_set():
             try:
                 # Use timeout to periodically check stop_event
-                frame_packet = self.frame_packet_queues[cam_id].get(timeout=0.5)
+                tracked_frame = self.tracked_frame_queues[cam_id].get(timeout=0.5)
             except Empty:
                 # No frame available, loop back to check stop_event
                 continue
 
             frame_index = self.cam_id_frame_count[cam_id]
 
-            self.all_frame_packets[f"{cam_id}_{frame_index}"] = frame_packet
+            self.all_tracked_frames[f"{cam_id}_{frame_index}"] = tracked_frame
             self.cam_id_frame_count[cam_id] += 1
 
             logger.debug(
-                f"Frame data harvested from reel {frame_packet.cam_id} with index {frame_index} and frame time of {frame_packet.frame_time}"  # noqa E501
+                f"Frame data harvested from reel {tracked_frame.cam_id} with index {frame_index} and frame time of {tracked_frame.frame_time}"  # noqa E501
             )
 
         logger.info(f"Frame harvester for cam_id {cam_id} completed")
@@ -175,7 +175,7 @@ class Synchronizer:
             frame_data_key = f"{c}_{next_index}"
 
             # problem with outpacing the threads reading data in, so wait if need be
-            while frame_data_key not in self.all_frame_packets.keys():
+            while frame_data_key not in self.all_tracked_frames.keys():
                 logger.debug(f"Waiting in a loop for frame data to populate with key: {frame_data_key}")
                 if self.subscribed_to_streams:
                     time.sleep(0.1)
@@ -185,7 +185,7 @@ class Synchronizer:
                         logger.info("Synchronizer not subscribed to any streams and busy waiting...")
                     time.sleep(1)
 
-            next_frame_time = self.all_frame_packets[frame_data_key].frame_time
+            next_frame_time = self.all_tracked_frames[frame_data_key].frame_time
 
             if next_frame_time == -1:
                 logger.info(f"End of frames at cam_id {c} detected; ending synchronization")
@@ -204,7 +204,7 @@ class Synchronizer:
         for c in self.cam_ids:
             current_index = self.cam_id_current_frame[c]
             frame_data_key = f"{c}_{current_index}"
-            current_frame_time = self.all_frame_packets[frame_data_key].frame_time
+            current_frame_time = self.all_tracked_frames[frame_data_key].frame_time
             if c != cam_id:
                 times_of_current_frames.append(current_frame_time)
 
@@ -236,7 +236,7 @@ class Synchronizer:
 
         logger.info("About to start synchronizing frames...")
         while not self.stop_event.is_set():
-            current_frame_packets = {}
+            current_tracked_frames = {}
 
             layer_frame_times = []
 
@@ -254,25 +254,25 @@ class Synchronizer:
                 current_frame_index = self.cam_id_current_frame[cam_id]
 
                 cam_id_index_key = f"{cam_id}_{current_frame_index}"
-                current_frame_packet = self.all_frame_packets[cam_id_index_key]
-                frame_time = current_frame_packet.frame_time
+                current_tracked_frame = self.all_tracked_frames[cam_id_index_key]
+                frame_time = current_tracked_frame.frame_time
 
-                # don't put a frame in a synched frame packet if the next packet has a frame before it
+                # don't put a frame in a sync layer if the next frame arrives before it
                 if frame_time > earliest_next[cam_id]:
                     # definitly should be put in the next layer and not this one
-                    current_frame_packets[cam_id] = None
+                    current_tracked_frames[cam_id] = None
                     logger.warning(f"Skipped frame at cam_id {cam_id}: > earliest_next")
                 elif (
                     earliest_next[cam_id] - frame_time < frame_time - latest_current[cam_id]
                 ):  # frame time is closer to earliest next than latest current
                     # if it's closer to the earliest next frame than the latest current frame, bump it up
                     # only applying for 2 camera setup where I noticed this was an issue (frames stay out of synch)
-                    current_frame_packets[cam_id] = None
+                    current_tracked_frames[cam_id] = None
                     logger.warning(f"Skipped frame at cam_id {cam_id}: delta < time-latest_current")
                 else:
                     # add the data and increment the index
-                    current_frame_packets[cam_id] = self.all_frame_packets.pop(cam_id_index_key)
-                    # frame_packets[cam_id]["sync_index"] = sync_index
+                    current_tracked_frames[cam_id] = self.all_tracked_frames.pop(cam_id_index_key)
+                    # tracked_frames[cam_id]["sync_index"] = sync_index
                     self.cam_id_current_frame[cam_id] += 1
                     layer_frame_times.append(frame_time)
                     logger.debug(
@@ -280,7 +280,7 @@ class Synchronizer:
                         f"at index {current_frame_index} and frame time: {frame_time}"
                     )
 
-            logger.debug(f"Unassigned Frames: {len(self.all_frame_packets)}")
+            logger.debug(f"Unassigned Frames: {len(self.all_tracked_frames)}")
 
             # only calculate mean and FPS if frames were actually synched this layer
             if layer_frame_times:
@@ -290,7 +290,7 @@ class Synchronizer:
                 logger.warning("No frames were synchronized this cycle; skipping FPS update")
 
             logger.debug(f"Updating sync packet for sync_index {sync_index}")
-            self.current_sync_packet = SyncPacket(sync_index, current_frame_packets)
+            self.current_sync_packet = SyncPacket(sync_index, current_tracked_frames)
 
             self.update_dropped_frame_history()
 
@@ -304,7 +304,7 @@ class Synchronizer:
                 q.put(self.current_sync_packet)
                 if self.current_sync_packet is not None:
                     logger.debug(
-                        f"Placing new synched frames packet on queue with {self.current_sync_packet.frame_packet_count} frames"  # noqa E501
+                        f"Placing new synched frames packet on queue with {self.current_sync_packet.tracked_frame_count} frames"  # noqa E501
                     )
                     logger.debug(f"Placing new synched frames with index {self.current_sync_packet.sync_index}")
 
@@ -313,7 +313,7 @@ class Synchronizer:
                         logger.info(f"Placing new synched frames with index {self.current_sync_packet.sync_index}")
                 else:
                     logger.info("signaling end of frames with `None` packet on subscriber queue.")
-                    for cam_id, q in self.frame_packet_queues.items():
-                        logger.info(f"Currently {q.qsize()} frame packets unprocessed for cam_id {cam_id}")
+                    for cam_id, q in self.tracked_frame_queues.items():
+                        logger.info(f"Currently {q.qsize()} tracked frames unprocessed for cam_id {cam_id}")
 
         logger.info("Frame synch worker successfully ended")

--- a/src/caliscope/core/intrinsic_calibrator.py
+++ b/src/caliscope/core/intrinsic_calibrator.py
@@ -7,7 +7,7 @@ import cv2
 import numpy as np
 
 from caliscope.cameras.camera_array import CameraData
-from caliscope.packets import FramePacket
+from caliscope.packets import TrackedFrame
 from caliscope.recording.frame_packet_streamer import FramePacketStreamer
 
 logger = logging.getLogger(__name__)
@@ -24,8 +24,8 @@ class IntrinsicCalibrator:
         self.streamer = streamer
         self.initialize_point_history()
 
-        self.frame_packet_q = Queue()
-        self.streamer.subscribe(self.frame_packet_q)
+        self.tracked_frame_q = Queue()
+        self.streamer.subscribe(self.tracked_frame_q)
 
         # The following group of parameters relate to the autopopulation of the calibrator
         self.grid_history_q = Queue()  # for passing ids, img_loc used in calibration
@@ -44,11 +44,11 @@ class IntrinsicCalibrator:
 
         def harvest_worker():
             while True:
-                frame_packet = self.frame_packet_q.get()
+                tracked_frame = self.tracked_frame_q.get()
                 if self.stop_event.is_set():
                     break
 
-                self.add_frame_packet(frame_packet)
+                self.add_tracked_frame(tracked_frame)
 
             logger.info(f"Harvest frames successfully ended in calibrator for cam {self.streamer.cam_id}")
 
@@ -58,8 +58,8 @@ class IntrinsicCalibrator:
     def stop(self):
         logger.info("Beginning to stop intrinsic calibrator")
         self.stop_event.set()
-        self.streamer.unsubscribe(self.frame_packet_q)
-        self.frame_packet_q.put(-1)
+        self.streamer.unsubscribe(self.tracked_frame_q)
+        self.tracked_frame_q.put(-1)
 
     @property
     def grid_count(self):
@@ -83,28 +83,28 @@ class IntrinsicCalibrator:
         self.all_img_loc = {}
         self.all_obj_loc = {}
 
-    def add_frame_packet(self, frame_packet: FramePacket):
+    def add_tracked_frame(self, tracked_frame: TrackedFrame):
         """
-        Point data from frame packet is stored, indexed by the frame index
+        Point data from tracked frame is stored, indexed by the frame index
         """
-        index = frame_packet.frame_index
+        index = tracked_frame.frame_index
 
-        if index != -1 and frame_packet.points is not None:
-            self.all_ids[index] = frame_packet.points.point_id
-            self.all_img_loc[index] = frame_packet.points.img_loc
-            self.all_obj_loc[index] = frame_packet.points.obj_loc
+        if index != -1 and tracked_frame.points is not None:
+            self.all_ids[index] = tracked_frame.points.point_id
+            self.all_img_loc[index] = tracked_frame.points.img_loc
+            self.all_obj_loc[index] = tracked_frame.points.obj_loc
 
             self.active_frame_index = index
 
             # when auto store data is set, the stream should be pushing out all
             # frames consecutively from the beginning
             if self.auto_store_data.is_set():
-                point_id = frame_packet.points.point_id
+                point_id = tracked_frame.points.point_id
 
                 if point_id.size == 0:
                     corner_count = 0
                 else:
-                    corner_count = frame_packet.points.point_id.shape[0]
+                    corner_count = tracked_frame.points.point_id.shape[0]
                 logger.debug(f"Corner count is {corner_count} and frame wait is {self.auto_pop_frame_wait}")
                 if self.auto_pop_frame_wait == 0 and corner_count >= self.threshold_corner_count:
                     # add frame to calibration data and reset the wait time
@@ -166,9 +166,9 @@ class IntrinsicCalibrator:
 
     def initiate_auto_pop(self, wait_between, threshold_corner_count, target_grid_count):
         """
-        This will enable actions within self.add_frame_packet
+        This will enable actions within self.add_tracked_frame
 
-        Now when frame_packets are read in from the stream, the
+        Now when tracked_frames are read in from the stream, the
 
         """
         logger.info(f"Initiating autopopulation of corner data in cam {self.camera.cam_id}")
@@ -184,7 +184,7 @@ class IntrinsicCalibrator:
         The data that will ultimately go into the calibration is determined by the calibration
         frame indices. This is where the calibration data is populated based on which frames
         have been flagged (either by the user via self.add_calibration_frame_index or by autopopulated
-        within self.add_frame_packet when autopop is enabled.)
+        within self.add_tracked_frame when autopop is enabled.)
         """
         self.calibration_point_ids = []
         self.calibration_img_loc = []

--- a/src/caliscope/core/process_synchronized_recording.py
+++ b/src/caliscope/core/process_synchronized_recording.py
@@ -93,13 +93,12 @@ def process_synchronized_recording(
             while True:
                 if token is not None and token.is_cancelled:
                     break
-                result = source.next_frame()
-                if result is None:
+                raw = source.next_frame()
+                if raw is None:
                     break
-                frame_index, frame_time, bgr = result
-                sync_index = frame_to_sync[frame_index]
-                points = tracker.get_points(bgr, cam_id, camera.rotation_count)
-                q.put((sync_index, FrameData(bgr, points, frame_index)))
+                sync_index = frame_to_sync[raw.frame_index]
+                points = tracker.get_points(raw.frame, cam_id, camera.rotation_count)
+                q.put((sync_index, FrameData(raw.frame, points, raw.frame_index)))
         finally:
             source.close()
             q.put(None)  # sentinel

--- a/src/caliscope/gui/presenters/intrinsic_calibration_presenter.py
+++ b/src/caliscope/gui/presenters/intrinsic_calibration_presenter.py
@@ -1,7 +1,7 @@
 """Presenter for intrinsic camera calibration workflow.
 
 Coordinates the collection of calibration board corner observations and calibration
-via the domain's pure functions. Emits raw FramePackets for the View to
+via the domain's pure functions. Emits raw TrackedFrames for the View to
 handle display transforms (undistortion, rotation, padding).
 
 This is a "scratchpad" presenter - accumulated data and calibration results
@@ -24,7 +24,7 @@ from caliscope.core.calibrate_intrinsics import (
 )
 from caliscope.core.frame_selector import IntrinsicCoverageReport, select_calibration_frames
 from caliscope.core.point_data import ImagePoints
-from caliscope.packets import FramePacket, PointPacket
+from caliscope.packets import PointPacket, TrackedFrame
 from caliscope.recording.frame_packet_streamer import create_streamer
 from caliscope.recording.frame_source import FrameSource
 from caliscope.task_manager.cancellation import CancellationToken
@@ -70,7 +70,7 @@ class IntrinsicCalibrationPresenter(QObject):
             Qt.AutoConnection queues to main thread).
 
     Queue:
-        display_queue: View's processing thread reads FramePackets from here.
+        display_queue: View's processing thread reads TrackedFrames from here.
             Keeps heavy frame data off the GUI thread until processed into QPixmap.
     """
 
@@ -129,7 +129,7 @@ class IntrinsicCalibrationPresenter(QObject):
             self._collected_points = list(restored_points)
 
         # Display queue for View consumption
-        self._display_queue: Queue[FramePacket | None] = Queue()
+        self._display_queue: Queue[TrackedFrame | None] = Queue()
 
         # Collection state
         self._is_collecting = False
@@ -144,7 +144,7 @@ class IntrinsicCalibrationPresenter(QObject):
             tracker=self._tracker,
             end_behavior="pause",  # Pause at end for interactive scrubbing
         )
-        self._frame_queue: Queue[FramePacket] = Queue()
+        self._frame_queue: Queue[TrackedFrame] = Queue()
         self._streamer.subscribe(self._frame_queue)
 
         # Start streamer worker (will read first frame, then we pause)
@@ -157,7 +157,7 @@ class IntrinsicCalibrationPresenter(QObject):
         self._streamer.pause()
 
         self._current_frame_index: int = self._streamer.start_frame_index
-        self._first_frame_packet: FramePacket | None = None
+        self._first_tracked_frame: TrackedFrame | None = None
 
         # Consumer thread caches first frame and forwards to display
         self._stop_event = Event()
@@ -179,7 +179,7 @@ class IntrinsicCalibrationPresenter(QObject):
         return IntrinsicCalibrationState.READY
 
     @property
-    def display_queue(self) -> Queue[FramePacket | None]:
+    def display_queue(self) -> Queue[TrackedFrame | None]:
         """Queue for View's processing thread to consume frames from.
 
         None sentinel signals end of current sequence (e.g., after stop).
@@ -244,8 +244,8 @@ class IntrinsicCalibrationPresenter(QObject):
 
     def _show_first_frame(self) -> None:
         """Put the cached first frame on the display queue."""
-        if self._first_frame_packet is not None:
-            self._display_queue.put(self._first_frame_packet)
+        if self._first_tracked_frame is not None:
+            self._display_queue.put(self._first_tracked_frame)
 
     def start_calibration(self) -> None:
         """Start collecting calibration frames via forward decode."""
@@ -308,30 +308,29 @@ class IntrinsicCalibrationPresenter(QObject):
         )
 
         try:
-            while (result := frame_source.next_frame()) is not None:
-                frame_idx, _frame_time, frame = result
+            while (raw := frame_source.next_frame()) is not None:
                 if self._stop_collection.is_set():
-                    logger.info(f"Collection cancelled at frame {frame_idx}")
+                    logger.info(f"Collection cancelled at frame {raw.frame_index}")
                     break
 
                 # Track the frame
-                points = self._tracker.get_points(frame, self._cam_id, self._camera.rotation_count)
+                points = self._tracker.get_points(raw.frame, self._cam_id, self._camera.rotation_count)
 
                 # Accumulate if board detected
                 if points is not None and len(points.point_id) > 0:
-                    self._collected_points.append((frame_idx, points))
+                    self._collected_points.append((raw.frame_index, points))
 
                 # Emit for display
-                packet = FramePacket(
+                tracked_frame = TrackedFrame(
                     cam_id=self._cam_id,
-                    frame_index=frame_idx,
-                    frame_time=0.0,
-                    frame=frame,
+                    frame_index=raw.frame_index,
+                    frame_time=raw.frame_time,
+                    frame=raw.frame,
                     points=points,
                 )
-                self._display_queue.put(packet)
-                self._current_frame_index = frame_idx
-                self.frame_position_changed.emit(frame_idx)
+                self._display_queue.put(tracked_frame)
+                self._current_frame_index = raw.frame_index
+                self.frame_position_changed.emit(raw.frame_index)
 
         finally:
             frame_source.close()
@@ -350,19 +349,19 @@ class IntrinsicCalibrationPresenter(QObject):
                 break
 
             try:
-                packet: FramePacket = self._frame_queue.get(timeout=0.1)
+                tracked_frame: TrackedFrame = self._frame_queue.get(timeout=0.1)
             except Empty:
                 continue
 
-            if packet.frame_index == -1:
+            if tracked_frame.frame_index == -1:
                 continue
 
-            if self._first_frame_packet is None:
-                self._first_frame_packet = packet
+            if self._first_tracked_frame is None:
+                self._first_tracked_frame = tracked_frame
 
-            self._display_queue.put(packet)
-            self._current_frame_index = packet.frame_index
-            self.frame_position_changed.emit(packet.frame_index)
+            self._display_queue.put(tracked_frame)
+            self._current_frame_index = tracked_frame.frame_index
+            self.frame_position_changed.emit(tracked_frame.frame_index)
 
         logger.debug(f"Consumer thread exiting for cam_id {self._cam_id}")
 

--- a/src/caliscope/gui/views/intrinsic_calibration_widget.py
+++ b/src/caliscope/gui/views/intrinsic_calibration_widget.py
@@ -39,7 +39,7 @@ from caliscope.gui.presenters.intrinsic_calibration_presenter import (
     IntrinsicCalibrationState,
 )
 from caliscope.gui.theme import Styles
-from caliscope.packets import FramePacket, PointPacket
+from caliscope.packets import PointPacket, TrackedFrame
 
 logger = logging.getLogger(__name__)
 
@@ -355,7 +355,7 @@ class FrameRenderThread(QThread):
 
     def __init__(
         self,
-        display_queue: Queue[FramePacket | None],
+        display_queue: Queue[TrackedFrame | None],
         camera: CameraData,
         presenter: IntrinsicCalibrationPresenter,
         pixmap_edge_length: int = 500,
@@ -371,8 +371,8 @@ class FrameRenderThread(QThread):
         self._keep_running = Event()
         self._overlay_settings = OverlaySettings()
 
-        # Cache last packet for re-rendering when overlay settings change
-        self._last_packet: FramePacket | None = None
+        # Cache last tracked frame for re-rendering when overlay settings change
+        self._last_tracked_frame: TrackedFrame | None = None
 
         # Compute overlay sizes based on image dimensions
         width = camera.size[0]
@@ -412,13 +412,13 @@ class FrameRenderThread(QThread):
         self._keep_running.clear()
 
     def rerender_cached(self) -> None:
-        """Re-render the last packet with current overlay settings.
+        """Re-render the last tracked frame with current overlay settings.
 
         Call this when overlay visibility changes instead of requesting
         a new frame from the presenter.
         """
-        if self._last_packet is not None:
-            self._render_packet(self._last_packet)
+        if self._last_tracked_frame is not None:
+            self._render_tracked_frame(self._last_tracked_frame)
 
     def _draw_current_points(self, frame: NDArray[Any], points: PointPacket) -> NDArray[Any]:
         """Draw current frame's detected points as red circles."""
@@ -479,13 +479,13 @@ class FrameRenderThread(QThread):
 
         return frame
 
-    def _render_packet(self, packet: FramePacket) -> None:
-        """Render a packet with current overlay settings and emit pixmap."""
-        if packet.frame is None:
+    def _render_tracked_frame(self, tracked_frame: TrackedFrame) -> None:
+        """Render a tracked frame with current overlay settings and emit pixmap."""
+        if tracked_frame.frame is None:
             return
 
         # Start with raw frame (View owns all rendering)
-        frame = packet.frame.copy()
+        frame = tracked_frame.frame.copy()
 
         # Layer 1: Accumulated points (behind current)
         if self._overlay_settings.show_accumulated:
@@ -496,8 +496,8 @@ class FrameRenderThread(QThread):
             frame = self._draw_selected_grids(frame)
 
         # Layer 3: Current frame points (on top)
-        if self._overlay_settings.show_current_points and packet.points is not None:
-            frame = self._draw_current_points(frame, packet.points)
+        if self._overlay_settings.show_current_points and tracked_frame.points is not None:
+            frame = self._draw_current_points(frame, tracked_frame.points)
 
         # Undistortion
         if self._undistort_enabled and self._visualizer is not None:
@@ -523,21 +523,18 @@ class FrameRenderThread(QThread):
 
         while self._keep_running.is_set():
             try:
-                packet = self._display_queue.get(timeout=0.1)
+                tracked_frame = self._display_queue.get(timeout=0.1)
             except Empty:
                 continue
 
-            # None sentinel - Presenter signals end of sequence
-            if packet is None:
+            if tracked_frame is None:
                 continue
 
-            # Skip packets with no frame (e.g., end-of-stream markers)
-            if packet.frame is None:
+            if tracked_frame.frame is None:
                 continue
 
-            # Cache for re-rendering on overlay toggle
-            self._last_packet = packet
-            self._render_packet(packet)
+            self._last_tracked_frame = tracked_frame
+            self._render_tracked_frame(tracked_frame)
 
         logger.debug(f"Frame render thread exiting for cam {self._camera.cam_id}")
 

--- a/src/caliscope/managers/synchronized_stream_manager.py
+++ b/src/caliscope/managers/synchronized_stream_manager.py
@@ -113,7 +113,7 @@ class SynchronizedStreamManager:
         Cleanup order matters for the pipeline:
         1. Recorder (downstream subscriber) - stop consuming sync packets
         2. Synchronizer (middle) - stop producing sync packets
-        3. Streamers (upstream) - stop producing frame packets
+        3. Streamers (upstream) - stop producing tracked frames
         """
         logger.info("SynchronizedStreamManager cleanup initiated")
 

--- a/src/caliscope/packets.py
+++ b/src/caliscope/packets.py
@@ -44,10 +44,17 @@ class PointPacket:
 
 @dataclass(frozen=True, slots=True)
 class FramePacket:
-    """
-    Holds the data for a single frame from a camera, including the frame itself,
-    the frame time and the points if they were generated
-    """
+    """Raw decode output from a single camera frame."""
+
+    cam_id: int
+    frame_index: int
+    frame_time: float
+    frame: NDArray[Any]
+
+
+@dataclass(frozen=True, slots=True)
+class TrackedFrame:
+    """A decoded frame enriched with tracking results."""
 
     cam_id: int
     frame_index: int
@@ -114,11 +121,11 @@ class FramePacket:
 @dataclass(frozen=True, slots=True)
 class SyncPacket:
     """
-    SyncPacket holds syncronized frame packets.
+    SyncPacket holds synchronized tracked frames.
     """
 
     sync_index: int
-    frame_packets: dict[int, FramePacket | None]  # cam_id: frame_packet
+    tracked_frames: dict[int, TrackedFrame | None]
 
     @property
     def triangulation_inputs(self):
@@ -133,11 +140,11 @@ class SyncPacket:
         point_ids = []
         img_xy = []
 
-        for cam_id, packet in self.frame_packets.items():
-            if packet is not None and packet.points is not None:
-                cameras.extend([cam_id] * len(packet.points.point_id))
-                point_ids.extend(packet.points.point_id.tolist())
-                img_xy.extend(packet.points.img_loc.tolist())
+        for cam_id, tracked_frame in self.tracked_frames.items():
+            if tracked_frame is not None and tracked_frame.points is not None:
+                cameras.extend([cam_id] * len(tracked_frame.points.point_id))
+                point_ids.extend(tracked_frame.points.point_id.tolist())
+                img_xy.extend(tracked_frame.points.img_loc.tolist())
 
         return cameras, point_ids, img_xy
 
@@ -147,18 +154,18 @@ class SyncPacket:
         convencience method to ease tracking of dropped frame rate within the synchronizer
         """
         temp_dict = {}
-        for cam_id, packet in self.frame_packets.items():
-            if packet is None:
+        for cam_id, tracked_frame in self.tracked_frames.items():
+            if tracked_frame is None:
                 temp_dict[cam_id] = 1
             else:
                 temp_dict[cam_id] = 0
         return temp_dict
 
     @property
-    def frame_packet_count(self):
+    def tracked_frame_count(self):
         count = 0
-        for cam_id, packet in self.frame_packets.items():
-            if packet is not None:
+        for cam_id, tracked_frame in self.tracked_frames.items():
+            if tracked_frame is not None:
                 count += 1
         return count
 

--- a/src/caliscope/recording/frame_packet_streamer.py
+++ b/src/caliscope/recording/frame_packet_streamer.py
@@ -1,4 +1,4 @@
-"""Streamer for FramePackets from recorded video.
+"""Streamer for TrackedFrames from recorded video.
 
 FramePacketStreamer wraps a FrameSource and FrameTimestamps, adding threading,
 pub/sub broadcasting, and optional tracking. Forward-only: no seeking.
@@ -20,7 +20,7 @@ from typing import Literal
 
 import numpy as np
 
-from caliscope.packets import FramePacket
+from caliscope.packets import TrackedFrame
 from caliscope.recording.frame_source import FrameSource
 from caliscope.recording.frame_timestamps import FrameTimestamps
 from caliscope.task_manager.cancellation import CancellationToken
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 
 class FramePacketStreamer:
-    """Streams FramePackets from recorded video to subscriber queues.
+    """Streams TrackedFrames from recorded video to subscriber queues.
 
     Wraps FrameSource (video I/O) and FrameTimestamps (timing), adding:
     - Pub/sub broadcasting to multiple queues
@@ -159,7 +159,7 @@ class FramePacketStreamer:
     # -------------------------------------------------------------------------
 
     def subscribe(self, queue: Queue) -> None:
-        """Add a queue to receive FramePackets.
+        """Add a queue to receive TrackedFrames.
 
         Thread-safe. Notifies waiting streamer if this is the first subscriber.
         """
@@ -172,7 +172,7 @@ class FramePacketStreamer:
                 logger.warning(f"Attempted duplicate subscription to streamer at cam_id {self.cam_id}")
 
     def unsubscribe(self, queue: Queue) -> None:
-        """Remove a queue from receiving FramePackets.
+        """Remove a queue from receiving TrackedFrames.
 
         Thread-safe.
         """
@@ -183,7 +183,7 @@ class FramePacketStreamer:
             else:
                 logger.warning(f"Attempted to unsubscribe non-existent queue at cam_id {self.cam_id}")
 
-    def _broadcast(self, packet: FramePacket) -> None:
+    def _broadcast(self, packet: TrackedFrame) -> None:
         """Send packet to all subscribers.
 
         Copies subscriber list while holding lock, then releases lock before
@@ -281,7 +281,7 @@ class FramePacketStreamer:
     # -------------------------------------------------------------------------
 
     def play_worker(self, token: CancellationToken, handle: TaskHandle | None = None) -> None:
-        """Main playback loop. Places FramePackets on subscriber queues.
+        """Main playback loop. Places TrackedFrames on subscriber queues.
 
         Args:
             token: Cancellation token for cooperative shutdown.
@@ -304,9 +304,11 @@ class FramePacketStreamer:
                 if self._milestones is not None:
                     sleep(self._wait_to_next_frame())
 
-                result = self._frame_source.next_frame()
-                if result is not None:
-                    self._frame_index, self._frame_time, current_frame = result
+                raw = self._frame_source.next_frame()
+                if raw is not None:
+                    self._frame_index = raw.frame_index
+                    self._frame_time = raw.frame_time
+                    current_frame = raw.frame
                 else:
                     current_frame = None
 
@@ -314,7 +316,7 @@ class FramePacketStreamer:
                 if current_frame is None:
                     logger.info(f"EOF reached at cam_id {self.cam_id}")
                     self._broadcast(
-                        FramePacket(
+                        TrackedFrame(
                             cam_id=self.cam_id,
                             frame_index=-1,
                             frame_time=-1,
@@ -334,7 +336,7 @@ class FramePacketStreamer:
                     point_data = None
                     draw_instructions = None
 
-                frame_packet = FramePacket(
+                tracked = TrackedFrame(
                     cam_id=self.cam_id,
                     frame_index=self._frame_index,
                     frame_time=self._frame_time,
@@ -344,13 +346,13 @@ class FramePacketStreamer:
                 )
 
                 logger.debug(f"Broadcasting frame {self._frame_index} at cam_id {self.cam_id}")
-                self._broadcast(frame_packet)
+                self._broadcast(tracked)
 
                 if self._frame_index == self.last_frame_index:
                     if self._end_behavior == "stop":
                         logger.info(f"Reached last frame at cam_id {self.cam_id}")
                         self._broadcast(
-                            FramePacket(
+                            TrackedFrame(
                                 cam_id=self.cam_id,
                                 frame_index=-1,
                                 frame_time=-1,

--- a/src/caliscope/recording/frame_source.py
+++ b/src/caliscope/recording/frame_source.py
@@ -1,8 +1,8 @@
 """Forward-only frame access for recorded video files.
 
 FrameSource wraps PyAV for sequential video decoding. One forward pass, no
-seeking, no random access. next_frame() returns the next frame as a tuple of
-(frame_index, frame_time, bgr). When wanted_indices is set at construction,
+seeking, no random access. next_frame() returns the next frame as a FramePacket.
+When wanted_indices is set at construction,
 unwanted frames are decoded but not converted to BGR — next_frame silently
 advances past them.
 
@@ -17,8 +17,9 @@ from threading import Lock
 from typing import Iterator, Self
 
 import av
-import numpy as np
 from av.video.frame import VideoFrame
+
+from caliscope.packets import FramePacket
 
 logger = logging.getLogger(__name__)
 
@@ -26,8 +27,8 @@ logger = logging.getLogger(__name__)
 class FrameSource:
     """Forward-only frame access for recorded video files.
 
-    next_frame() advances the stream and returns (frame_index, frame_time, bgr)
-    or None at EOF. When wanted_indices is provided at construction, frames not
+    next_frame() advances the stream and returns a FramePacket or None at EOF.
+    When wanted_indices is provided at construction, frames not
     in that set are decoded (unavoidable with video codecs) but skipped without
     the costly BGR conversion — next_frame silently advances to the next wanted
     frame.
@@ -130,8 +131,8 @@ class FrameSource:
     def last_frame_index(self) -> int:
         return self.frame_count - 1
 
-    def next_frame(self) -> tuple[int, float, np.ndarray] | None:
-        """Return the next (wanted) frame as (frame_index, frame_time, bgr), or None at EOF.
+    def next_frame(self) -> FramePacket | None:
+        """Return the next (wanted) frame as a FramePacket, or None at EOF.
 
         When wanted_indices was set at construction, silently advances past
         unwanted frames (decoding them but skipping BGR conversion). When no
@@ -160,7 +161,12 @@ class FrameSource:
                         continue
 
                     frame_time = frame.pts * self._time_base if frame.pts is not None else 0.0
-                    return i, frame_time, frame.to_ndarray(format="bgr24")
+                    return FramePacket(
+                        cam_id=self.cam_id,
+                        frame_index=i,
+                        frame_time=frame_time,
+                        frame=frame.to_ndarray(format="bgr24"),
+                    )
 
             except StopIteration:
                 return None

--- a/src/caliscope/recording/video_recorder.py
+++ b/src/caliscope/recording/video_recorder.py
@@ -100,17 +100,17 @@ class VideoRecorder:
 
             self.sync_index = sync_packet.sync_index
 
-            for cam_id, frame_packet in sync_packet.frame_packets.items():
-                if frame_packet is not None:
-                    logger.debug("Processiong frame packet...")
+            for cam_id, tracked_frame in sync_packet.tracked_frames.items():
+                if tracked_frame is not None:
+                    logger.debug("Processing tracked frame...")
                     # read in the data for this frame for this cam_id
                     if show_points:
-                        frame = frame_packet.frame_with_points
+                        frame = tracked_frame.frame_with_points
                     else:
-                        frame = frame_packet.frame
+                        frame = tracked_frame.frame
 
-                    frame_index = frame_packet.frame_index
-                    frame_time = frame_packet.frame_time
+                    frame_index = tracked_frame.frame_index
+                    frame_time = tracked_frame.frame_time
 
                     if include_video and frame is not None:
                         # store the frame
@@ -126,7 +126,7 @@ class VideoRecorder:
                         self.frame_history["frame_index"].append(frame_index)
                         self.frame_history["frame_time"].append(frame_time)
 
-                    new_tidy_table = frame_packet.to_tidy_table(self.sync_index)
+                    new_tidy_table = tracked_frame.to_tidy_table(self.sync_index)
                     if new_tidy_table is not None:  # i.e. it has data
                         for key, value in self.point_data_history.copy().items():
                             logger.debug("Extending tidy table of point history")

--- a/src/caliscope/tracker.py
+++ b/src/caliscope/tracker.py
@@ -50,7 +50,7 @@ class Tracker(ABC):
 
         As an example, the dictionary could have the form: {"radius": 5, "color": (220, 0, 0), "thickness": 3}
         The parameters `radius`, `color`, and `thickness` are used downstream in a call to `cv2.circle`
-        to place the tracked point on the frame. See `FramePacket` below.
+        to place the tracked point on the frame. See `TrackedFrame` in packets.py.
         """
         pass
 

--- a/src/caliscope/triangulate/sync_packet_triangulator.py
+++ b/src/caliscope/triangulate/sync_packet_triangulator.py
@@ -76,10 +76,10 @@ class SyncPacketTriangulator:
                 logger.info("End processing of incoming sync packets...end signaled with `None` packet")
             else:
                 logger.debug(
-                    f"Sync Packet {sync_packet.sync_index} acquired with {sync_packet.frame_packet_count} frames"
+                    f"Sync Packet {sync_packet.sync_index} acquired with {sync_packet.tracked_frame_count} frames"
                 )
                 # only attempt to process if data exists
-                if sync_packet.frame_packet_count >= 2:
+                if sync_packet.tracked_frame_count >= 2:
                     cameras, point_ids, imgs_xy = sync_packet.triangulation_inputs
                     cameras = np.array(cameras)
                     point_ids = np.array(point_ids)

--- a/tests/test_frame_source.py
+++ b/tests/test_frame_source.py
@@ -53,23 +53,21 @@ class TestFrameSourceProperties:
 class TestSequentialReading:
     """Test read_frame() sequential access."""
 
-    def test_next_frame_returns_tuple(self, frame_source: FrameSource) -> None:
-        """next_frame() returns (frame_index, frame_time, bgr)."""
+    def test_next_frame_returns_frame_packet(self, frame_source: FrameSource) -> None:
+        """next_frame() returns a FramePacket."""
         result = frame_source.next_frame()
         assert result is not None
-        frame_index, frame_time, bgr = result
-        assert frame_index == 0
-        assert isinstance(frame_time, float)
-        assert isinstance(bgr, np.ndarray)
-        assert bgr.ndim == 3
-        assert bgr.shape[2] == 3
+        assert result.frame_index == 0
+        assert isinstance(result.frame_time, float)
+        assert isinstance(result.frame, np.ndarray)
+        assert result.frame.ndim == 3
+        assert result.frame.shape[2] == 3
 
     def test_next_frame_matches_video_size(self, frame_source: FrameSource) -> None:
         """Frame dimensions match video size."""
         result = frame_source.next_frame()
         assert result is not None
-        _, _, bgr = result
-        height, width, _ = bgr.shape
+        height, width, _ = result.frame.shape
         expected_width, expected_height = frame_source.size
         assert width == expected_width
         assert height == expected_height
@@ -89,7 +87,7 @@ class TestSequentialReading:
         r2 = frame_source.next_frame()
         assert r1 is not None
         assert r2 is not None
-        diff = np.abs(r1[2].astype(np.int16) - r2[2].astype(np.int16))
+        diff = np.abs(r1.frame.astype(np.int16) - r2.frame.astype(np.int16))
         assert np.max(diff) > 0, "Sequential frames should differ"
 
 
@@ -167,10 +165,5 @@ if __name__ == "__main__":
         print(f"Start index: {source.start_frame_index}")
         print(f"Last index: {source.last_frame_index}")
 
-        frame = source.read_frame()
-        print(f"First frame shape: {frame.shape if frame is not None else None}")
-
-    with FrameSource(TEST_VIDEO_DIR, TEST_CAM_ID) as source:
-        wanted = [0, 5, 10]
-        got = {i: bgr for i, _t, bgr in source.iter_frames(wanted)}
-        print(f"iter_frames({wanted}) returned indices {sorted(got)}")
+        result = source.next_frame()
+        print(f"First frame shape: {result.frame.shape if result is not None else None}")

--- a/tests/test_frame_source_iter_frames.py
+++ b/tests/test_frame_source_iter_frames.py
@@ -51,7 +51,7 @@ def test_next_frame_decode_count_matches_metadata():
     try:
         indices = []
         while (result := fs.next_frame()) is not None:
-            indices.append(result[0])
+            indices.append(result.frame_index)
     finally:
         fs.close()
     assert indices == list(range(N_FRAMES))
@@ -70,7 +70,7 @@ def test_next_frame_with_wanted_selects_true_frame():
     try:
         got: dict[int, np.ndarray] = {}
         while (result := fs.next_frame()) is not None:
-            got[result[0]] = result[2]
+            got[result.frame_index] = result.frame
     finally:
         fs.close()
 

--- a/tests/test_intrinsic_calibrator.py
+++ b/tests/test_intrinsic_calibrator.py
@@ -51,12 +51,12 @@ def test_intrinsic_calibrator(tmp_path: Path):
 
     collected = 0
     while collected < len(test_frames):
-        packet = frame_q.get(timeout=5.0)
-        if packet.frame is None:
+        tracked_frame = frame_q.get(timeout=5.0)
+        if tracked_frame.frame is None:
             break
-        if packet.frame_index in test_frames:
-            intrinsic_calibrator.add_frame_packet(packet)
-            intrinsic_calibrator.add_calibration_frame_index(packet.frame_index)
+        if tracked_frame.frame_index in test_frames:
+            intrinsic_calibrator.add_tracked_frame(tracked_frame)
+            intrinsic_calibrator.add_calibration_frame_index(tracked_frame.frame_index)
             collected += 1
 
     streamer.stop()

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -37,9 +37,9 @@ def test_streamer():
     streamer.unpause()
 
     while True:
-        frame_packet = frame_q.get()
+        tracked_frame = frame_q.get()
 
-        if frame_packet.frame is None:
+        if tracked_frame.frame is None:
             break
 
         if streamer.frame_index == 10:


### PR DESCRIPTION
## Summary

- Split the old `FramePacket` into two types: `FramePacket` (raw decode output from `FrameSource.next_frame()`) and `TrackedFrame` (frame enriched with tracking results)
- `FrameSource.next_frame()` returns a `FramePacket` instead of a bare tuple
- `SyncPacket.frame_packets` renamed to `SyncPacket.tracked_frames`; `frame_packet_count` renamed to `tracked_frame_count`
- All variable names, parameters, methods, attributes, docstrings, and comments updated to match the new types across 17 files

## Test plan

- [x] basedpyright zero errors on all changed files
- [x] Full test suite 384/384 green
- [x] Three rounds of adversarial review (senior-dev agent) to catch stale references
- [x] Final grep sweep confirms no stale `frame_packet` references for TrackedFrame objects