### PR TITLE
Non-planar PnP bootstrap and metric chessboard extrinsic calibration

### DIFF
--- a/src/caliscope/core/bootstrap_pose/pose_network_builder.py
+++ b/src/caliscope/core/bootstrap_pose/pose_network_builder.py
@@ -86,8 +86,12 @@ class PoseNetworkBuilder:
 
         Args:
             min_points: Minimum points for reliable PnP (default: 4)
-            pnp_flags: Primary PnP algorithm (default: SOLVEPNP_IPPE)
-            fallback_flags: Fallback algorithm (default: SOLVEPNP_ITERATIVE)
+            pnp_flags: Primary PnP algorithm for planar groups (default: SOLVEPNP_IPPE)
+            fallback_flags: Fallback algorithm for planar groups (default: SOLVEPNP_ITERATIVE)
+
+        pnp_flags and fallback_flags apply to planar groups only. Non-planar
+        groups (obj_loc_z spread) always use SOLVEPNP_SQPNP with an ITERATIVE
+        fallback and a 6-point floor.
 
         Returns:
             self for method chaining
@@ -214,12 +218,20 @@ def compute_camera_to_object_poses_pnp(
     """
     Compute per-camera poses relative to the object coordinate frame for each sync_index.
 
+    Each (cam_id, sync_index, object_id) group is classified planar or
+    non-planar by its obj_loc_z spread. Planar groups use pnp_flags with a
+    fallback_flags fallback and the min_points floor — the historical path,
+    unchanged. Non-planar groups (a genuine 3D target) use SOLVEPNP_SQPNP with
+    a SOLVEPNP_ITERATIVE fallback and an effective floor of max(min_points, 6),
+    because IPPE only solves planar targets and ITERATIVE's DLT init needs >= 6
+    non-coplanar points.
+
     Args:
         image_points: Validated 2D point correspondences
         camera_array: Camera array with intrinsic parameters
         min_points: Minimum points required for reliable PnP (default: 4)
-        pnp_flags: Primary PnP algorithm flag (default: SOLVEPNP_IPPE for planar targets)
-        fallback_flags: Fallback algorithm if primary fails (default: SOLVEPNP_ITERATIVE)
+        pnp_flags: Primary PnP algorithm flag for planar groups (default: SOLVEPNP_IPPE)
+        fallback_flags: Fallback algorithm for planar groups (default: SOLVEPNP_ITERATIVE)
 
     Returns:
         dict mapping (cam_id, sync_index, object_id) -> (R, t, reprojection_error)
@@ -259,23 +271,40 @@ def compute_camera_to_object_poses_pnp(
     D_perfect = np.zeros(5)
 
     for (cam_id, sync_index, object_id), group in grouped:
-        if len(group) < min_points:
+        # Read all three object columns; planar trackers leave obj_loc_z NaN
+        # or 0, so fill NaN with 0 before classifying and solving.
+        obj_points = group[["obj_loc_x", "obj_loc_y", "obj_loc_z"]].to_numpy().copy()
+        obj_points[:, 2] = np.nan_to_num(obj_points[:, 2], nan=0.0)
+
+        # Planar iff every point shares one z (tracker-emitted planar targets
+        # sit at z exactly 0.0); a genuine 3D target spreads z over decimeters.
+        is_planar = np.ptp(obj_points[:, 2]) < 1e-6
+        if is_planar:
+            effective_min = min_points
+            primary_flags, secondary_flags = pnp_flags, fallback_flags
+        else:
+            # IPPE returns success=False on non-planar input, and ITERATIVE's
+            # DLT initialization needs >= 6 non-coplanar points, so a 3D target
+            # needs a global solver (SQPNP) as primary and a 6-point floor.
+            effective_min = max(min_points, 6)
+            primary_flags, secondary_flags = cv2.SOLVEPNP_SQPNP, cv2.SOLVEPNP_ITERATIVE
+
+        if len(group) < effective_min:
             failure_count += 1
             continue
 
+        obj_points = obj_points.astype(np.float32)
         # Use pre-undistorted points
         img_points = group[["undistort_x", "undistort_y"]].to_numpy(dtype=np.float32)
-        obj_points = group[["obj_loc_x", "obj_loc_y"]].to_numpy()
-        obj_points = np.hstack([obj_points, np.zeros((len(obj_points), 1))]).astype(np.float32)
 
-        # PnP with configurable flags
+        # PnP with the classified flags
         success, rvec, tvec = cv2.solvePnP(
-            obj_points, img_points, cameraMatrix=K_perfect, distCoeffs=D_perfect, flags=pnp_flags
+            obj_points, img_points, cameraMatrix=K_perfect, distCoeffs=D_perfect, flags=primary_flags
         )
 
         if not success:
             success, rvec, tvec = cv2.solvePnP(
-                obj_points, img_points, cameraMatrix=K_perfect, distCoeffs=D_perfect, flags=fallback_flags
+                obj_points, img_points, cameraMatrix=K_perfect, distCoeffs=D_perfect, flags=secondary_flags
             )
 
         if success:

--- a/src/caliscope/core/chessboard.py
+++ b/src/caliscope/core/chessboard.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from pathlib import Path
 import numpy as np
 import rtoml
@@ -8,16 +8,23 @@ import rtoml
 class Chessboard:
     """Chessboard calibration pattern definition.
 
-    Represents the internal corner grid of a chessboard pattern.
-    Used for intrinsic calibration only.
+    Represents the internal corner grid of a chessboard pattern. Serves
+    intrinsic calibration always; with square_size_cm set it also produces
+    metric object points and so drives extrinsic calibration (the Calibration
+    Target Interchangeability contract).
 
     Attributes:
         rows: Number of internal corners vertically (e.g., 6 for 7 rows of squares)
         columns: Number of internal corners horizontally (e.g., 9 for 10 columns of squares)
+        square_size_cm: Edge length of each square in centimeters. When None,
+            object points use unit spacing (intrinsic calibration is
+            scale-invariant); when set, spacing is metric so the same board can
+            drive extrinsic calibration.
     """
 
     rows: int
     columns: int
+    square_size_cm: float | None = None
 
     def get_object_points(self) -> np.ndarray:
         """Generate 3D object points for all internal corners.
@@ -30,21 +37,20 @@ class Chessboard:
         - Z=0 (planar board)
 
         Returns:
-            Array of shape (rows * columns, 3) with dtype float32.
-            Spacing is unit spacing (1.0 between adjacent corners).
+            Array of shape (rows * columns, 3) with dtype float32. Spacing is
+            square_size_cm / 100 meters when set, else unit spacing (1.0).
         """
+        spacing = self.square_size_cm / 100 if self.square_size_cm is not None else 1.0
         # Standard OpenCV chessboard object points pattern:
         # mgrid[0:columns, 0:rows].T.reshape(-1, 2) produces row-major order
         # (left-to-right, then top-to-bottom) matching findChessboardCorners output.
         object_points = np.zeros((self.rows * self.columns, 3), dtype=np.float32)
-        object_points[:, :2] = np.mgrid[0 : self.columns, 0 : self.rows].T.reshape(-1, 2)
+        object_points[:, :2] = np.mgrid[0 : self.columns, 0 : self.rows].T.reshape(-1, 2) * spacing
         return object_points
 
     @classmethod
     def from_toml(cls, path: Path) -> "Chessboard":
         """Load Chessboard from TOML file.
-
-        Strips legacy 'square_size_cm' field if present.
 
         Raises:
             PersistenceError: If file doesn't exist or contains invalid parameters
@@ -56,7 +62,6 @@ class Chessboard:
 
         try:
             data = rtoml.load(path)
-            data.pop("square_size_cm", None)  # Strip legacy field
             return cls(**data)
         except Exception as e:
             raise PersistenceError(f"Failed to load Chessboard from {path}: {e}") from e
@@ -71,7 +76,12 @@ class Chessboard:
 
         try:
             path.parent.mkdir(parents=True, exist_ok=True)
-            _safe_write_toml(asdict(self), path)
+            # rtoml can't serialize None, so omit square_size_cm when unset
+            # (same omit-empty pattern as ConstraintSet.to_toml).
+            data: dict = {"rows": self.rows, "columns": self.columns}
+            if self.square_size_cm is not None:
+                data["square_size_cm"] = self.square_size_cm
+            _safe_write_toml(data, path)
         except Exception as e:
             raise PersistenceError(f"Failed to save Chessboard to {path}: {e}") from e
 

--- a/src/caliscope/core/constraints.py
+++ b/src/caliscope/core/constraints.py
@@ -13,6 +13,7 @@ from caliscope.core.aruco_marker import ArucoMarkerSet
 
 if TYPE_CHECKING:
     from caliscope.core.charuco import Charuco
+    from caliscope.core.chessboard import Chessboard
     from caliscope.core.point_data import ImagePoints
 
 
@@ -205,21 +206,23 @@ class ConstraintSet:
 
         return ImagePoints(df)
 
-    @classmethod
-    def from_charuco(cls, charuco: Charuco, sigma_m: float = 0.002) -> ConstraintSet:
-        """Compile board-geometry distance constraints for BA.
+    @staticmethod
+    def _truss_distance_constraints(
+        corners: np.ndarray, spacing: float, sigma_m: float
+    ) -> tuple[DistanceConstraint, ...]:
+        """Local-truss + extreme-corner-brace distance constraints for a grid.
 
-        object_id is 0 for every corner, matching CharucoTracker's identity
-        scheme (object_id=0, keypoint_id=chessboard corner index).
-        static_object_ids is empty — the board moves. Produces only
-        DistanceConstraints, never centroids (a charuco board has no separate
-        markers to link by centroid).
+        corners is (N, 3) in meters; spacing is the grid pitch in meters.
+        object_id is 0 for every corner (matching the Charuco/Chessboard tracker
+        identity scheme: object_id=0, keypoint_id=corner index).
 
-        Corner ids come from `charuco.board.getChessboardCorners()`, the same
-        (N, 3) array CharucoTracker indexes by `keypoint_id`. Edges are found
-        by corner *coordinates*, not assumed index order — the same robust
-        pattern `Charuco.get_connected_points` uses — because OpenCV does not
-        guarantee any particular corner-id-to-grid-position layout.
+        Corners are located on the grid by rounding each coordinate to the
+        nearest multiple of spacing, so the layout is recovered from geometry
+        rather than assumed corner-id order — OpenCV does not guarantee any
+        particular charuco corner-id-to-grid-position layout. Points are emitted
+        as float32, so exact equality is unsafe; the rounding scales with board
+        size and tolerates float32 error (empirically up to ~1e-6 of a square)
+        with wide margin below the 0.5-square ambiguity band.
 
         Constraint density is a local truss (horizontal + vertical neighbor
         edges, both diagonals of every grid cell) plus 6 global braces among
@@ -233,16 +236,8 @@ class ConstraintSet:
         rows for a typical board) would add no rigidity information beyond
         what the truss + braces already pin down.
         """
-        corners = np.asarray(charuco.board.getChessboardCorners())
-        square_length = float(charuco.board.getSquareLength())
-
-        # Quantize by rounding each coordinate to the nearest multiple of
-        # square_length. OpenCV emits these as float32, so exact equality is
-        # unsafe; unlike a fixed absolute tolerance, this scales with board
-        # size and tolerates float32 error (empirically up to ~1e-6 of a
-        # square) with wide margin below the 0.5-square ambiguity band.
-        x_keys = np.round(corners[:, 0] / square_length).astype(np.int64)
-        y_keys = np.round(corners[:, 1] / square_length).astype(np.int64)
+        x_keys = np.round(corners[:, 0] / spacing).astype(np.int64)
+        y_keys = np.round(corners[:, 1] / spacing).astype(np.int64)
 
         edges: list[tuple[int, int]] = []
 
@@ -287,7 +282,7 @@ class ConstraintSet:
         ]
         edges.extend(combinations(extreme_corners, 2))
 
-        constraints = tuple(
+        return tuple(
             DistanceConstraint(
                 object_id_a=0,
                 keypoint_id_a=a,
@@ -299,6 +294,45 @@ class ConstraintSet:
             for a, b in edges
         )
 
+    @classmethod
+    def from_charuco(cls, charuco: Charuco, sigma_m: float = 0.002) -> ConstraintSet:
+        """Compile board-geometry distance constraints for BA.
+
+        object_id is 0 for every corner, matching CharucoTracker's identity
+        scheme (object_id=0, keypoint_id=chessboard corner index).
+        static_object_ids is empty — the board moves. Produces only
+        DistanceConstraints, never centroids (a charuco board has no separate
+        markers to link by centroid).
+
+        Corner ids come from `charuco.board.getChessboardCorners()`, the same
+        (N, 3) array CharucoTracker indexes by `keypoint_id`. Truss density and
+        the grid-from-coordinates recovery live in _truss_distance_constraints.
+        """
+        corners = np.asarray(charuco.board.getChessboardCorners())
+        square_length = float(charuco.board.getSquareLength())
+        constraints = cls._truss_distance_constraints(corners, square_length, sigma_m)
+        return cls(distances=constraints, static_object_ids=frozenset(), centroid_distances=())
+
+    @classmethod
+    def from_chessboard(cls, chessboard: Chessboard, sigma_m: float = 0.002) -> ConstraintSet:
+        """Compile board-geometry distance constraints from a metric chessboard.
+
+        object_id is 0 for every corner, matching ChessboardTracker's identity
+        scheme. static_object_ids is empty — the board moves. Same truss density
+        and rationale as from_charuco (see _truss_distance_constraints).
+
+        Requires chessboard.square_size_cm to be set: without it
+        get_object_points() returns unit-spacing points, and a unit-spacing
+        constraint set is a silent scale bug.
+        """
+        if chessboard.square_size_cm is None:
+            raise ValueError(
+                "from_chessboard requires square_size_cm to be set; a unit-spacing "
+                "constraint set would silently pin the wrong scale."
+            )
+        corners = chessboard.get_object_points()
+        spacing = chessboard.square_size_cm / 100
+        constraints = cls._truss_distance_constraints(corners, spacing, sigma_m)
         return cls(distances=constraints, static_object_ids=frozenset(), centroid_distances=())
 
     def to_toml(self, path: Path) -> None:

--- a/src/caliscope/synthetic/__init__.py
+++ b/src/caliscope/synthetic/__init__.py
@@ -35,10 +35,11 @@ from caliscope.synthetic.scene_factories import (
     sparse_coverage_scene,
     visibility_culling_scene,
 )
-from caliscope.synthetic.scene_factories import charuco_target_scene, machine_vision_scene
+from caliscope.synthetic.scene_factories import box_target_scene, charuco_target_scene, machine_vision_scene
 from caliscope.synthetic.se3_pose import SE3Pose
 from caliscope.synthetic.target_factories import (
     aruco_marker,
+    box_target,
     charuco_board,
     double_sided_charuco_board,
 )
@@ -56,6 +57,8 @@ __all__ = [
     "aruco_marker",
     "aruco_multi_object_scene",
     "aruco_scene",
+    "box_target",
+    "box_target_scene",
     "charuco_board",
     "charuco_target_scene",
     "IDEAL",

--- a/src/caliscope/synthetic/scene_factories.py
+++ b/src/caliscope/synthetic/scene_factories.py
@@ -10,7 +10,7 @@ from caliscope.core.point_data import ImagePoints
 from caliscope.synthetic.calibration_object import CalibrationObject
 from caliscope.synthetic.camera_synthesizer import CameraSynthesizer, MACHINE_VISION
 from caliscope.synthetic.outliers import OutlierConfig, inject_outliers
-from caliscope.synthetic.target_factories import double_sided_charuco_board
+from caliscope.synthetic.target_factories import box_target, double_sided_charuco_board
 from caliscope.synthetic.se3_pose import SE3Pose
 from caliscope.synthetic.synthetic_scene import SceneObject, SyntheticScene
 from caliscope.synthetic.trajectory import Trajectory
@@ -121,6 +121,35 @@ def charuco_target_scene(
     """4-camera ring with a double-sided charuco board (visible from both sides)."""
     camera_array = CameraSynthesizer().add_ring(n=4, radius=2.0, height=0.5).build()
     calibration_object = double_sided_charuco_board(rows=5, cols=7, square_size=0.05)
+    trajectory = Trajectory.orbital(
+        n_frames=20,
+        radius=0.2,
+        arc_extent_deg=360.0,
+        tumble_rate=1.0,
+    )
+
+    return SyntheticScene.single(
+        camera_array=camera_array,
+        calibration_object=calibration_object,
+        trajectory=trajectory,
+        pixel_noise_sigma=pixel_noise_sigma,
+        random_seed=random_seed,
+    )
+
+
+def box_target_scene(
+    pixel_noise_sigma: float = 0.5,
+    random_seed: int = 42,
+) -> SyntheticScene:
+    """4-camera ring with a non-planar box target (visible from all sides).
+
+    Same ring arrangement, frame count, and trajectory as default_ring_scene,
+    but the target is a 0.4m box (8 corners + 6 face centers). Its z spread
+    makes the bootstrap classify each view as non-planar and solve it with
+    SQPNP.
+    """
+    camera_array = CameraSynthesizer().add_ring(n=4, radius=2.0, height=0.5).build()
+    calibration_object = box_target(width=0.4, height=0.4, depth=0.4)
     trajectory = Trajectory.orbital(
         n_frames=20,
         radius=0.2,

--- a/src/caliscope/synthetic/target_factories.py
+++ b/src/caliscope/synthetic/target_factories.py
@@ -55,6 +55,34 @@ def double_sided_charuco_board(
     return charuco_board(rows, cols, square_size, single_sided=False)
 
 
+def box_target(width: float, height: float, depth: float) -> CalibrationObject:
+    """Non-planar target: 8 box corners plus 6 face centers, centered at origin.
+
+    14 genuinely non-coplanar points with no face_normal, so every camera sees
+    all of them. Exercises the bootstrap's non-planar (SQPNP) PnP path, which
+    the planar grid and charuco factories never reach.
+
+    Args:
+        width: Box extent along X (meters)
+        height: Box extent along Y (meters)
+        depth: Box extent along Z (meters)
+    """
+    half_width, half_height, half_depth = width / 2, height / 2, depth / 2
+    corners = [
+        [sx * half_width, sy * half_height, sz * half_depth] for sx in (-1, 1) for sy in (-1, 1) for sz in (-1, 1)
+    ]
+    face_centers = [
+        [-half_width, 0.0, 0.0],
+        [half_width, 0.0, 0.0],
+        [0.0, -half_height, 0.0],
+        [0.0, half_height, 0.0],
+        [0.0, 0.0, -half_depth],
+        [0.0, 0.0, half_depth],
+    ]
+    points = np.array(corners + face_centers, dtype=np.float64)
+    return CalibrationObject.from_points(points)
+
+
 def aruco_marker(
     size: float,
     *,

--- a/src/caliscope/trackers/chessboard_tracker.py
+++ b/src/caliscope/trackers/chessboard_tracker.py
@@ -1,7 +1,11 @@
 """
-Chessboard corner tracker for intrinsic calibration.
+Chessboard corner tracker.
 
-Uses OpenCV's findChessboardCorners with sub-pixel refinement.
+Uses OpenCV's findChessboardCorners with sub-pixel refinement. Serves
+intrinsic calibration always; when its Chessboard carries a square_size_cm the
+emitted obj_loc is metric, so the same tracker also drives extrinsic
+calibration (the Calibration Target Interchangeability contract).
+
 Unlike CharucoTracker, there is no mirror search — chessboard patterns
 don't need it for intrinsic calibration (frames without detection are skipped).
 """

--- a/src/caliscope/trackers/chessboard_tracker.py
+++ b/src/caliscope/trackers/chessboard_tracker.py
@@ -22,6 +22,26 @@ from caliscope.tracker import Tracker
 logger = logging.getLogger(__name__)
 
 
+def _subpix_window_half_width(corners_row_major: np.ndarray, columns: int, rows: int) -> int:
+    """Sub-pixel search-window half-width derived from detected corner pitch.
+
+    corners_row_major is the raw findChessboardCorners output (shape (N, 1, 2)
+    or (N, 2)), row-major in (columns, rows) order. A window wider than ~a
+    quarter of the corner pitch drags corners toward neighbors: on OpenCap Cam0
+    (16 px squares) the fixed 11 px window inflated the planar-homography
+    residual to 4-8 px vs 0.12 px at a 5 px window. The pitch is the min over
+    both horizontal and vertical neighbors — perspective foreshortening (camera
+    well off the board plane) can make the smallest pitch vertical. Half-width =
+    clamp(floor(min_neighbor_px / 4), 2, 11); 11 stays the large-board ceiling
+    so GUI-scale boards are unchanged.
+    """
+    grid = corners_row_major.reshape(rows, columns, 2)
+    horizontal_px = np.linalg.norm(np.diff(grid, axis=1), axis=2)
+    vertical_px = np.linalg.norm(np.diff(grid, axis=0), axis=2)
+    min_neighbor_px = float(min(horizontal_px.min(), vertical_px.min()))
+    return int(np.clip(np.floor(min_neighbor_px / 4), 2, 11))
+
+
 class ChessboardTracker(Tracker):
     """
     Tracker for chessboard calibration patterns.
@@ -51,7 +71,8 @@ class ChessboardTracker(Tracker):
             30,  # max iterations
             0.001,  # epsilon (corner movement threshold)
         )
-        self._win_size = (11, 11)  # Search window for sub-pixel refinement
+        # Sub-pixel search window is derived per frame from the detected
+        # corner pitch (see _subpix_window_half_width), not fixed.
 
     @property
     def name(self) -> str:
@@ -77,11 +98,12 @@ class ChessboardTracker(Tracker):
                 obj_loc=np.empty((0, 3), dtype=np.float32),
             )
 
-        # Sub-pixel corner refinement
+        # Sub-pixel corner refinement, window scaled to the board's frame size
+        half_width = _subpix_window_half_width(corners, self.chessboard.columns, self.chessboard.rows)
         corners_refined = cv2.cornerSubPix(
             gray,
             corners,
-            self._win_size,
+            (half_width, half_width),
             (-1, -1),  # zero zone (no dead zone)
             self._criteria,
         )

--- a/tests/synthetic/test_nonplanar_pnp.py
+++ b/tests/synthetic/test_nonplanar_pnp.py
@@ -1,0 +1,112 @@
+"""Non-planar bootstrap coverage: box target end-to-end and PnP dispatch.
+
+The planar grid and charuco factories never reach the bootstrap's non-planar
+(SQPNP) branch. These tests drive a genuinely 3D target (box_target) through
+the same bootstrap + optimize path the planar scenes use, and check the
+point-count dispatch of compute_camera_to_object_poses_pnp directly.
+
+Tolerances are derived, not tuned. A failure is a finding, not a prompt to
+relax the bound.
+"""
+
+from __future__ import annotations
+
+import cv2
+import numpy as np
+import pandas as pd
+
+from caliscope.cameras.camera_array import CameraArray, CameraData
+from caliscope.core.bootstrap_pose.pose_network_builder import compute_camera_to_object_poses_pnp
+from caliscope.core.capture_volume import CaptureVolume
+from caliscope.core.point_data import ImagePoints
+from caliscope.synthetic.scene_factories import box_target_scene
+from tests.synthetic.assertions import align_to_ground_truth, pose_error
+
+
+class TestNonPlanarBootstrap:
+    def test_pose_recovery(self) -> None:
+        # 1.0 deg / 10mm. box_target_scene is the default 4-cam ring (radius
+        # 2.0, height 0.5), 20 frames, 0.5px sigma — identical geometry to
+        # default_ring_scene, which is bounded at 0.5 deg / 5mm by covariance
+        # propagation (tests/synthetic/README.md). The box carries 14 points
+        # against the grid's 35, so pose std scales by the covariance geometry
+        # factor sqrt(N_grid / N_box) = sqrt(35 / 14) ~ 1.58, giving 5mm x 1.58
+        # ~ 8mm; rounded up to the README's generic geometry-factor envelope
+        # (GEOMETRY_FACTOR 20 x 0.5px = 10mm). Rotation pairs at 1.0 deg,
+        # following the suite's convention that a 10mm translation bound carries
+        # a 1.0 deg rotation bound (TestOutlierProduction). Measured worst across
+        # seeds 42/7/99/123/2024: 0.068 deg / 1.95mm.
+        scene = box_target_scene()
+        cv = CaptureVolume.bootstrap(scene.image_points_noisy, scene.intrinsics_only_cameras())
+        optimized = cv.optimize()
+        status = optimized.optimization_status
+        assert status is not None and status.converged
+
+        aligned = align_to_ground_truth(optimized, scene)
+        for cam_id in scene.camera_array.cameras:
+            err = pose_error(aligned.camera_array.cameras[cam_id], scene.camera_array.cameras[cam_id])
+            assert err.rotation_deg < 1.0, f"cam {cam_id}: rotation {err.rotation_deg:.3f} deg > 1.0 deg"
+            assert err.translation_m < 0.010, f"cam {cam_id}: translation {err.translation_m * 1000:.2f} mm > 10 mm"
+
+
+def _non_planar_group_image_points(num_points: int) -> tuple[ImagePoints, CameraArray]:
+    """One camera viewing num_points non-coplanar points at a known pose.
+
+    Projects the points through the camera to get exact img_loc, so a valid
+    solve is available when the point count clears the non-planar floor.
+    """
+    matrix = np.array([[600.0, 0.0, 320.0], [0.0, 600.0, 240.0], [0.0, 0.0, 1.0]])
+    camera = CameraData(cam_id=0, size=(640, 480), matrix=matrix, distortions=np.zeros(5))
+    camera_array = CameraArray(cameras={0: camera})
+
+    obj_points = np.array(
+        [
+            [0.00, 0.00, 0.00],
+            [0.10, 0.00, 0.02],
+            [0.00, 0.10, 0.04],
+            [0.10, 0.10, 0.06],
+            [0.05, 0.05, 0.10],
+            [0.02, 0.08, 0.08],
+        ]
+    )[:num_points]
+
+    img_points, _ = cv2.projectPoints(obj_points, np.zeros(3), np.array([0.0, 0.0, 1.0]), matrix, np.zeros(5))
+    img_points = img_points.reshape(-1, 2)
+
+    df = pd.DataFrame(
+        {
+            "sync_index": 0,
+            "cam_id": 0,
+            "object_id": 0,
+            "keypoint_id": np.arange(num_points),
+            "img_loc_x": img_points[:, 0],
+            "img_loc_y": img_points[:, 1],
+            "obj_loc_x": obj_points[:, 0],
+            "obj_loc_y": obj_points[:, 1],
+            "obj_loc_z": obj_points[:, 2],
+        }
+    )
+    return ImagePoints(df), camera_array
+
+
+class TestNonPlanarDispatch:
+    def test_five_points_below_floor_returns_no_pose(self) -> None:
+        # A non-planar group of 5 points sits below the non-planar minimum of 6,
+        # so no pose is returned for it.
+        image_points, camera_array = _non_planar_group_image_points(num_points=5)
+        poses = compute_camera_to_object_poses_pnp(image_points, camera_array)
+        assert (0, 0, 0) not in poses
+
+    def test_six_points_at_floor_returns_a_pose(self) -> None:
+        # Six non-coplanar points clear the floor and SQPNP solves the group.
+        image_points, camera_array = _non_planar_group_image_points(num_points=6)
+        poses = compute_camera_to_object_poses_pnp(image_points, camera_array)
+        assert (0, 0, 0) in poses
+
+
+if __name__ == "__main__":
+    TestNonPlanarBootstrap().test_pose_recovery()
+    print("  nonplanar bootstrap pose_recovery: PASSED")
+    TestNonPlanarDispatch().test_five_points_below_floor_returns_no_pose()
+    TestNonPlanarDispatch().test_six_points_at_floor_returns_a_pose()
+    print("  nonplanar dispatch: PASSED")

--- a/tests/test_chessboard.py
+++ b/tests/test_chessboard.py
@@ -14,7 +14,39 @@ import pytest
 
 from caliscope.core.chessboard import Chessboard
 from caliscope.persistence import PersistenceError
-from caliscope.trackers.chessboard_tracker import ChessboardTracker
+from caliscope.trackers.chessboard_tracker import ChessboardTracker, _subpix_window_half_width
+
+
+def _row_major_grid(columns: int, rows: int, pitch_px: float) -> np.ndarray:
+    """Synthetic raw findChessboardCorners output: (N, 1, 2), row-major."""
+    xs, ys = np.meshgrid(np.arange(columns) * pitch_px, np.arange(rows) * pitch_px)
+    return np.stack([xs.ravel(), ys.ravel()], axis=1).reshape(-1, 1, 2).astype(np.float32)
+
+
+def test_subpix_window_small_board_shrinks():
+    """A 16 px-pitch board (OpenCap scale) gets a 4 px half-window, not 11.
+
+    Measured on OpenCap Cam0: the fixed 11 px window inflated the homography
+    residual to 4-8 px; floor(16 / 4) = 4 px keeps it near 0.1 px.
+    """
+    corners = _row_major_grid(columns=9, rows=6, pitch_px=16.0)
+    assert _subpix_window_half_width(corners, columns=9, rows=6) == 4
+
+
+def test_subpix_window_large_board_hits_ceiling():
+    """GUI-scale board (60 px pitch) clamps to the old 11 px ceiling — unchanged."""
+    corners = _row_major_grid(columns=9, rows=6, pitch_px=60.0)
+    assert _subpix_window_half_width(corners, columns=9, rows=6) == 11
+
+
+def test_subpix_window_uses_min_over_both_axes():
+    """Vertical foreshortening drives the window: a board wide in X but squashed
+    in Y (12 px vertical pitch) must pick the vertical minimum, not the 60 px
+    horizontal pitch.
+    """
+    xs, ys = np.meshgrid(np.arange(9) * 60.0, np.arange(6) * 12.0)
+    corners = np.stack([xs.ravel(), ys.ravel()], axis=1).reshape(-1, 1, 2).astype(np.float32)
+    assert _subpix_window_half_width(corners, columns=9, rows=6) == 3  # floor(12 / 4)
 
 
 # ── Dataclass ────────────────────────────────────────────────────────────────

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1213,3 +1213,40 @@ def test_from_charuco_object_ids_all_zero_and_no_centroids():
     assert all(d.object_id_a == 0 and d.object_id_b == 0 for d in cs.distances)
     assert cs.static_object_ids == frozenset()
     assert cs.centroid_distances == ()
+
+
+# -- ConstraintSet.from_chessboard --
+
+
+def test_from_chessboard_requires_square_size():
+    """Without a square size the object points are unit-spacing, which would
+    pin the wrong scale — from_chessboard must refuse it.
+    """
+    from caliscope.core.chessboard import Chessboard
+
+    with pytest.raises(ValueError, match="square_size_cm"):
+        ConstraintSet.from_chessboard(Chessboard(rows=4, columns=6))
+
+
+def test_from_chessboard_metric_truss():
+    """A 4x6-corner metric chessboard yields the same truss+brace count as the
+    charuco path, with neighbor distances equal to the square size in meters,
+    object_id 0 everywhere, no statics, and no centroids.
+    """
+    from caliscope.core.chessboard import Chessboard
+
+    n_rows, n_cols = 4, 6  # both >= 3, so braces don't alias truss edges
+    square_size_cm = 5.0
+    cb = Chessboard(rows=n_rows, columns=n_cols, square_size_cm=square_size_cm)
+    cs = ConstraintSet.from_chessboard(cb)
+
+    expected = n_rows * (n_cols - 1) + (n_rows - 1) * n_cols + 2 * (n_rows - 1) * (n_cols - 1) + 6
+    assert len(cs.distances) == expected
+
+    square_size_m = square_size_cm / 100
+    neighbor_distances = [d.distance for d in cs.distances if d.distance == pytest.approx(square_size_m, abs=1e-6)]
+    assert len(neighbor_distances) > 0
+
+    assert all(d.object_id_a == 0 and d.object_id_b == 0 for d in cs.distances)
+    assert cs.static_object_ids == frozenset()
+    assert cs.centroid_distances == ()


### PR DESCRIPTION
## Summary
- **Non-planar PnP in the bootstrap** (`compute_camera_to_object_poses_pnp`): reads `obj_loc_z` (NaN→0, matching every other geometry consumer) and classifies each (cam_id, sync_index, object_id) group by z spread. Planar groups keep the exact IPPE/ITERATIVE path with the existing 4-point floor; non-planar groups use SOLVEPNP_SQPNP with an ITERATIVE fallback and a 6-point floor (ITERATIVE's DLT init needs >= 6 non-coplanar points). This was the last geometry consumer that dropped z, and it unblocks body-as-calibration-target work where the object is a human skeleton.
- **Metric Chessboard**: optional `square_size_cm` field (same name and cm unit as Charuco); `get_object_points()` scales to meters when set, unit spacing otherwise. The legacy from_toml strip of `square_size_cm` is removed — the field is live again. With a square size, the plain chessboard now drives extrinsic calibration, not just intrinsics.
- **`ConstraintSet.from_chessboard`**: truss construction (neighbor edges + cell diagonals + extreme-corner braces) extracted from `from_charuco` into a shared helper keyed on grid spacing; `from_charuco` output unchanged. Raises without `square_size_cm` (a unit-spacing constraint set is a silent scale bug).
- **Adaptive chessboard sub-pixel window**: the fixed 11 px cornerSubPix window spans more than one square when the board is small in frame and drags corners toward neighbors (measured on OpenCap: 0.3-0.6 px raw → 4-8 px refined at 16 px squares). Half-width is now clamp(floor(min_neighbor_px / 4), 2, 11) over both grid axes, with 11 kept as the large-board ceiling so GUI-scale boards are unchanged.
- **Synthetic non-planar coverage**: `box_target` (8 corners + 6 face centers, genuinely non-coplanar) and `box_target_scene`; end-to-end bootstrap + optimize recovers poses at 0.07 deg / 2 mm worst-case across seeds against a derived 1.0 deg / 10 mm tolerance (derivation in the test comment).

## Validation on real footage
Calibrated the OpenCap LabValidation checkerboard videos (5 iPhones, 11x8 board, 60 mm squares, static board) and compared against OpenCap's own per-camera PnP calibration on gauge-free pairwise relative poses: worst well-conditioned pair 0.24 deg / 1.4 cm at 0.43 px RMSE (script lives in the monokin repo, mprib/monokin#23, since this repo gitignores new `scripts/` entries).

## Test plan
- Full suite: 658 passed, 0 failed.
- New: box-target bootstrap end-to-end, PnP point-floor dispatch, from_chessboard construction + rejection, adaptive-window derivation (horizontal and vertical pitch).
- Planar path byte-identical: existing bootstrap/synthetic/constraint suites pass unchanged.