### PR TITLE
Markerless calibration: epipolar bootstrap and metric anchoring

### DIFF
--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -114,8 +114,8 @@ This prints a lower-triangle grid of shared observation counts and flags structu
 
 ```python
 constraints = ConstraintSet.from_charuco(charuco)
-result = calibrate_extrinsics(ext_points, cameras, constraints)
-volume = result.capture_volume
+run = calibrate_extrinsics(ext_points, cameras, constraints)
+volume = run.capture_volume
 ```
 
 The constraints feed the board's known corner geometry into bundle adjustment as rigidity information, which stabilizes the solution and locks world scale.
@@ -127,16 +127,17 @@ Two keyword arguments matter most:
   Refinement is subject to the [depth-ratio gate](extrinsic_calibration_reference.md#the-depth-ratio-gate): if any camera saw the target over too narrow a depth range, refinement is disabled for the whole rig.
 - `filter_percentile` (default `2.5`): the worst percentage of observations removed per camera between the two optimization passes.
 
-The returned `ExtrinsicCalibrationResult` carries the calibrated volume plus diagnostics:
+The returned `CalibrationRun` carries the calibrated volume plus diagnostics:
 
 ```python
-result.capture_volume              # the calibrated CaptureVolume
-result.intrinsic_refinement_gated  # True if refinement was requested but gated off
-result.depth_ratios                # per-camera near/far depth ratios
-result.synthesized_cam_ids         # cameras whose intrinsics started from a blind guess
-result.intrinsic_estimates         # initial vs recovered f, k1, k2 per camera
-result.dropped_static_markers      # static markers excluded for moving (ArUco path)
+run.capture_volume              # the calibrated CaptureVolume
+run.intrinsic_refinement_gated  # True if refinement was requested but gated off
+run.synthesized_cam_ids         # cameras whose intrinsics started from a blind guess
+run.intrinsic_estimates         # initial vs recovered f, k1, k2 per camera
+run.dropped_static_markers      # static markers excluded for moving (ArUco path)
 ```
+
+Per-camera near/far depth ratios are available via `compute_depth_ratios(run.capture_volume)` (`from caliscope.core.scale_accuracy import compute_depth_ratios`).
 
 Check `intrinsic_refinement_gated` when you expected refinement: a `True` here with poor results usually means the target was not moved toward and away from the cameras enough.
 

--- a/src/caliscope/api.py
+++ b/src/caliscope/api.py
@@ -48,6 +48,7 @@ from caliscope.core.calibrate_intrinsics import (
 from caliscope.core.capture_volume import CaptureVolume
 from caliscope.core.charuco import Charuco
 from caliscope.core.point_data import ImagePoints
+from caliscope.core.scale_cues import CameraDistance, DepthObservation, SegmentLength
 from caliscope.exceptions import CalibrationError
 from caliscope.tracker import Tracker
 from caliscope.trackers.charuco_tracker import CharucoTracker
@@ -86,6 +87,10 @@ __all__ = [
     "CameraArray",
     "ImagePoints",
     "CaptureVolume",
+    # Scale cues
+    "CameraDistance",
+    "SegmentLength",
+    "DepthObservation",
     # Result types
     "IntrinsicCalibrationOutput",
     "IntrinsicCalibrationReport",

--- a/src/caliscope/api.py
+++ b/src/caliscope/api.py
@@ -47,6 +47,8 @@ from caliscope.core.calibrate_intrinsics import (
 )
 from caliscope.core.capture_volume import CaptureVolume
 from caliscope.core.charuco import Charuco
+from caliscope.estimators.moge import MoGeResult, run_moge
+from caliscope.estimators.vertical import VerticalEstimate, estimate_vertical
 from caliscope.core.point_data import ImagePoints
 from caliscope.core.scale_cues import CameraDistance, DepthObservation, SegmentLength
 from caliscope.exceptions import CalibrationError
@@ -95,11 +97,15 @@ __all__ = [
     "IntrinsicCalibrationOutput",
     "IntrinsicCalibrationReport",
     "CalibrationRun",
+    "MoGeResult",
+    "VerticalEstimate",
     # Functions
     "extract_image_points",
     "extract_image_points_multicam",
     "calibrate_intrinsics",
     "calibrate_extrinsics",
+    "run_moge",
+    "estimate_vertical",
     # Exceptions
     "CalibrationError",
 ]

--- a/src/caliscope/api.py
+++ b/src/caliscope/api.py
@@ -21,8 +21,8 @@ Quick start (pre-calibrated cameras):
 Or use the one-call extrinsic calibration pipeline (synthesizes blind
 intrinsics for uncalibrated cameras, runs joint BA with intrinsic recovery):
 
-    result = calibrate_extrinsics(points, cameras, constraints)
-    result.capture_volume.save("capture_volume")
+    run = calibrate_extrinsics(points, cameras, constraints)
+    run.capture_volume.save("capture_volume")
 
 Pass ``progress=None`` to any extraction function to suppress progress output.
 
@@ -38,7 +38,7 @@ from typing import TYPE_CHECKING, Any, Generator
 
 from caliscope.cameras.camera_array import CameraArray, CameraData
 from caliscope.core.calibrate_extrinsics import (
-    ExtrinsicCalibrationResult,
+    CalibrationRun,
     calibrate_extrinsics,
 )
 from caliscope.core.calibrate_intrinsics import (
@@ -89,7 +89,7 @@ __all__ = [
     # Result types
     "IntrinsicCalibrationOutput",
     "IntrinsicCalibrationReport",
-    "ExtrinsicCalibrationResult",
+    "CalibrationRun",
     # Functions
     "extract_image_points",
     "extract_image_points_multicam",

--- a/src/caliscope/cameras/camera_array.py
+++ b/src/caliscope/cameras/camera_array.py
@@ -340,6 +340,38 @@ class CameraArray:
         return cls(cameras)
 
     @classmethod
+    def from_focal_estimates(cls, focal_per_cam: dict[int, float], videos: Mapping[int, Path | str]) -> CameraArray:
+        """Build a CameraArray with intrinsics from per-camera focal estimates.
+
+        Each camera gets a pinhole matrix ``[[f, 0, cx], [0, f, cy], [0, 0, 1]]``
+        with the principal point at the image center and zero distortion; no
+        extrinsics are set. Image dimensions come from the video metadata. The
+        focal estimates typically come from ``run_moge`` (MoGeResult.focal_per_cam).
+        """
+        from caliscope.recording.video_utils import read_video_properties
+
+        cameras = {}
+        for cam_id, focal in focal_per_cam.items():
+            if cam_id not in videos:
+                raise ValueError(f"No video provided for cam_id {cam_id} in focal_per_cam.")
+            props = read_video_properties(Path(videos[cam_id]))
+            width, height = props["width"], props["height"]
+            matrix = np.array(
+                [
+                    [focal, 0.0, width / 2.0],
+                    [0.0, focal, height / 2.0],
+                    [0.0, 0.0, 1.0],
+                ]
+            )
+            cameras[cam_id] = CameraData(
+                cam_id=cam_id,
+                size=(width, height),
+                matrix=matrix,
+                distortions=np.zeros(5),
+            )
+        return cls(cameras)
+
+    @classmethod
     def from_image_sizes(cls, sizes: dict[int, tuple[int, int]]) -> CameraArray:
         """Create uncalibrated CameraArray from known image sizes.
 

--- a/src/caliscope/core/bootstrap_pose/build_paired_pose_network.py
+++ b/src/caliscope/core/bootstrap_pose/build_paired_pose_network.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import logging
 
 from caliscope.cameras.camera_array import CameraArray
+from caliscope.core.bootstrap_pose.epipolar_pose_builder import build_epipolar_pose_network
 from caliscope.core.bootstrap_pose.paired_pose_network import PairedPoseNetwork
-from caliscope.core.point_data import ImagePoints
 from caliscope.core.bootstrap_pose.pose_network_builder import PoseNetworkBuilder
+from caliscope.core.point_data import ImagePoints
 
 logger = logging.getLogger(__name__)
 
@@ -14,5 +15,17 @@ def build_paired_pose_network(
     image_points: ImagePoints,
     camera_array: CameraArray,
 ) -> PairedPoseNetwork:
+    """Build the stereo-pair pose graph, selecting the strategy from the data.
+
+    With known object geometry (obj_loc populated) the PnP path resections each
+    camera against the calibration target. With 2D-only observations (obj_loc all
+    NaN -- e.g. body keypoints) the essential-matrix path recovers relative poses
+    from 2D-2D correspondences. Both return a PairedPoseNetwork.
+    """
+    obj_cols = image_points.df[["obj_loc_x", "obj_loc_y", "obj_loc_z"]]
+    if obj_cols.isna().all().all():
+        logger.info("No object geometry (obj_loc all NaN); using epipolar bootstrap.")
+        return build_epipolar_pose_network(image_points, camera_array)
+
     builder = PoseNetworkBuilder(camera_array, image_points)
     return builder.estimate_camera_to_object_poses().estimate_relative_poses().filter_outliers(threshold=1.5).build()

--- a/src/caliscope/core/bootstrap_pose/epipolar_pose_builder.py
+++ b/src/caliscope/core/bootstrap_pose/epipolar_pose_builder.py
@@ -1,0 +1,390 @@
+"""Essential-matrix bootstrap for 2D-only observations (no object geometry).
+
+The PnP path (pose_network_builder) needs each observation's known 3D object
+location (obj_loc) to resection a camera against the calibration target. Body
+keypoints carry no such geometry -- the person is the moving "target", and only
+its 2D projections are known. This module recovers the extrinsic rig from those
+2D-2D correspondences alone via the essential matrix, producing a result correct
+up to a 7-DOF similarity transform (arbitrary scale, rotation, translation),
+ready for bundle adjustment.
+
+Ported from monokin's rig_calibration.py (validated on Pose2Sim), adapted to
+caliscope's ImagePoints / CameraArray types. The numerics and RANSAC behavior
+are monokin's; the data plumbing is caliscope's.
+
+Composition (the pairwise-scale problem). Each essential pair is metric only up
+to its own unknown baseline, so pairwise poses cannot simply be chained.
+Instead one pair (the SCAFFOLD) is triangulated into a single 3D cloud in the
+anchor camera's frame, and every other camera is registered to that one cloud by
+resection. This yields a globally consistent rig in one shot, no loop closure --
+cameras that share no frames with each other still both see the cloud.
+
+Coplanarity (the multi-frame requirement and the scaffold guard). Body keypoints
+at capture distance have a depth-to-baseline ratio near the coplanarity
+degeneracy for essential estimation. pooled_correspondences pools each pair's
+matches across every shared frame, where the subject has moved, so the pooled 3D
+points span a volume rather than a plane. Near the degeneracy the essential
+estimate can still flip to a wrong-but-self-consistent solution that cheirality
+alone accepts, so the scaffold is not chosen by cheirality: each candidate is
+validated by how well its cloud explains the *other* cameras (resection
+reprojection error), the classic third-view disambiguation. A per-pair E
+singular-value ratio is logged as a weak conditioning hint (findEssentialMat
+always returns a (sigma, sigma, 0) matrix, so it rarely fires); the third-view
+resection score is the operative degeneracy guard.
+
+Intrinsics precondition: the essential decomposition has no obj_loc anchor to
+absorb focal error, so it requires real calibrated intrinsics. The blind
+`f = width/2` fallback is geometrically fatal here; calibrate_extrinsics gates
+on this before ever reaching the bootstrap.
+"""
+
+from __future__ import annotations
+
+import logging
+from itertools import combinations
+
+import cv2
+import numpy as np
+import pandas as pd
+from numpy.typing import NDArray
+
+from caliscope.cameras.camera_array import CameraArray, CameraData
+from caliscope.core.bootstrap_pose.paired_pose_network import PairedPoseNetwork
+from caliscope.core.bootstrap_pose.pose_network_builder import estimate_pnp_paired_pose_network
+from caliscope.core.bootstrap_pose.stereopairs import StereoPair
+from caliscope.core.point_data import ImagePoints
+
+logger = logging.getLogger(__name__)
+
+RANSAC_THRESHOLD_PX = 3.0  # essential-matrix inlier gate, pixels (converted to normalized units per camera)
+RANSAC_PROB = 0.999
+MIN_RESECTION_POINTS = 50  # cloud points a camera must share to be resectioned
+MIN_CORRESPONDENCES = 8  # an essential matrix needs 8 point correspondences
+CONDITIONING_FLOOR = 0.5  # E singular-value ratio below this flags a near-degenerate (coplanar) pair
+MAX_SCAFFOLD_CANDIDATES = 12  # cap third-view validation cost on large rigs (correct scaffolds rank high by cheirality)
+
+
+def pooled_correspondences(df_a: pd.DataFrame, df_b: pd.DataFrame) -> tuple[NDArray, NDArray, NDArray]:
+    """Matched observation pixels for one camera pair, pooled over every shared frame.
+
+    A correspondence is a single (object_id, keypoint_id) seen at the same
+    sync_index by both cameras -- one 3D point at one instant viewed by two
+    static cameras, a valid epipolar correspondence. Pooling across frames (as
+    the subject moves) just adds points, which is what breaks the coplanarity
+    degeneracy. Non-finite pixels drop out: a correspondence needs both views.
+
+    Returns (keys, pixels_a, pixels_b): keys is (N, 3) int
+    [object_id, keypoint_id, sync_index]; pixels_a/pixels_b are (N, 2) pixel
+    coordinates in cameras a and b, row-aligned with keys.
+    """
+    merged = pd.merge(
+        df_a,
+        df_b,
+        on=["sync_index", "object_id", "keypoint_id"],
+        suffixes=("_a", "_b"),
+    )
+    if merged.empty:
+        return np.empty((0, 3), dtype=np.int64), np.empty((0, 2)), np.empty((0, 2))
+
+    keys = merged[["object_id", "keypoint_id", "sync_index"]].to_numpy(dtype=np.int64)
+    pix_a = merged[["img_loc_x_a", "img_loc_y_a"]].to_numpy(dtype=np.float64)
+    pix_b = merged[["img_loc_x_b", "img_loc_y_b"]].to_numpy(dtype=np.float64)
+
+    finite = np.isfinite(pix_a).all(axis=1) & np.isfinite(pix_b).all(axis=1)
+    return keys[finite], pix_a[finite], pix_b[finite]
+
+
+def _essential_conditioning(essential: NDArray) -> float:
+    """Ratio of the two largest singular values of E; ~1.0 when well-conditioned.
+
+    An ideal essential matrix has singular values (sigma, sigma, 0). The ratio
+    of the second to the first drops toward 0 as the point cloud approaches
+    coplanarity and the estimate becomes ambiguous.
+    """
+    singular_values = np.linalg.svd(essential, compute_uv=False)
+    if singular_values[0] < 1e-12:
+        return 0.0
+    return float(singular_values[1] / singular_values[0])
+
+
+def recover_pair_pose(pixels_a: NDArray, pixels_b: NDArray, *, camera_a: CameraData, camera_b: CameraData) -> dict:
+    """Essential-matrix relative pose of camera b w.r.t. camera a from matched pixels.
+
+    Normalizes each camera's pixels through its own intrinsics (removing lens
+    distortion), runs findEssentialMat (RANSAC) then recoverPose. Returns
+    rotation (b's world-to-camera when a is the world origin), unit translation,
+    the inlier statistics, the E conditioning ratio, and the normalized inlier
+    points (kept so the scaffold pair can be triangulated without renormalizing).
+
+    Raises:
+        ValueError: if essential-matrix estimation fails or is degenerate.
+    """
+    assert camera_a.matrix is not None and camera_b.matrix is not None
+    norm_a = camera_a.undistort_points(pixels_a, output="normalized").astype(np.float64)
+    norm_b = camera_b.undistort_points(pixels_b, output="normalized").astype(np.float64)
+
+    # One shared threshold from the mean focal assumes the two focals are near-equal.
+    mean_focal = 0.5 * (camera_a.matrix[0, 0] + camera_b.matrix[0, 0])
+    threshold = RANSAC_THRESHOLD_PX / mean_focal  # normalized units
+
+    essential, mask = cv2.findEssentialMat(
+        norm_a,
+        norm_b,
+        cameraMatrix=np.eye(3),
+        method=cv2.RANSAC,
+        prob=RANSAC_PROB,
+        threshold=threshold,
+    )
+    if essential is None or essential.shape != (3, 3):
+        # findEssentialMat returns None on failure and a (3N, 3) stack of
+        # candidate solutions on degenerate input; neither can be recovered.
+        raise ValueError(
+            "essential-matrix estimation failed or was degenerate "
+            f"(got {'None' if essential is None else essential.shape})"
+        )
+    conditioning = _essential_conditioning(essential)
+    mask = mask.ravel().astype(bool)
+    _, rotation, translation, pose_mask = cv2.recoverPose(essential, norm_a[mask], norm_b[mask], cameraMatrix=np.eye(3))
+    pose_mask = pose_mask.ravel().astype(bool)
+    inlier_index = np.flatnonzero(mask)[pose_mask]  # rows of the original arrays kept by both stages
+    return {
+        "rotation": rotation,
+        "translation": translation.ravel(),
+        "inlier_fraction": float(mask.sum() / len(mask)),
+        "n_inliers": int(mask.sum()),
+        "n_total": int(len(mask)),
+        "cheirality_inliers": int(pose_mask.sum()),
+        "conditioning": conditioning,
+        "norm_a": norm_a,
+        "norm_b": norm_b,
+        "inlier_index": inlier_index,
+    }
+
+
+def triangulate_scaffold(pair_pose: dict, keys: NDArray) -> dict[tuple[int, int, int], NDArray]:
+    """3D cloud from the scaffold pair, in camera a's (== world) frame at baseline 1.
+
+    Triangulates the pair's cheirality-inlier normalized points with P_a = [I|0],
+    P_b = [R|t]. Returns {(object_id, keypoint_id, sync_index): xyz} -- the anchor
+    the other cameras resection against.
+    """
+    index = pair_pose["inlier_index"]
+    norm_a = pair_pose["norm_a"][index]
+    norm_b = pair_pose["norm_b"][index]
+    projection_a = np.hstack([np.eye(3), np.zeros((3, 1))])
+    projection_b = np.hstack([pair_pose["rotation"], pair_pose["translation"].reshape(3, 1)])
+    homogeneous = cv2.triangulatePoints(projection_a, projection_b, norm_a.T, norm_b.T)
+    weights = homogeneous[3]
+    finite = np.abs(weights) > 1e-12  # w ~ 0: point at infinity, unusable 3D
+    points = (homogeneous[:3, finite] / weights[finite]).T
+    return {(int(keys[i, 0]), int(keys[i, 1]), int(keys[i, 2])): points[j] for j, i in enumerate(index[finite])}
+
+
+def resection_camera(
+    cloud: dict[tuple[int, int, int], NDArray],
+    df_cam: pd.DataFrame,
+    camera: CameraData,
+) -> tuple[NDArray, NDArray, int, float]:
+    """World-to-camera pose of one camera by resection against the scaffold cloud.
+
+    Gathers cloud points whose (object_id, keypoint_id, sync_index) this camera
+    also observed with a finite pixel, then solvePnPRansac against its normalized
+    pixels (K = identity). The cloud's 3D is pure 2D-2D triangulation, so no
+    external depth enters the pose. The returned median reprojection error (in
+    normalized units, over every matched point) measures how well this third view
+    agrees with the cloud -- the signal that discriminates a correct scaffold from
+    a geometrically wrong (twisted-pair) one.
+
+    Raises:
+        ValueError: if fewer than MIN_RESECTION_POINTS shared points exist, or
+            solvePnPRansac fails.
+    """
+    assert camera.matrix is not None
+    if not cloud:
+        raise ValueError("scaffold cloud is empty")
+
+    cloud_df = pd.DataFrame(
+        [(o, k, s, xyz[0], xyz[1], xyz[2]) for (o, k, s), xyz in cloud.items()],
+        columns=["object_id", "keypoint_id", "sync_index", "X", "Y", "Z"],
+    )
+    merged = pd.merge(df_cam, cloud_df, on=["object_id", "keypoint_id", "sync_index"])
+    pixels = merged[["img_loc_x", "img_loc_y"]].to_numpy(dtype=np.float64)
+    finite = np.isfinite(pixels).all(axis=1)
+    merged, pixels = merged[finite], pixels[finite]
+
+    if len(merged) < MIN_RESECTION_POINTS:
+        raise ValueError(f"only {len(merged)} cloud points to resection against")
+
+    object_points = merged[["X", "Y", "Z"]].to_numpy(dtype=np.float64)
+    normalized = camera.undistort_points(pixels, output="normalized").astype(np.float64)
+    ok, rvec, tvec, _ = cv2.solvePnPRansac(
+        object_points,
+        normalized,
+        np.eye(3),
+        None,
+        reprojectionError=RANSAC_THRESHOLD_PX / camera.matrix[0, 0],
+        iterationsCount=200,
+        flags=cv2.SOLVEPNP_ITERATIVE,
+    )
+    if not ok:
+        raise ValueError("solvePnPRansac failed")
+    rotation, _ = cv2.Rodrigues(rvec)
+    projected, _ = cv2.projectPoints(object_points, rvec, tvec, np.eye(3), np.zeros(5))
+    reproj_error = float(np.median(np.linalg.norm(normalized - projected.reshape(-1, 2), axis=1)))
+    return rotation, tvec.ravel(), len(object_points), reproj_error
+
+
+def _assemble_from_scaffold(
+    scaffold_pair: tuple[int, int],
+    scaffold_pose: dict,
+    scaffold_keys: NDArray,
+    cam_ids: list[int],
+    per_cam: dict[int, pd.DataFrame],
+    camera_array: CameraArray,
+) -> tuple[dict[int, tuple[NDArray, NDArray]], tuple[int, float, int]]:
+    """Build the full pose set from one candidate scaffold and score its global fit.
+
+    Triangulates the scaffold cloud (anchor = scaffold_pair[0], at the origin),
+    resections every other camera against it, and returns the poses together with
+    a consistency score. The score is (n_failures, worst third-view reprojection
+    error, -total cheirality inliers): a wrong scaffold reconstructs a cloud that
+    third views cannot fit, inflating the reprojection error, so the correct
+    scaffold minimizes this key. Cameras that cannot be resectioned (too little
+    overlap with this cloud) count as failures but do not abort the assembly.
+    """
+    anchor_cam, other_cam = scaffold_pair
+    cloud = triangulate_scaffold(scaffold_pose, scaffold_keys)
+    poses: dict[int, tuple[NDArray, NDArray]] = {
+        anchor_cam: (np.eye(3), np.zeros(3)),
+        other_cam: (scaffold_pose["rotation"], scaffold_pose["translation"]),
+    }
+    reproj_errors: list[float] = []
+    n_failures = 0
+    for cam_id in cam_ids:
+        if cam_id in poses:
+            continue
+        try:
+            rotation, translation, _, reproj_error = resection_camera(
+                cloud, per_cam[cam_id], camera_array.cameras[cam_id]
+            )
+        except ValueError:
+            n_failures += 1
+            continue
+        poses[cam_id] = (rotation, translation)
+        reproj_errors.append(reproj_error)
+
+    worst_reproj = max(reproj_errors) if reproj_errors else 0.0
+    score = (n_failures, worst_reproj, -scaffold_pose["cheirality_inliers"])
+    return poses, score
+
+
+def build_epipolar_pose_network(
+    image_points: ImagePoints,
+    camera_array: CameraArray,
+) -> PairedPoseNetwork:
+    """Recover the extrinsic rig from 2D-2D correspondences (no object geometry).
+
+    For each candidate scaffold pair, triangulates its cloud in the pair's anchor
+    frame and resections every other camera into it; the scaffold whose cloud the
+    third views best agree with (lowest reprojection residual) wins. This third-
+    view validation rejects wrong-but-self-consistent essential estimates that
+    slip past cheirality alone near the coplanarity degeneracy. The winning rig is
+    packaged as anchor-relative StereoPairs in a PairedPoseNetwork -- the same
+    abstraction the PnP path produces, so bootstrap's apply_to + triangulate flow
+    is unchanged. Baseline scale is arbitrary (fixed later by a metric scale cue).
+
+    With exactly 2 cameras there is no third view to validate against, so the
+    single essential pair is taken as-is (its twisted-pair ambiguity, if any, is
+    fundamentally unresolvable without more views).
+
+    Raises:
+        CalibrationError: if fewer than 2 cameras have data, or no camera pair
+            reaches the shared-correspondence minimum an essential matrix needs.
+    """
+    from caliscope.exceptions import CalibrationError
+
+    df = image_points.df
+    observed_cam_ids = set(df["cam_id"].unique())
+    cam_ids = sorted(
+        cam_id for cam_id, cam in camera_array.cameras.items() if not cam.ignore and cam_id in observed_cam_ids
+    )
+    if len(cam_ids) < 2:
+        raise CalibrationError(f"Epipolar bootstrap needs at least 2 cameras with observations, found {len(cam_ids)}.")
+
+    per_cam = {cam_id: df[df["cam_id"] == cam_id] for cam_id in cam_ids}
+
+    pair_poses: dict[tuple[int, int], dict] = {}
+    pair_keys: dict[tuple[int, int], NDArray] = {}
+    for cam_a, cam_b in combinations(cam_ids, 2):
+        keys, pix_a, pix_b = pooled_correspondences(per_cam[cam_a], per_cam[cam_b])
+        if len(keys) < MIN_CORRESPONDENCES:
+            continue
+        try:
+            pose = recover_pair_pose(
+                pix_a,
+                pix_b,
+                camera_a=camera_array.cameras[cam_a],
+                camera_b=camera_array.cameras[cam_b],
+            )
+        except ValueError as exc:
+            logger.warning(f"Pair {cam_a}-{cam_b}: essential-matrix recovery failed ({exc})")
+            continue
+        pair_poses[(cam_a, cam_b)] = pose
+        pair_keys[(cam_a, cam_b)] = keys
+        logger.info(
+            f"Pair {cam_a}-{cam_b}: {pose['n_inliers']}/{pose['n_total']} inliers, "
+            f"{pose['cheirality_inliers']} cheirality, E conditioning {pose['conditioning']:.3f}"
+        )
+        if pose["conditioning"] < CONDITIONING_FLOOR:
+            logger.warning(
+                f"Pair {cam_a}-{cam_b}: essential matrix poorly conditioned "
+                f"(singular-value ratio {pose['conditioning']:.3f} < {CONDITIONING_FLOOR})."
+            )
+
+    if not pair_poses:
+        raise CalibrationError(
+            f"Insufficient camera overlap for epipolar bootstrap: no camera pair reached the "
+            f"{MIN_CORRESPONDENCES} shared correspondences an essential matrix needs. Cameras must "
+            f"share observations of the moving subject across frames."
+        )
+
+    # Consider the strongest pairs (by cheirality) as scaffold candidates, and pick
+    # the one whose cloud the other cameras best agree with. Third-view validation
+    # is what catches a wrong essential estimate that cheirality alone accepts.
+    candidates = sorted(pair_poses, key=lambda p: pair_poses[p]["cheirality_inliers"], reverse=True)
+    candidates = candidates[:MAX_SCAFFOLD_CANDIDATES]
+
+    best_poses: dict[int, tuple[NDArray, NDArray]] | None = None
+    best_score: tuple[int, float, int] | None = None
+    best_pair: tuple[int, int] | None = None
+    for pair in candidates:
+        poses, score = _assemble_from_scaffold(pair, pair_poses[pair], pair_keys[pair], cam_ids, per_cam, camera_array)
+        if best_score is None or score < best_score:
+            best_poses, best_score, best_pair = poses, score, pair
+
+    assert best_poses is not None and best_pair is not None and best_score is not None
+    anchor_cam = best_pair[0]
+    logger.info(
+        f"Selected scaffold {best_pair[0]}-{best_pair[1]} "
+        f"(failures={best_score[0]}, worst third-view reprojection={best_score[1]:.5f}); "
+        f"posed {len(best_poses)}/{len(cam_ids)} cameras, anchor = cam {anchor_cam}"
+    )
+
+    # Package as anchor-relative StereoPairs (primary < secondary, matching the
+    # PnP path's convention so the shared RMSE/graph machinery keys correctly).
+    aggregated: dict[tuple[int, int], StereoPair] = {}
+    for cam_id, (rotation, translation) in best_poses.items():
+        if cam_id == anchor_cam:
+            continue
+        pair = StereoPair(
+            primary_cam_id=anchor_cam,
+            secondary_cam_id=cam_id,
+            error_score=float("nan"),
+            rotation=rotation,
+            translation=translation,
+        )
+        if pair.primary_cam_id > pair.secondary_cam_id:
+            pair = pair.inverted()
+        aggregated[pair.pair] = pair
+
+    return estimate_pnp_paired_pose_network(aggregated, camera_array, image_points)

--- a/src/caliscope/core/calibrate_extrinsics.py
+++ b/src/caliscope/core/calibrate_extrinsics.py
@@ -18,6 +18,7 @@ from caliscope.core.bundle_parameterization import IntrinsicEstimate
 from caliscope.core.capture_volume import CaptureVolume
 from caliscope.core.constraints import ConstraintSet, RigidityReport
 from caliscope.core.point_data import ImagePoints
+from caliscope.exceptions import CalibrationError
 from caliscope.core.scale_accuracy import compute_depth_ratios
 from caliscope.task_manager.cancellation import CancellationToken
 
@@ -75,6 +76,21 @@ def calibrate_extrinsics(
         if cam.matrix is None or cam.distortions is None:
             synthesized.add(cam.cam_id)
             cam.synthesize_default_intrinsics()
+
+    # Intrinsic-quality gate for the epipolar path. With no object geometry the
+    # bootstrap falls back to essential-matrix decomposition, which -- unlike PnP
+    # -- has no obj_loc anchor to absorb focal error. Blind intrinsics (f=width/2)
+    # produce geometrically wrong poses, so refuse to proceed on synthesized cams.
+    obj_absent = image_points.df[["obj_loc_x", "obj_loc_y", "obj_loc_z"]].isna().all().all()
+    if obj_absent and synthesized:
+        raise CalibrationError(
+            f"Epipolar bootstrap requires calibrated intrinsics, but cameras {sorted(synthesized)} "
+            f"have none and fell back to blind defaults (f=width/2). The essential-matrix "
+            f"decomposition has no object-geometry anchor to absorb focal-length error, so blind "
+            f"intrinsics yield geometrically wrong poses (not merely mis-scaled ones). Supply real "
+            f"intrinsics first -- run MoGe focal estimation or charuco intrinsic calibration for "
+            f"these cameras -- then re-run extrinsic calibration."
+        )
 
     # 2. Capture initial intrinsic anchors
     anchors: dict[int, tuple[float, float, float]] = {}

--- a/src/caliscope/core/calibrate_extrinsics.py
+++ b/src/caliscope/core/calibrate_extrinsics.py
@@ -1,8 +1,8 @@
 """Use-case function for extrinsic calibration.
 
 Pipeline: synthesize blind intrinsics → bootstrap → static-marker guard →
-optimize → filter → optimize. Returns an ExtrinsicCalibrationResult with
-recovered intrinsic estimates, bound warnings, depth ratios, and dropped markers.
+optimize → filter → optimize. Returns a CalibrationRun with recovered
+intrinsic estimates and dropped markers.
 """
 
 from __future__ import annotations
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 
 
 from caliscope.cameras.camera_array import CameraArray
-from caliscope.core.bundle_parameterization import BoundWarning, IntrinsicEstimate
+from caliscope.core.bundle_parameterization import IntrinsicEstimate
 from caliscope.core.capture_volume import CaptureVolume
 from caliscope.core.constraints import ConstraintSet, RigidityReport
 from caliscope.core.point_data import ImagePoints
@@ -32,16 +32,11 @@ MIN_DEPTH_RATIO_FOR_INTRINSIC_REFINEMENT = 2.0
 
 
 @dataclass(frozen=True)
-class ExtrinsicCalibrationResult:
+class CalibrationRun:
     capture_volume: CaptureVolume
     intrinsic_estimates: tuple[IntrinsicEstimate, ...]
     synthesized_cam_ids: frozenset[int]
-    bound_warnings: tuple[BoundWarning, ...]
     dropped_static_markers: tuple[int, ...]
-    # Per-camera depth ratios of the final volume; may differ from the values the
-    # refinement gate acted on (which were computed on the post-first-linear-pass
-    # volume, before filtering and the final optimize).
-    depth_ratios: dict[int, float]
     intrinsic_refinement_gated: bool
 
 
@@ -54,7 +49,7 @@ def calibrate_extrinsics(
     filter_percentile: float = 2.5,
     cancellation_token: CancellationToken | None = None,
     progress: Callable[[int, str], None] | None = None,
-) -> ExtrinsicCalibrationResult:
+) -> CalibrationRun:
     """Run the full extrinsic calibration pipeline.
 
     Synthesizes blind intrinsics for uncalibrated cameras, bootstraps poses,
@@ -214,7 +209,7 @@ def calibrate_extrinsics(
 
     # 9. Assemble result
     _progress(100, "Done")
-    return _build_result(
+    return _build_run(
         capture_volume=capture_volume,
         anchors=anchors,
         synthesized_cam_ids=frozenset(synthesized),
@@ -223,20 +218,20 @@ def calibrate_extrinsics(
     )
 
 
-def refresh_result(
-    previous: ExtrinsicCalibrationResult,
+def refresh_run(
+    previous: CalibrationRun,
     capture_volume: CaptureVolume,
-) -> ExtrinsicCalibrationResult:
-    """Rebuild the result around a re-optimized capture volume.
+) -> CalibrationRun:
+    """Rebuild the run around a re-optimized capture volume.
 
     Preserved: initial anchors, synthesized_cam_ids, dropped markers.
-    Recomputed: intrinsic estimates, bound warnings, depth ratios.
+    Recomputed: intrinsic estimates.
     """
     anchors: dict[int, tuple[float, float, float]] = {}
     for est in previous.intrinsic_estimates:
         anchors[est.cam_id] = (est.f_initial, est.k1_initial, est.k2_initial)
 
-    return _build_result(
+    return _build_run(
         capture_volume=capture_volume,
         anchors=anchors,
         synthesized_cam_ids=previous.synthesized_cam_ids,
@@ -245,13 +240,13 @@ def refresh_result(
     )
 
 
-def _build_result(
+def _build_run(
     capture_volume: CaptureVolume,
     anchors: dict[int, tuple[float, float, float]],
     synthesized_cam_ids: frozenset[int],
     dropped_static_markers: tuple[int, ...],
     intrinsic_refinement_gated: bool,
-) -> ExtrinsicCalibrationResult:
+) -> CalibrationRun:
     estimates: list[IntrinsicEstimate] = []
     for cam_id, cam in capture_volume.camera_array.posed_cameras.items():
         if cam_id not in anchors or cam.matrix is None or cam.distortions is None:
@@ -269,16 +264,11 @@ def _build_result(
             )
         )
 
-    status = capture_volume.optimization_status
-    bound_warnings = status.bound_warnings if status is not None else ()
-
-    return ExtrinsicCalibrationResult(
+    return CalibrationRun(
         capture_volume=capture_volume,
         intrinsic_estimates=tuple(estimates),
         synthesized_cam_ids=synthesized_cam_ids,
-        bound_warnings=bound_warnings,
         dropped_static_markers=dropped_static_markers,
-        depth_ratios=compute_depth_ratios(capture_volume),
         intrinsic_refinement_gated=intrinsic_refinement_gated,
     )
 

--- a/src/caliscope/core/capture_volume.py
+++ b/src/caliscope/core/capture_volume.py
@@ -308,15 +308,9 @@ class CaptureVolume:
                 f"    cameras[{uncalibrated[0]}] = output.camera"
             )
 
-        # Validate: obj_loc presence
-        obj_cols = image_points.df[["obj_loc_x", "obj_loc_y", "obj_loc_z"]]
-        if obj_cols.isna().all().all():
-            raise CalibrationError(
-                "ImagePoints contain no object location data (obj_loc columns are all NaN). "
-                "Extrinsic calibration requires a tracker that provides known 3D positions "
-                "(e.g., CharucoTracker)."
-            )
-
+        # obj_loc presence is no longer validated here: build_paired_pose_network
+        # branches on it, using the PnP path when object geometry is present and
+        # the essential-matrix (epipolar) path when obj_loc is all NaN.
         cameras = deepcopy(camera_array)
         pose_network = build_paired_pose_network(image_points, cameras)
         pose_network.apply_to(cameras)

--- a/src/caliscope/core/capture_volume.py
+++ b/src/caliscope/core/capture_volume.py
@@ -1031,14 +1031,46 @@ class CaptureVolume:
         A single cue sets scale exactly (metric / arbitrary). Multiple cues are
         combined by sigma-weighted least squares on the scale factor, using each
         cue's ``sigma_m``. Cues whose implied scales disagree by more than 2 sigma
-        (propagated to scale space) trigger a ``warnings.warn``. Zero cues, or a
-        cue referencing a missing camera/keypoint, raise ``ValueError``.
+        (propagated to scale space) trigger a ``warnings.warn``.
+
+        ``CameraDistance`` and ``SegmentLength`` cues are user-typed and strict: a
+        missing camera or keypoint raises ``ValueError``. ``DepthObservation`` cues
+        are bulk estimator output (one per detection), so unresolvable ones are
+        skipped with a single aggregated ``warnings.warn`` rather than aborting:
+        a keypoint triangulated in fewer than two views has no world point, and
+        triangulation noise can push a point behind the camera (non-positive
+        depth). Zero cues, or all cues unresolvable, raise ``ValueError``.
         """
         if not cues:
             raise ValueError("scaled() requires at least one cue; got none.")
 
-        # Compile each cue to (d_arbitrary, d_metric, sigma_m).
-        compiled: list[tuple[float, float, float]] = [self._compile_cue(cue) for cue in cues]
+        # Compile each cue to (d_arbitrary, d_metric, sigma_m). Strict cue types
+        # raise on failure; depth cues (bulk estimator output) are filtered.
+        compiled: list[tuple[float, float, float]] = []
+        skip_reasons: list[str] = []
+        n_depth = 0
+        for cue in cues:
+            if isinstance(cue, DepthObservation):
+                n_depth += 1
+                outcome = self._compile_depth_cue(cue)
+                if isinstance(outcome, str):
+                    skip_reasons.append(outcome)
+                else:
+                    compiled.append(outcome)
+            else:
+                compiled.append(self._compile_cue(cue))
+
+        if skip_reasons:
+            from collections import Counter
+
+            breakdown = ", ".join(f"{count} {reason}" for reason, count in sorted(Counter(skip_reasons).items()))
+            warnings.warn(
+                f"Skipped {len(skip_reasons)} of {n_depth} depth cues as unresolvable ({breakdown}).",
+                stacklevel=2,
+            )
+
+        if not compiled:
+            raise ValueError(f"All {len(cues)} scale cues were unresolvable; cannot determine scale.")
 
         d_arb = np.array([c[0] for c in compiled], dtype=np.float64)
         d_met = np.array([c[1] for c in compiled], dtype=np.float64)
@@ -1082,8 +1114,12 @@ class CaptureVolume:
             _optimization_status=self._optimization_status,
         )
 
-    def _compile_cue(self, cue: CameraDistance | SegmentLength | DepthObservation) -> tuple[float, float, float]:
-        """Reduce a cue to (d_arbitrary, d_metric, sigma_m) in the current BA frame."""
+    def _compile_cue(self, cue: CameraDistance | SegmentLength) -> tuple[float, float, float]:
+        """Reduce a strict (user-typed) cue to (d_arbitrary, d_metric, sigma_m).
+
+        Raises ``ValueError`` on any unresolvable reference -- these cues are few
+        and hand-entered, so a bad reference is a real mistake worth surfacing.
+        """
         if isinstance(cue, CameraDistance):
             posed = self.camera_array.posed_cameras
             for cam_id in (cue.cam_a, cue.cam_b):
@@ -1111,26 +1147,32 @@ class CaptureVolume:
             d_arb = float(np.median(distances))
             return d_arb, float(cue.meters), float(cue.sigma_m)
 
-        if isinstance(cue, DepthObservation):
-            cam = self.camera_array.cameras.get(cue.cam_id)
-            if cam is None or cam.rotation is None or cam.translation is None:
-                raise ValueError(f"DepthObservation references cam_id {cue.cam_id}, which is not a posed camera.")
-            match = world_df[(world_df["sync_index"] == cue.sync_index) & (world_df["keypoint_id"] == cue.keypoint_id)]
-            if match.empty:
-                raise ValueError(
-                    f"DepthObservation found no world point for keypoint {cue.keypoint_id} "
-                    f"at sync_index {cue.sync_index}."
-                )
-            if len(match) > 1:
-                raise ValueError(
-                    f"DepthObservation matched {len(match)} world points for keypoint {cue.keypoint_id} "
-                    f"at sync_index {cue.sync_index}; the (sync_index, keypoint_id) pair is ambiguous."
-                )
-            p_world = match[["x_coord", "y_coord", "z_coord"]].to_numpy()[0]
-            d_arb = float((cam.rotation @ p_world + cam.translation)[2])
-            return d_arb, float(cue.depth_m), float(cue.sigma_m)
-
         raise TypeError(f"Unknown scale cue type: {type(cue).__name__}")
+
+    def _compile_depth_cue(self, cue: DepthObservation) -> tuple[float, float, float] | str:
+        """Reduce a depth cue to (d_arbitrary, d_metric, sigma_m), or a skip reason.
+
+        Depth cues are bulk estimator output, so unresolvable ones return a short
+        reason string (for the caller's aggregated warning) instead of raising:
+        an unposed camera, no world point (single-view keypoint), an ambiguous
+        match, or a non-positive depth (point behind the camera from noise).
+        """
+        cam = self.camera_array.cameras.get(cue.cam_id)
+        if cam is None or cam.rotation is None or cam.translation is None:
+            return "unposed camera"
+
+        world_df = self.world_points.df
+        match = world_df[(world_df["sync_index"] == cue.sync_index) & (world_df["keypoint_id"] == cue.keypoint_id)]
+        if match.empty:
+            return "no world point"
+        if len(match) > 1:
+            return "ambiguous match"
+
+        p_world = match[["x_coord", "y_coord", "z_coord"]].to_numpy()[0]
+        d_arb = float((cam.rotation @ p_world + cam.translation)[2])
+        if d_arb <= 0.0:
+            return "non-positive depth"
+        return d_arb, float(cue.depth_m), float(cue.sigma_m)
 
     def oriented(self, up: dict[int, NDArray]) -> "CaptureVolume":
         """Rotate so the consensus vertical becomes +Z, yaw fixed by the anchor camera.

--- a/src/caliscope/core/capture_volume.py
+++ b/src/caliscope/core/capture_volume.py
@@ -9,6 +9,7 @@ from functools import cached_property
 from pathlib import Path
 from typing import Literal
 import logging
+import warnings
 
 from caliscope.cameras.camera_array import CameraArray
 from caliscope.core.constraints import ConstraintSet, ConstraintViolation, RigidityReport
@@ -33,6 +34,8 @@ from caliscope.core.scale_accuracy import (
     FrameScaleError,
     VolumetricScaleReport,
 )
+from caliscope.core.coordinate_frame import world_basis_from_up_and_forward
+from caliscope.core.scale_cues import CameraDistance, DepthObservation, SegmentLength
 
 import pandas as pd
 
@@ -1000,6 +1003,208 @@ class CaptureVolume:
             scale=1.0,
         )
 
+        new_camera_array, new_world_points = apply_similarity_transform(self.camera_array, self.world_points, transform)
+
+        return CaptureVolume(
+            camera_array=new_camera_array,
+            image_points=self.image_points,
+            world_points=new_world_points,
+            constraints=self.constraints,
+            _optimization_status=self._optimization_status,
+        )
+
+    # ------------------------------------------------------------------
+    # Metric anchoring (post-BA). Each returns a new frozen CaptureVolume.
+    # ------------------------------------------------------------------
+
+    def _anchor_cam_id(self) -> int:
+        """The lowest posed cam_id -- the yaw/XY convention anchor ("camera 0")."""
+        posed = self.camera_array.posed_cameras
+        if not posed:
+            raise ValueError("No posed cameras; cannot anchor a shape-only volume.")
+        return min(posed)
+
+    def _camera_center(self, cam_id: int) -> NDArray:
+        """Camera center in the current world frame: C = -R.T @ t."""
+        cam = self.camera_array.cameras[cam_id]
+        if cam.rotation is None or cam.translation is None:
+            raise ValueError(f"Camera {cam_id} has no pose; cannot compute its center.")
+        return -cam.rotation.T @ cam.translation
+
+    def scaled(self, *cues: CameraDistance | SegmentLength | DepthObservation) -> "CaptureVolume":
+        """Apply uniform metric scale recovered from one or more metric cues.
+
+        A single cue sets scale exactly (metric / arbitrary). Multiple cues are
+        combined by sigma-weighted least squares on the scale factor, using each
+        cue's ``sigma_m``. Cues whose implied scales disagree by more than 2 sigma
+        (propagated to scale space) trigger a ``warnings.warn``. Zero cues, or a
+        cue referencing a missing camera/keypoint, raise ``ValueError``.
+        """
+        if not cues:
+            raise ValueError("scaled() requires at least one cue; got none.")
+
+        # Compile each cue to (d_arbitrary, d_metric, sigma_m).
+        compiled: list[tuple[float, float, float]] = [self._compile_cue(cue) for cue in cues]
+
+        d_arb = np.array([c[0] for c in compiled], dtype=np.float64)
+        d_met = np.array([c[1] for c in compiled], dtype=np.float64)
+        sigma = np.array([c[2] for c in compiled], dtype=np.float64)
+
+        if len(compiled) == 1:
+            scale = float(d_met[0] / d_arb[0])
+        else:
+            # Sigma-weighted least squares: scale = Σ(m·d/σ²) / Σ(d²/σ²).
+            numerator = float(np.sum(d_met * d_arb / sigma**2))
+            denominator = float(np.sum(d_arb**2 / sigma**2))
+            scale = numerator / denominator
+
+            # Disagreement diagnostic in scale space.
+            implied = d_met / d_arb
+            sigma_scale = sigma / d_arb
+            n = len(compiled)
+            for i in range(n):
+                for j in range(i + 1, n):
+                    combined = float(np.hypot(sigma_scale[i], sigma_scale[j]))
+                    if abs(implied[i] - implied[j]) > 2.0 * combined:
+                        warnings.warn(
+                            f"Scale cues {i} and {j} disagree: implied scales "
+                            f"{implied[i]:.6g} vs {implied[j]:.6g} differ by more than "
+                            f"2 sigma ({2.0 * combined:.6g}).",
+                            stacklevel=2,
+                        )
+
+        transform = SimilarityTransform(
+            rotation=np.eye(3, dtype=np.float64),
+            translation=np.zeros(3, dtype=np.float64),
+            scale=scale,
+        )
+        new_camera_array, new_world_points = apply_similarity_transform(self.camera_array, self.world_points, transform)
+
+        return CaptureVolume(
+            camera_array=new_camera_array,
+            image_points=self.image_points,
+            world_points=new_world_points,
+            constraints=self.constraints,
+            _optimization_status=self._optimization_status,
+        )
+
+    def _compile_cue(self, cue: CameraDistance | SegmentLength | DepthObservation) -> tuple[float, float, float]:
+        """Reduce a cue to (d_arbitrary, d_metric, sigma_m) in the current BA frame."""
+        if isinstance(cue, CameraDistance):
+            posed = self.camera_array.posed_cameras
+            for cam_id in (cue.cam_a, cue.cam_b):
+                if cam_id not in posed:
+                    raise ValueError(f"CameraDistance references cam_id {cam_id}, which is not a posed camera.")
+            d_arb = float(np.linalg.norm(self._camera_center(cue.cam_a) - self._camera_center(cue.cam_b)))
+            if d_arb == 0.0:
+                raise ValueError(f"Cameras {cue.cam_a} and {cue.cam_b} coincide; distance cue is degenerate.")
+            return d_arb, float(cue.meters), float(cue.sigma_m)
+
+        world_df = self.world_points.df
+
+        if isinstance(cue, SegmentLength):
+            coords = ["x_coord", "y_coord", "z_coord"]
+            side_a = world_df[world_df["keypoint_id"] == cue.keypoint_id_a][["sync_index", "object_id", *coords]]
+            side_b = world_df[world_df["keypoint_id"] == cue.keypoint_id_b][["sync_index", "object_id", *coords]]
+            merged = side_a.merge(side_b, on=["sync_index", "object_id"], suffixes=("_a", "_b"))
+            if merged.empty:
+                raise ValueError(
+                    f"SegmentLength found no frame where both keypoints "
+                    f"{cue.keypoint_id_a} and {cue.keypoint_id_b} are triangulated."
+                )
+            deltas = merged[[f"{c}_a" for c in coords]].to_numpy() - merged[[f"{c}_b" for c in coords]].to_numpy()
+            distances = np.linalg.norm(deltas, axis=1)
+            d_arb = float(np.median(distances))
+            return d_arb, float(cue.meters), float(cue.sigma_m)
+
+        if isinstance(cue, DepthObservation):
+            cam = self.camera_array.cameras.get(cue.cam_id)
+            if cam is None or cam.rotation is None or cam.translation is None:
+                raise ValueError(f"DepthObservation references cam_id {cue.cam_id}, which is not a posed camera.")
+            match = world_df[(world_df["sync_index"] == cue.sync_index) & (world_df["keypoint_id"] == cue.keypoint_id)]
+            if match.empty:
+                raise ValueError(
+                    f"DepthObservation found no world point for keypoint {cue.keypoint_id} "
+                    f"at sync_index {cue.sync_index}."
+                )
+            if len(match) > 1:
+                raise ValueError(
+                    f"DepthObservation matched {len(match)} world points for keypoint {cue.keypoint_id} "
+                    f"at sync_index {cue.sync_index}; the (sync_index, keypoint_id) pair is ambiguous."
+                )
+            p_world = match[["x_coord", "y_coord", "z_coord"]].to_numpy()[0]
+            d_arb = float((cam.rotation @ p_world + cam.translation)[2])
+            return d_arb, float(cue.depth_m), float(cue.sigma_m)
+
+        raise TypeError(f"Unknown scale cue type: {type(cue).__name__}")
+
+    def oriented(self, up: dict[int, NDArray]) -> "CaptureVolume":
+        """Rotate so the consensus vertical becomes +Z, yaw fixed by the anchor camera.
+
+        ``up`` maps cam_id to that camera's up vector in its own (OpenCV) frame.
+        Each is mapped into the world frame (``R.T @ up_cam``), averaged, and
+        normalized to a consensus vertical. The anchor camera (lowest posed cam_id)
+        supplies the yaw: its optical axis, projected onto the horizontal plane,
+        becomes +Y. Scale and translation are untouched.
+        """
+        if not up:
+            raise ValueError("oriented() requires at least one up vector.")
+
+        world_ups: list[NDArray] = []
+        for cam_id, up_cam in up.items():
+            cam = self.camera_array.cameras.get(cam_id)
+            if cam is None or cam.rotation is None:
+                raise ValueError(f"oriented() references cam_id {cam_id}, which is not a posed camera.")
+            v = np.asarray(up_cam, dtype=np.float64)
+            world_ups.append(cam.rotation.T @ v)
+
+        consensus = np.mean(np.stack(world_ups), axis=0)
+        norm = float(np.linalg.norm(consensus))
+        if norm < 1e-9:
+            raise ValueError("Consensus up vector is degenerate (per-camera verticals cancel).")
+        consensus_up = consensus / norm
+
+        anchor_cam = self.camera_array.cameras[self._anchor_cam_id()]
+        assert anchor_cam.rotation is not None  # _anchor_cam_id returns a posed camera
+        # Optical axis (+Z in the camera frame) expressed in the world frame.
+        forward = anchor_cam.rotation.T @ np.array([0.0, 0.0, 1.0])
+
+        rotation = world_basis_from_up_and_forward(consensus_up, forward=forward)
+
+        transform = SimilarityTransform(
+            rotation=rotation,
+            translation=np.zeros(3, dtype=np.float64),
+            scale=1.0,
+        )
+        new_camera_array, new_world_points = apply_similarity_transform(self.camera_array, self.world_points, transform)
+
+        return CaptureVolume(
+            camera_array=new_camera_array,
+            image_points=self.image_points,
+            world_points=new_world_points,
+            constraints=self.constraints,
+            _optimization_status=self._optimization_status,
+        )
+
+    def grounded(self, mode: Literal["lowest_point"] = "lowest_point") -> "CaptureVolume":
+        """Translate so the ground sits at Z=0 and the XY origin lies under the anchor camera.
+
+        ``mode="lowest_point"`` places the world point of least Z at Z=0 (call after
+        ``oriented()`` so Z is vertical). XY origin is set under the anchor camera
+        (lowest posed cam_id). No rotation or scale change.
+        """
+        if mode != "lowest_point":
+            raise ValueError(f"grounded() only supports mode='lowest_point', got {mode!r}.")
+
+        min_z = float(self.world_points.df["z_coord"].min())
+        anchor_center = self._camera_center(self._anchor_cam_id())
+        offset = np.array([anchor_center[0], anchor_center[1], min_z], dtype=np.float64)
+
+        transform = SimilarityTransform(
+            rotation=np.eye(3, dtype=np.float64),
+            translation=-offset,
+            scale=1.0,
+        )
         new_camera_array, new_world_points = apply_similarity_transform(self.camera_array, self.world_points, transform)
 
         return CaptureVolume(

--- a/src/caliscope/core/coordinate_frame.py
+++ b/src/caliscope/core/coordinate_frame.py
@@ -1,0 +1,32 @@
+"""Building a canonical Z-up world basis from a gravity vector and a heading.
+
+Ported from monokin's ``coordinate_frame.py``. The numerics are identical:
+up becomes +Z, forward's horizontal component becomes +Y (the yaw anchor),
+and +X completes the right-handed basis.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+def world_basis_from_up_and_forward(up: NDArray, *, forward: NDArray) -> NDArray:
+    """(3,3) rotation into the Z-up world frame: rows are the world basis vectors.
+
+    up (gravity-up, normalized here) becomes world +Z; forward's horizontal
+    component becomes world +Y, the yaw anchor, so the source frame's forward
+    direction unfolds along +Y; +X completes the right-handed basis. Apply as
+    p_world = R @ p_source. Raises when forward is within ~1e-6 of vertical,
+    where the yaw anchor is undefined.
+    """
+    z_world = np.asarray(up, dtype=np.float64)
+    z_world = z_world / np.linalg.norm(z_world)
+    horizontal = np.asarray(forward, dtype=np.float64)
+    horizontal = horizontal - np.dot(horizontal, z_world) * z_world
+    norm = float(np.linalg.norm(horizontal))
+    if norm < 1e-6:
+        raise ValueError("forward points along gravity (pitch ~ +/-90 deg); the forward-to-+Y yaw anchor is undefined")
+    y_world = horizontal / norm
+    x_world = np.cross(y_world, z_world)
+    return np.stack([x_world, y_world, z_world])

--- a/src/caliscope/core/scale_cues.py
+++ b/src/caliscope/core/scale_cues.py
@@ -1,0 +1,43 @@
+"""Metric scale cues for anchoring a shape-only capture volume.
+
+Bundle adjustment determines shape up to a similarity transform. Each cue
+supplies one observation of true metric distance, compiled by
+``CaptureVolume.scaled()`` to an (arbitrary-units distance, metric meters,
+sigma) triple. One cue scales exactly; multiple cues combine via
+sigma-weighted least squares.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CameraDistance:
+    """Known distance between two camera centers (e.g., tape measure)."""
+
+    cam_a: int  # cam_id
+    cam_b: int  # cam_id
+    meters: float
+    sigma_m: float = 0.01  # tape measure accuracy
+
+
+@dataclass(frozen=True)
+class SegmentLength:
+    """Known distance between two tracked keypoints (e.g., a body segment)."""
+
+    keypoint_id_a: int  # keypoint id from ImagePoints
+    keypoint_id_b: int  # keypoint id from ImagePoints
+    meters: float
+    sigma_m: float = 0.02
+
+
+@dataclass(frozen=True)
+class DepthObservation:
+    """Metric depth of one keypoint in one camera at one moment (e.g., MoGe)."""
+
+    cam_id: int
+    keypoint_id: int
+    sync_index: int
+    depth_m: float
+    sigma_m: float = 0.1  # monocular depth noise

--- a/src/caliscope/estimators/__init__.py
+++ b/src/caliscope/estimators/__init__.py
@@ -1,0 +1,7 @@
+"""Estimators — extractors that eat video and emit observation types.
+
+Parallels ``trackers/``: trackers emit 2D landmarks (ImagePoints), estimators
+emit metric cues (focal lengths, depths, vertical directions) consumed by the
+anchoring API. Import runners from their modules directly, e.g.
+``caliscope.estimators.moge`` or ``caliscope.estimators.vertical``.
+"""

--- a/src/caliscope/estimators/model_store.py
+++ b/src/caliscope/estimators/model_store.py
@@ -1,0 +1,45 @@
+"""Estimator model specs and on-demand download.
+
+Estimator ONNX models (MoGe, GeoCalib fields) don't fit the tracker
+``ModelCard`` schema (no keypoints, no SimCC/heatmap format, dynamic
+resolution), so each estimator declares a frozen ``EstimatorModelSpec``
+constant instead of a TOML card. Weights live in the same ``MODELS_DIR``
+as tracker models; the tracker registry ignores them because it scans
+TOML cards, not ``.onnx`` files.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from caliscope import MODELS_DIR
+from caliscope.trackers.model_download import download_and_extract_model
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class EstimatorModelSpec:
+    """Downloadable ONNX model for an estimator. Satisfies ``ModelSource``."""
+
+    name: str
+    filename: str
+    source_url: str | None
+    sha256: str | None
+    extraction: str | None = "direct"
+    file_size_mb: float | None = None
+    license_info: str | None = None
+    model_path: Path = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "model_path", MODELS_DIR / self.filename)
+
+
+def ensure_model(spec: EstimatorModelSpec) -> Path:
+    """Return the local path to the model weights, downloading on first use."""
+    if spec.model_path.exists():
+        return spec.model_path
+    logger.info(f"Estimator model '{spec.name}' not found locally; downloading.")
+    return download_and_extract_model(spec, MODELS_DIR)

--- a/src/caliscope/estimators/moge.py
+++ b/src/caliscope/estimators/moge.py
@@ -72,13 +72,17 @@ def run_moge(
     frame is decoded once (via PyAV) and run through MoGe. The camera's focal
     length is the median of per-frame estimates; a ``DepthObservation`` is emitted
     for every tracked keypoint whose pixel falls on a valid (masked, positive)
-    depth.
+    depth. Observations stay keyed by sync_index (the domain's time key).
 
-    ``points`` carries no frame_index column, so sync_index is treated as the
-    frame index (correct for single-video-per-camera extraction).
+    Decoding uses the ``frame_index`` column when present (from
+    ``extract_image_points_multicam``): sync_index and frame_index diverge when
+    cameras start staggered or drop frames, so decoding by sync_index would sample
+    the depth map at the wrong instant. When ``frame_index`` is absent (the
+    single-video ``extract_image_points`` path), sync_index is the frame index.
     """
     session = _build_session()
     df = points.df
+    has_frame_index = "frame_index" in df.columns
 
     focal_per_cam: dict[int, float] = {}
     depth_observations: list[DepthObservation] = []
@@ -94,10 +98,17 @@ def run_moge(
         if len(sync_indices) == 0:
             continue
 
-        frame_focals: list[float] = []
-        frames = _decode_frames(Path(videos[cam_id]), cam_id, sync_indices)
+        sync_to_frame = _sync_to_frame_map(cam_df, has_frame_index)
+        frame_indices = [sync_to_frame[s] for s in sync_indices]
+        frames = _decode_frames(Path(videos[cam_id]), cam_id, frame_indices)
 
-        for sync_index, rgb in frames.items():
+        frame_focals: list[float] = []
+        for sync_index in sync_indices:
+            rgb = frames.get(sync_to_frame[sync_index])
+            if rgb is None:
+                logger.warning(f"cam_id {cam_id}: frame {sync_to_frame[sync_index]} not decoded; skipping.")
+                continue
+
             point_map, mask_binary, metric_scale = _infer_frame(session, rgb)
 
             focal, shift = recover_focal_shift_numpy(point_map, mask_binary)
@@ -205,6 +216,19 @@ def _keypoint_depths(
             )
         )
     return observations
+
+
+def _sync_to_frame_map(cam_df, has_frame_index: bool) -> dict[int, int]:
+    """Map each sync_index to the video frame index to decode for it.
+
+    With a frame_index column, the mapping comes from the data (frame_index is
+    constant within a (cam_id, sync_index) group). Without it, sync_index is the
+    frame index — the identity map.
+    """
+    if not has_frame_index:
+        return {int(s): int(s) for s in cam_df["sync_index"].unique()}
+    deduped = cam_df.drop_duplicates("sync_index")
+    return {int(s): int(f) for s, f in zip(deduped["sync_index"], deduped["frame_index"])}
 
 
 def _sample_sync_indices(sync_indices: np.ndarray, count: int) -> list[int]:

--- a/src/caliscope/estimators/moge.py
+++ b/src/caliscope/estimators/moge.py
@@ -1,0 +1,231 @@
+"""MoGe-2 runner: per-camera focal length + metric depth at tracked keypoints.
+
+MoGe-2 (Microsoft) estimates an affine-invariant point map, a validity mask, and
+a metric scale from a single image. This runner drives the official ONNX export
+over a handful of sampled frames per camera and emits two observation types:
+
+- ``focal_per_cam``: the median per-frame focal length in pixels, a source of
+  camera intrinsics for the epipolar bootstrap (M1).
+- ``depth_observations``: metric depth sampled at each tracked keypoint, a
+  ``DepthObservation`` scale cue for ``CaptureVolume.scaled()`` (M2).
+
+The affine-invariant point map leaves two degrees of freedom the network cannot
+know — focal length and z-shift — recovered by the vendored numpy post-processing
+in ``moge_utils`` (``recover_focal_shift_numpy``). Depth is then
+``(points_z + shift) * metric_scale``.
+
+onnxruntime is imported lazily (it ships in the ``[tracking]`` extra); this
+module imports cleanly on a lean install.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+from caliscope.core.point_data import ImagePoints
+from caliscope.core.scale_cues import DepthObservation
+from caliscope.estimators.model_store import EstimatorModelSpec, ensure_model
+from caliscope.estimators.moge_utils import recover_focal_shift_numpy
+from caliscope.packets import PixelFormat
+from caliscope.recording.frame_source import FrameSource
+
+logger = logging.getLogger(__name__)
+
+
+# num_tokens for the ViT-L backbone (fixed by the model architecture).
+MOGE_NUM_TOKENS = 3600
+
+MOGE_MODEL_SPEC = EstimatorModelSpec(
+    name="moge-2-vitl-normal",
+    filename="moge_2_vitl_normal.onnx",
+    source_url="https://huggingface.co/Ruicheng/moge-2-vitl-normal-onnx/resolve/main/model.onnx",
+    sha256="afbc4ccc3450298f3afb35b90f015f4c4f552dea21dc6470d5f7b78b77e2d751",
+    extraction="direct",
+    file_size_mb=1262.9,  # 1324265014 bytes
+    license_info="MIT",
+)
+
+
+@dataclass(frozen=True)
+class MoGeResult:
+    """One MoGe run: focal estimates and metric depths at tracked keypoints."""
+
+    focal_per_cam: dict[int, float]  # cam_id -> focal length in pixels
+    depth_observations: list[DepthObservation]
+
+
+def run_moge(
+    videos: Mapping[int, Path | str],
+    points: ImagePoints,
+    *,
+    frames_per_camera: int = 4,
+) -> MoGeResult:
+    """Run MoGe-2 on sampled frames and estimate focal length + keypoint depths.
+
+    For each camera, up to ``frames_per_camera`` sync indices that carry keypoint
+    detections are sampled, spread evenly across the observed range. Each sampled
+    frame is decoded once (via PyAV) and run through MoGe. The camera's focal
+    length is the median of per-frame estimates; a ``DepthObservation`` is emitted
+    for every tracked keypoint whose pixel falls on a valid (masked, positive)
+    depth.
+
+    ``points`` carries no frame_index column, so sync_index is treated as the
+    frame index (correct for single-video-per-camera extraction).
+    """
+    session = _build_session()
+    df = points.df
+
+    focal_per_cam: dict[int, float] = {}
+    depth_observations: list[DepthObservation] = []
+
+    for cam_id in sorted(df["cam_id"].unique()):
+        cam_id = int(cam_id)
+        if cam_id not in videos:
+            logger.warning(f"cam_id {cam_id} has image points but no video; skipping MoGe run.")
+            continue
+
+        cam_df = df[df["cam_id"] == cam_id]
+        sync_indices = _sample_sync_indices(cam_df["sync_index"].to_numpy(), frames_per_camera)
+        if len(sync_indices) == 0:
+            continue
+
+        frame_focals: list[float] = []
+        frames = _decode_frames(Path(videos[cam_id]), cam_id, sync_indices)
+
+        for sync_index, rgb in frames.items():
+            point_map, mask_binary, metric_scale = _infer_frame(session, rgb)
+
+            focal, shift = recover_focal_shift_numpy(point_map, mask_binary)
+            frame_focals.append(_focal_to_pixels(float(focal), point_map.shape[1], point_map.shape[0]))
+
+            depth_map = (point_map[..., 2] + shift) * metric_scale
+            valid_depth = mask_binary & (depth_map > 0)
+
+            frame_rows = cam_df[cam_df["sync_index"] == sync_index]
+            depth_observations.extend(_keypoint_depths(frame_rows, depth_map, valid_depth, cam_id, sync_index))
+
+        if frame_focals:
+            focal_per_cam[cam_id] = float(np.median(frame_focals))
+
+    return MoGeResult(focal_per_cam=focal_per_cam, depth_observations=depth_observations)
+
+
+def _build_session():
+    """Construct the MoGe ONNX inference session, downloading the model on first use.
+
+    onnxruntime is imported here (not at module scope) so the module stays
+    importable on a lean install without the ``[tracking]`` extra.
+    """
+    try:
+        import onnxruntime as ort  # type: ignore[reportMissingImports]  # no type stubs
+    except ModuleNotFoundError as e:
+        raise ModuleNotFoundError(
+            "MoGe estimation requires onnxruntime, which is not installed.\n"
+            "Install the tracking extra:\n"
+            "    pip install caliscope[tracking]\n"
+            "(GUI users: pip install caliscope[gui] includes tracking.)"
+        ) from e
+
+    model_path = ensure_model(MOGE_MODEL_SPEC)
+    logger.info(f"Loading MoGe ONNX model: {model_path}")
+    return ort.InferenceSession(str(model_path), providers=["CPUExecutionProvider"])
+
+
+def _infer_frame(session, rgb: np.ndarray) -> tuple[np.ndarray, np.ndarray, float]:
+    """Run one RGB frame through MoGe, returning (point_map, mask_binary, metric_scale).
+
+    ``point_map`` is (H, W, 3) affine-invariant; ``mask_binary`` is (H, W) bool
+    (sigmoid > 0.5); ``metric_scale`` is the scalar that maps shifted z to meters.
+    """
+    image = (rgb.transpose(2, 0, 1)[None].astype(np.float32)) / 255.0
+
+    feed: dict[str, np.ndarray] = {}
+    for model_input in session.get_inputs():
+        if model_input.name == "image":
+            feed["image"] = image
+        elif model_input.name == "num_tokens":
+            feed["num_tokens"] = np.array(MOGE_NUM_TOKENS, dtype=np.int64)
+        else:
+            raise ValueError(f"unexpected MoGe ONNX input: {model_input.name}")
+
+    output_names = [o.name for o in session.get_outputs()]
+    raw = dict(zip(output_names, session.run(None, feed)))
+
+    point_map = raw["points"][0].astype(np.float32)  # (H, W, 3)
+    mask_binary = raw["mask"][0] > 0.5
+    metric_scale = float(raw["metric_scale"][0])
+    return point_map, mask_binary, metric_scale
+
+
+def _focal_to_pixels(focal: float, width: int, height: int) -> float:
+    """Convert MoGe's recovered focal (in normalized-diagonal units) to pixels.
+
+    ``recover_focal_shift_numpy`` works in MoGe's normalized view-plane UV, where
+    the image diagonal spans 2 units. Converting to the utils3d "normalized
+    intrinsics" convention (fx over image width) and then to pixels:
+
+        fx_norm = focal / 2 * sqrt(1 + aspect^2) / aspect
+        focal_px = fx_norm * width
+
+    Matches monokin's validated probe (probe_moge_onnx.py).
+    """
+    aspect_ratio = width / height
+    fx_norm = focal / 2 * (1 + aspect_ratio**2) ** 0.5 / aspect_ratio
+    return fx_norm * width
+
+
+def _keypoint_depths(
+    frame_rows,
+    depth_map: np.ndarray,
+    valid_depth: np.ndarray,
+    cam_id: int,
+    sync_index: int,
+) -> list[DepthObservation]:
+    """Sample metric depth at each keypoint pixel, skipping invalid (unmasked) samples."""
+    height, width = depth_map.shape
+    observations: list[DepthObservation] = []
+    for row in frame_rows.itertuples(index=False):
+        px = int(round(row.img_loc_x))
+        py = int(round(row.img_loc_y))
+        px = min(max(px, 0), width - 1)
+        py = min(max(py, 0), height - 1)
+        if not valid_depth[py, px]:
+            continue
+        observations.append(
+            DepthObservation(
+                cam_id=cam_id,
+                keypoint_id=int(row.keypoint_id),
+                sync_index=sync_index,
+                depth_m=float(depth_map[py, px]),
+            )
+        )
+    return observations
+
+
+def _sample_sync_indices(sync_indices: np.ndarray, count: int) -> list[int]:
+    """Pick up to ``count`` unique sync indices spread evenly across the observed range."""
+    unique = np.unique(sync_indices)
+    if len(unique) <= count:
+        return [int(s) for s in unique]
+    positions = np.linspace(0, len(unique) - 1, count).round().astype(int)
+    return [int(unique[p]) for p in np.unique(positions)]
+
+
+def _decode_frames(video_path: Path, cam_id: int, sync_indices: list[int]) -> dict[int, np.ndarray]:
+    """Decode the requested frames as RGB, keyed by frame index (== sync_index).
+
+    MoGe expects RGB; ``FrameSource`` yields BGR, so channels are flipped here.
+    """
+    wanted = set(sync_indices)
+    frames: dict[int, np.ndarray] = {}
+    with FrameSource.from_path(
+        video_path, cam_id=cam_id, wanted_indices=wanted, pixel_format=PixelFormat.BGR
+    ) as source:
+        while (packet := source.next_frame()) is not None:
+            frames[packet.frame_index] = np.ascontiguousarray(packet.frame[..., ::-1])
+    return frames

--- a/src/caliscope/estimators/moge_utils.py
+++ b/src/caliscope/estimators/moge_utils.py
@@ -1,0 +1,298 @@
+# type: ignore  # vendored verbatim — excluded from type checking (see module docstring)
+"""Vendored numpy post-processing for MoGe-2 ONNX inference.
+
+Vendored from microsoft/MoGe (https://github.com/microsoft/MoGe), MIT license.
+The functions are copied unmodified except for their imports: the original
+``recover_focal_shift_numpy`` (in ``moge/utils/geometry_numpy.py``) called
+``utils3d.np.masked_nearest_resize``; the ``utils3d`` numpy helpers it depends on
+(``masked_nearest_resize``, ``uv_map``, ``pixel_coord_map``, ``sliding_window``,
+from Ruicheng/utils3d, also MIT) are inlined here so the one cross-package call
+resolves locally. No numerical logic was changed.
+
+``recover_focal_shift_numpy`` recovers the two degrees of freedom the MoGe
+network's affine-invariant point map cannot fix — focal length and z-shift —
+by least-squares over the masked point map.
+"""
+
+# ruff: noqa: E501 — vendored verbatim; upstream long docstring/comment lines kept as-is.
+
+from __future__ import annotations
+
+import math
+from functools import partial
+from typing import TYPE_CHECKING, Optional, Tuple, Union
+
+import cv2
+import numpy as np
+from numpy import ndarray
+
+if TYPE_CHECKING:
+    # Unpack lives in typing only on 3.11+; caliscope supports 3.10. Runtime
+    # never evaluates the annotation (see ``from __future__ import annotations``),
+    # so the checker-only import keeps the vendored signature verbatim.
+    from typing_extensions import Unpack
+
+
+# --------------------------------------------------------------------------- #
+# From Ruicheng/utils3d — utils3d/numpy/utils.py
+# --------------------------------------------------------------------------- #
+
+
+def sliding_window(
+    x: ndarray,
+    window_size: Union[int, Tuple[int, ...]],
+    stride: Optional[Union[int, Tuple[int, ...]]] = None,
+    pad_size: Optional[Union[int, Tuple[int, int], Tuple[Tuple[int, int]]]] = None,
+    pad_mode: str = "constant",
+    pad_value: float = 0,
+    axis: Optional[Tuple[int, ...]] = None,
+) -> ndarray:
+    """
+    Get a sliding window of the input array. Window axis(axes) will be appended as the last dimension(s).
+    This function is a wrapper of `numpy.lib.stride_tricks.sliding_window_view` with additional support for padding and stride.
+    """
+    # Process axis
+    if axis is None:
+        axis = tuple(range(x.ndim))
+    if isinstance(axis, int):
+        axis = (axis,)
+    axis = [axis[i] % x.ndim for i in range(len(axis))]
+    if isinstance(window_size, int):
+        window_size = (window_size,) * len(axis)
+
+    # Pad the input array if needed
+    if pad_size is not None:
+        if isinstance(pad_size, int):
+            pad_size = ((pad_size, pad_size),) * len(axis)
+        elif isinstance(pad_size, tuple) and len(pad_size) == 2 and all(isinstance(p, int) for p in pad_size):
+            pad_size = (pad_size,) * len(axis)
+        elif isinstance(pad_size, tuple) and all(isinstance(p, tuple) and 1 <= len(p) <= 2 for p in pad_size):
+            if len(pad_size) == 1:
+                pad_size = pad_size * len(axis)
+            else:
+                assert len(pad_size) == len(axis), f"pad_size {pad_size} must match the number of axes {len(axis)}"
+        else:
+            raise ValueError(f"Invalid pad_size {pad_size}")
+        full_pad = [(0, 0) if i not in axis else pad_size[axis.index(i)] for i in range(x.ndim)]
+        if pad_mode == "constant":
+            x = np.pad(x, full_pad, mode=pad_mode, constant_values=pad_value)
+        else:
+            x = np.pad(x, full_pad, mode=pad_mode)
+
+    # Apply sliding window
+    x = np.lib.stride_tricks.sliding_window_view(x, window_size, axis=axis)
+
+    # Apply stride if needed
+    if stride is not None:
+        if isinstance(stride, int):
+            stride = (stride,) * len(axis)
+        stride_slice = tuple(
+            slice(None) if i not in axis else slice(None, None, stride[axis.index(i)]) for i in range(x.ndim)
+        )
+        x = x[stride_slice]
+
+    return x
+
+
+# --------------------------------------------------------------------------- #
+# From Ruicheng/utils3d — utils3d/numpy/maps.py
+# --------------------------------------------------------------------------- #
+
+
+def uv_map(
+    *size: Union[int, Tuple[int, int]],
+    top: float = 0.0,
+    left: float = 0.0,
+    bottom: float = 1.0,
+    right: float = 1.0,
+    dtype: np.dtype = np.float32,
+) -> ndarray:
+    """
+    Get image UV space coordinate map, where (0., 0.) is the top-left corner of the image, and (1., 1.) is the bottom-right corner of the image.
+    This is commonly used as normalized image coordinates in texture mapping (when image is not flipped vertically).
+    """
+    if len(size) == 1 and isinstance(size[0], tuple):
+        height, width = size[0]
+    else:
+        height, width = size
+    u = np.linspace(left + 0.5 / width, right - 0.5 / width, width, dtype=dtype)
+    v = np.linspace(top + 0.5 / height, bottom - 0.5 / height, height, dtype=dtype)
+    u, v = np.meshgrid(u, v, indexing="xy")
+    return np.stack([u, v], axis=2)
+
+
+def pixel_coord_map(
+    *size: Union[int, Tuple[int, int]],
+    top: int = 0,
+    left: int = 0,
+    convention: str = "integer-center",
+    dtype: np.dtype = np.float32,
+) -> ndarray:
+    """
+    Get image pixel coordinates map, where (0, 0) is the top-left corner of the top-left pixel, and (width, height) is the bottom-right corner of the bottom-right pixel.
+    """
+    if len(size) == 1 and isinstance(size[0], tuple):
+        height, width = size[0]
+    else:
+        height, width = size
+    u = np.arange(left, left + width, dtype=dtype)
+    v = np.arange(top, top + height, dtype=dtype)
+    if convention == "integer-corner":
+        assert np.issubdtype(dtype, np.floating), (
+            "dtype should be a floating point type when convention is 'integer-corner'"
+        )
+        u = u + 0.5
+        v = v + 0.5
+    u, v = np.meshgrid(u, v, indexing="xy")
+    return np.stack([u, v], axis=2)
+
+
+def masked_nearest_resize(
+    *image: ndarray,
+    mask: ndarray,
+    size: Tuple[int, int],
+    return_index: bool = False,
+) -> Tuple[Unpack[Tuple[ndarray, ...]], ndarray, Tuple[ndarray, ...]]:
+    """
+    Resize image(s) by nearest sampling with mask awareness.
+    """
+    height, width = mask.shape[-2:]
+    target_height, target_width = size
+    filter_h_f, filter_w_f = max(1, height / target_height), max(1, width / target_width)
+    filter_h_i, filter_w_i = math.ceil(filter_h_f), math.ceil(filter_w_f)
+    filter_size = filter_h_i * filter_w_i
+    filter_shape = (filter_h_i, filter_w_i)
+    padding_h, padding_w = filter_h_i // 2 + 1, filter_w_i // 2 + 1
+    padding_shape = ((padding_h, padding_h), (padding_w, padding_w))
+
+    # Window the original mask and uv
+    pixels = pixel_coord_map(height, width, convention="integer-corner", dtype=np.float32)
+    indices = np.arange(height * width, dtype=np.int32).reshape(height, width)
+    window_pixels = sliding_window(pixels, window_size=filter_shape, pad_size=padding_shape, axis=(0, 1))
+    window_indices = sliding_window(indices, window_size=filter_shape, pad_size=padding_shape, axis=(0, 1))
+    window_mask = sliding_window(mask, window_size=filter_shape, pad_size=padding_shape, axis=(-2, -1))
+
+    # Gather the target pixels's local window
+    target_centers = uv_map(target_height, target_width, dtype=np.float32) * np.array([width, height], dtype=np.float32)
+    target_lefttop = target_centers - np.array((filter_w_f / 2, filter_h_f / 2), dtype=np.float32)
+    target_window = np.round(target_lefttop).astype(np.int32) + np.array((padding_w, padding_h), dtype=np.int32)
+
+    target_window_pixels = window_pixels[target_window[..., 1], target_window[..., 0], :, :, :].reshape(
+        target_height, target_width, 2, filter_size
+    )  # (target_height, tgt_width, 2, filter_size)
+    target_window_mask = window_mask[..., target_window[..., 1], target_window[..., 0], :, :].reshape(
+        *mask.shape[:-2], target_height, target_width, filter_size
+    )  # (..., target_height, tgt_width, filter_size)
+    target_window_indices = window_indices[target_window[..., 1], target_window[..., 0], :, :].reshape(
+        target_height, target_width, filter_size
+    )  # (target_height, tgt_width, filter_size)
+
+    # Compute nearest neighbor in the local window for each pixel
+    dist = np.square(target_window_pixels - target_centers[..., None])
+    dist = dist[..., 0, :] + dist[..., 1, :]
+    dist = np.where(target_window_mask, dist, np.inf)  # (..., target_height, tgt_width, filter_size)
+    nearest_in_window = np.argmin(dist, axis=-1, keepdims=True)  # (..., target_height, tgt_width, 1)
+    nearest_idx = np.take_along_axis(
+        np.broadcast_to(target_window_indices, dist.shape),
+        nearest_in_window,
+        axis=-1,
+    ).squeeze(-1)  # (..., target_height, tgt_width)
+    nearest_i, nearest_j = nearest_idx // width, nearest_idx % width
+    target_mask = np.any(target_window_mask, axis=-1)
+    batch_indices = [
+        np.arange(n).reshape([1] * i + [n] + [1] * (mask.ndim - i - 1)) for i, n in enumerate(mask.shape[:-2])
+    ]
+
+    nearest_indices = (*batch_indices, nearest_i, nearest_j)
+    outputs = tuple(x[nearest_indices] for x in image)
+
+    if return_index:
+        return *outputs, target_mask, nearest_indices
+    else:
+        return *outputs, target_mask
+
+
+# --------------------------------------------------------------------------- #
+# From microsoft/MoGe — moge/utils/geometry_numpy.py
+# --------------------------------------------------------------------------- #
+
+
+def normalized_view_plane_uv_numpy(
+    width: int, height: int, aspect_ratio: float = None, dtype: np.dtype = np.float32
+) -> np.ndarray:
+    "UV with left-top corner as (-width / diagonal, -height / diagonal) and right-bottom corner as (width / diagonal, height / diagonal)"
+    if aspect_ratio is None:
+        aspect_ratio = width / height
+
+    span_x = aspect_ratio / (1 + aspect_ratio**2) ** 0.5
+    span_y = 1 / (1 + aspect_ratio**2) ** 0.5
+
+    u = np.linspace(-span_x * (width - 1) / width, span_x * (width - 1) / width, width, dtype=dtype)
+    v = np.linspace(-span_y * (height - 1) / height, span_y * (height - 1) / height, height, dtype=dtype)
+    u, v = np.meshgrid(u, v, indexing="xy")
+    uv = np.stack([u, v], axis=-1)
+    return uv
+
+
+def solve_optimal_focal_shift(uv: np.ndarray, xyz: np.ndarray):
+    "Solve `min |focal * xy / (z + shift) - uv|` with respect to shift and focal"
+    from scipy.optimize import least_squares
+
+    uv, xy, z = uv.reshape(-1, 2), xyz[..., :2].reshape(-1, 2), xyz[..., 2].reshape(-1)
+
+    def fn(uv: np.ndarray, xy: np.ndarray, z: np.ndarray, shift: np.ndarray):
+        xy_proj = xy / (z + shift)[:, None]
+        f = (xy_proj * uv).sum() / np.square(xy_proj).sum()
+        err = (f * xy_proj - uv).ravel()
+        return err
+
+    solution = least_squares(partial(fn, uv, xy, z), x0=0, ftol=1e-3, method="lm")
+    optim_shift = solution["x"].squeeze().astype(np.float32)
+
+    xy_proj = xy / (z + optim_shift)[:, None]
+    optim_focal = (xy_proj * uv).sum() / np.square(xy_proj).sum()
+
+    return optim_shift, optim_focal
+
+
+def solve_optimal_shift(uv: np.ndarray, xyz: np.ndarray, focal: float):
+    "Solve `min |focal * xy / (z + shift) - uv|` with respect to shift"
+    from scipy.optimize import least_squares
+
+    uv, xy, z = uv.reshape(-1, 2), xyz[..., :2].reshape(-1, 2), xyz[..., 2].reshape(-1)
+
+    def fn(uv: np.ndarray, xy: np.ndarray, z: np.ndarray, shift: np.ndarray):
+        xy_proj = xy / (z + shift)[:, None]
+        err = (focal * xy_proj - uv).ravel()
+        return err
+
+    solution = least_squares(partial(fn, uv, xy, z), x0=0, ftol=1e-3, method="lm")
+    optim_shift = solution["x"].squeeze().astype(np.float32)
+
+    return optim_shift
+
+
+def recover_focal_shift_numpy(
+    points: np.ndarray, mask: np.ndarray = None, focal: float = None, downsample_size: Tuple[int, int] = (64, 64)
+):
+    assert points.shape[-1] == 3, "Points should (H, W, 3)"
+
+    height, width = points.shape[-3], points.shape[-2]
+
+    uv = normalized_view_plane_uv_numpy(width=width, height=height)
+
+    if mask is None:
+        points_lr = cv2.resize(points, downsample_size, interpolation=cv2.INTER_LINEAR).reshape(-1, 3)
+        uv_lr = cv2.resize(uv, downsample_size, interpolation=cv2.INTER_LINEAR).reshape(-1, 2)
+    else:
+        points_lr, uv_lr, mask_lr = masked_nearest_resize(points, uv, mask=mask, size=downsample_size)
+
+    if points_lr.size < 2:
+        return 1.0, 0.0
+
+    if focal is None:
+        shift, focal = solve_optimal_focal_shift(uv_lr, points_lr)
+    else:
+        shift = solve_optimal_shift(uv_lr, points_lr, focal)
+
+    return focal, shift

--- a/src/caliscope/estimators/vertical.py
+++ b/src/caliscope/estimators/vertical.py
@@ -1,0 +1,258 @@
+"""Per-camera vertical (up-vector) estimation via the GeoCalib field net.
+
+Runs the GeoCalib perspective-field ONNX (up + latitude fields with
+confidences) on a handful of frames sampled evenly across each camera's video,
+fits gravity per frame with the numpy LM solver (``vertical_solver``), and
+aggregates to one up vector per camera plus a frame-to-frame spread diagnostic.
+
+The estimator eats video and emits a :class:`VerticalEstimate` observation
+type; it never touches camera state. Focal priors come from each camera's
+intrinsic matrix (the solver holds focal fixed and solves the 2-DOF gravity
+direction only). Cross-camera disagreement -- the real accuracy signal -- is
+computed later by ``CaptureVolume.oriented()`` consumers, not here.
+
+Preprocessing is a cv2/numpy port of GeoCalib's kornia image processor
+(``ImagePreprocessor({"resize": 320, "edge_divisible_by": 32})``): resize the
+short side to 320 preserving aspect, then center-crop both edges to a multiple
+of 32. onnxruntime is a lazy import so this module stays importable on a lean
+install; only running the field net requires the ``[tracking]`` extra.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+import cv2
+import numpy as np
+from numpy.typing import NDArray
+
+from caliscope.cameras.camera_array import CameraArray
+from caliscope.estimators.model_store import EstimatorModelSpec, ensure_model
+from caliscope.estimators.vertical_solver import (
+    fit_gravity,
+    gravity_vec_from_roll_pitch,
+)
+from caliscope.recording.frame_source import FrameSource
+from caliscope.recording.video_utils import read_video_properties
+
+logger = logging.getLogger(__name__)
+
+# The four dense fields the network emits, in the ONNX graph's output order.
+FIELD_NAMES = ("up_field", "up_confidence", "latitude_field", "latitude_confidence")
+
+# GeoCalib's fixed preprocessing geometry.
+NET_SHORT_SIDE = 320
+EDGE_MULTIPLE = 32
+
+# Below this resize scale (shrinking more than 2x) cv2.INTER_AREA area-averaging
+# stands in for kornia's antialiased downsample; above it plain bilinear.
+_ANTIALIAS_SCALE_THRESHOLD = 0.5
+
+GEOCALIB_FIELDS_SPEC = EstimatorModelSpec(
+    name="geocalib-fields",
+    filename="geocalib_fields.onnx",
+    source_url=("https://huggingface.co/mprib/geocalib-fields-onnx/resolve/main/geocalib_fields.onnx"),
+    sha256="a724447e1bf7138352e5e70bbe0f011e6fb02909edd3148a5d0f46e8d153ae7b",
+    extraction="direct",
+    file_size_mb=118.2,
+    license_info="Apache-2.0",
+)
+
+
+@dataclass(frozen=True)
+class VerticalEstimate:
+    """Per-camera up vectors with a frame-to-frame stability diagnostic.
+
+    ``up_per_cam`` maps cam_id to a unit up vector in that camera's frame
+    (OpenCV convention, ``[0, -1, 0]`` for a level camera), the normalized mean
+    over the sampled frames. ``spread_per_cam`` maps cam_id to the median
+    angular deviation (degrees) of the per-frame up vectors from that mean --
+    small (0.1-0.3 deg on real footage) when the network is stable across the
+    clip. It is a stability check, not an accuracy one; cross-camera agreement
+    is the accuracy signal and is computed downstream.
+    """
+
+    up_per_cam: dict[int, NDArray]
+    spread_per_cam: dict[int, float]
+
+
+def sample_frame_indices(num_frames: int, num_samples: int) -> tuple[int, ...]:
+    """Evenly spaced frame indices covering the whole clip, first and last included.
+
+    A clip shorter than ``num_samples`` returns every frame. Indices are unique
+    and ascending (np.unique guards the rounding collisions linspace can produce
+    when ``num_samples`` approaches ``num_frames``).
+    """
+    if num_frames <= 0:
+        raise ValueError(f"num_frames must be positive, got {num_frames}")
+    if num_samples <= 0:
+        raise ValueError(f"num_samples must be positive, got {num_samples}")
+    if num_samples >= num_frames:
+        return tuple(range(num_frames))
+    spaced = np.linspace(0, num_frames - 1, num_samples).round().astype(int)
+    return tuple(int(i) for i in np.unique(spaced))
+
+
+def _net_size(orig_h: int, orig_w: int) -> tuple[int, int]:
+    """(net_h, net_w) with the short side at 320, aspect preserved by truncation.
+
+    Mirrors GeoCalib's ``get_new_image_size(side="short")`` including its int()
+    truncation of the long side.
+    """
+    aspect = orig_w / orig_h
+    if aspect < 1.0:  # portrait: width is the short side
+        return int(NET_SHORT_SIDE / aspect), NET_SHORT_SIDE
+    return NET_SHORT_SIDE, int(NET_SHORT_SIDE * aspect)
+
+
+def preprocess_frame(frame_bgr: NDArray) -> tuple[NDArray, float, float]:
+    """Resize/crop a BGR frame to the field net's input; return it with resize scales.
+
+    Returns ``(image, scale_x, scale_y)`` where ``image`` is a
+    ``(1, 3, H, W)`` float32 RGB tensor in [0, 1] with both spatial edges
+    divisible by 32, and the scales (net-resolution / original, taken before the
+    divisibility crop) map an original-image focal into net pixels for the
+    solver. Matches GeoCalib's normalize -> resize -> center-crop order.
+    """
+    orig_h, orig_w = frame_bgr.shape[:2]
+    net_h, net_w = _net_size(orig_h, orig_w)
+
+    rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB).astype(np.float32) / 255.0
+    scale = min(net_w / orig_w, net_h / orig_h)
+    interpolation = cv2.INTER_AREA if scale <= _ANTIALIAS_SCALE_THRESHOLD else cv2.INTER_LINEAR
+    resized = cv2.resize(rgb, (net_w, net_h), interpolation=interpolation)
+
+    # Scales are net-resolution / original, measured before the crop (the crop
+    # shifts the principal point but not the focal), matching GeoCalib.
+    scale_x = net_w / orig_w
+    scale_y = net_h / orig_h
+
+    # Center-crop to a multiple of 32, matching GeoCalib's fit_to_multiple(crop).
+    target_h = (net_h // EDGE_MULTIPLE) * EDGE_MULTIPLE
+    target_w = (net_w // EDGE_MULTIPLE) * EDGE_MULTIPLE
+    top = -((target_h - net_h) // 2)
+    left = -((target_w - net_w) // 2)
+    cropped = resized[top : top + target_h, left : left + target_w]
+
+    image = np.ascontiguousarray(cropped.transpose(2, 0, 1)[None])  # (1, 3, H, W)
+    return image, scale_x, scale_y
+
+
+def _load_session(model_path: Path):
+    """Create a CPU onnxruntime session, lazily importing onnxruntime."""
+    try:
+        import onnxruntime as ort  # type: ignore[reportMissingImports]  # no type stubs
+    except ModuleNotFoundError as e:
+        raise ModuleNotFoundError(
+            "Vertical estimation requires onnxruntime, which is not installed.\n"
+            "Install the tracking extra:\n"
+            "    pip install caliscope[tracking]\n"
+            "(GUI users: pip install caliscope[gui] includes tracking.)"
+        ) from e
+
+    logger.info(f"Loading GeoCalib field net: {model_path}")
+    return ort.InferenceSession(str(model_path), providers=["CPUExecutionProvider"])
+
+
+def _run_field_net(session, image: NDArray, input_name: str) -> tuple[NDArray, ...]:
+    """Run the field net; return the four fields in FIELD_NAMES order."""
+    outputs = session.run(None, {input_name: image})
+    by_name = {out.name: value for out, value in zip(session.get_outputs(), outputs)}
+    return tuple(by_name[name] for name in FIELD_NAMES)
+
+
+def _angle_deg(vec_a: NDArray, vec_b: NDArray) -> float:
+    """Angle between two unit vectors in degrees."""
+    cosine = float(np.clip(np.dot(vec_a, vec_b), -1.0, 1.0))
+    return float(np.degrees(np.arccos(cosine)))
+
+
+def _up_vectors_for_camera(
+    session,
+    input_name: str,
+    video_path: Path,
+    cam_id: int,
+    focal_x: float,
+    focal_y: float,
+    frames_per_camera: int,
+) -> list[NDArray]:
+    """Sample frames, run the field net + solver on each, return per-frame up vectors."""
+    properties = read_video_properties(video_path)
+    indices = sample_frame_indices(properties["frame_count"], frames_per_camera)
+
+    ups: list[NDArray] = []
+    source = FrameSource.from_path(video_path, cam_id=cam_id, wanted_indices=set(indices))
+    try:
+        while (packet := source.next_frame()) is not None:
+            image, scale_x, scale_y = preprocess_frame(packet.frame)
+            fields = _run_field_net(session, image, input_name)
+            fit = fit_gravity(
+                *fields,
+                focal_x_px=focal_x * scale_x,
+                focal_y_px=focal_y * scale_y,
+            )
+            ups.append(gravity_vec_from_roll_pitch(fit.roll_rad, fit.pitch_rad))
+    finally:
+        source.close()
+
+    if not ups:
+        raise ValueError(f"No frames decoded for cam {cam_id} at {video_path}")
+    return ups
+
+
+def estimate_vertical(
+    videos: Mapping[int, Path | str],
+    cameras: CameraArray,
+    *,
+    frames_per_camera: int = 12,
+) -> VerticalEstimate:
+    """Estimate a per-camera up vector from video, using GeoCalib's field net.
+
+    ``videos`` maps cam_id to that camera's video path. Each camera must carry an
+    intrinsic ``matrix`` in ``cameras`` (fx, fy supply the fixed focal prior).
+    Downloads the field-net weights on first use. Runs ``frames_per_camera``
+    evenly spaced frames per camera; the up vector is the normalized mean over
+    those frames and the spread is their median angular deviation from it.
+    """
+    model_path = ensure_model(GEOCALIB_FIELDS_SPEC)
+    session = _load_session(model_path)
+    input_name = session.get_inputs()[0].name
+
+    up_per_cam: dict[int, NDArray] = {}
+    spread_per_cam: dict[int, float] = {}
+
+    for cam_id, video in videos.items():
+        camera = cameras[cam_id]
+        if camera.matrix is None:
+            raise ValueError(
+                f"Camera {cam_id} lacks an intrinsic matrix; vertical estimation "
+                "needs a focal prior. Calibrate intrinsics or supply MoGe focals."
+            )
+        focal_x = float(camera.matrix[0, 0])
+        focal_y = float(camera.matrix[1, 1])
+
+        ups = _up_vectors_for_camera(
+            session,
+            input_name,
+            Path(video),
+            cam_id,
+            focal_x,
+            focal_y,
+            frames_per_camera,
+        )
+
+        stacked = np.array(ups)
+        consensus = stacked.mean(axis=0)
+        consensus = consensus / np.linalg.norm(consensus)
+        spread = float(np.median([_angle_deg(up, consensus) for up in ups]))
+
+        up_per_cam[cam_id] = consensus
+        spread_per_cam[cam_id] = spread
+        logger.info(
+            f"cam {cam_id}: up {consensus.round(4).tolist()}, frame spread {spread:.4f} deg over {len(ups)} frames"
+        )
+
+    return VerticalEstimate(up_per_cam=up_per_cam, spread_per_cam=spread_per_cam)

--- a/src/caliscope/estimators/vertical_solver.py
+++ b/src/caliscope/estimators/vertical_solver.py
@@ -1,0 +1,297 @@
+"""Torch-free LM solver: fit roll and pitch to GeoCalib's perspective fields.
+
+A numpy port of GeoCalib's LM optimizer (ETH CVG, ECCV 2024, Apache 2.0;
+github.com/cvg/GeoCalib, lm_optimizer.py / perspective_fields.py / gravity.py /
+misc.py), reduced to the one case the pipeline needs: pinhole camera, focal
+known and fixed, solve the 2-DOF gravity direction. Together with the field-net
+ONNX export this removes torch from gravity estimation.
+
+The solver's forward model: propose a gravity direction, render the up and
+latitude fields that camera tilt would produce (closed-form geometry), and
+compare against the network's predicted fields, weighting each pixel by the
+network's confidence and a Huber robust loss. Levenberg-Marquardt iterates on
+the unit sphere (Householder-parameterized tangent steps). Faithful port
+quirks, kept deliberately: every step is accepted (no rollback -- a cost
+increase only raises the damping lambda), latitude residuals live in sine
+space, and the second residual evaluation per iteration drives both the lambda
+update and early stopping.
+
+Inputs are the raw field-net outputs at net resolution and the focal in
+net-resolution pixels. Principal point is assumed at the image center, matching
+GeoCalib's pinhole configuration.
+
+Ported verbatim from monokin (src/monokin/gravity_solver.py), validated to
+1.6e-5 deg parity against torch GeoCalib on identical fields. Numerics are kept
+identical; only the module docstring notes the provenance.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+DEFAULT_NUM_STEPS = 30
+DEFAULT_INITIAL_LAMBDA = 0.1
+LAMBDA_MIN, LAMBDA_MAX = 1e-6, 1e2
+STOP_ATOL = STOP_RTOL = 1e-8
+UP_LOSS_SCALE = LAT_LOSS_SCALE = 1e-2
+
+
+@dataclass(frozen=True)
+class GravityFit:
+    """The solver's result: gravity angles, Hessian uncertainties, run evidence."""
+
+    roll_rad: float
+    pitch_rad: float
+    roll_uncertainty_rad: float
+    pitch_uncertainty_rad: float
+    gravity_uncertainty_rad: float
+    initial_cost: float
+    final_cost: float
+    stop_step: int
+
+
+def gravity_vec_from_roll_pitch(roll_rad: float, pitch_rad: float) -> NDArray:
+    """Unit up vector in the OpenCV camera frame; [0, -1, 0] for a level camera."""
+    sin_roll, cos_roll = np.sin(roll_rad), np.cos(roll_rad)
+    sin_pitch, cos_pitch = np.sin(pitch_rad), np.cos(pitch_rad)
+    return np.array([-sin_roll * cos_pitch, -cos_roll * cos_pitch, sin_pitch], dtype=np.float64)
+
+
+def roll_pitch_from_gravity_vec(vec: NDArray) -> tuple[float, float]:
+    """Angles back out of the vector; GeoCalib's branch handles roll beyond +/-90."""
+    eps = 1e-4  # Gravity.eps
+    x, y, z = float(vec[0]), float(vec[1]), float(vec[2])
+    pitch = float(np.arcsin(np.clip(z, -1.0, 1.0)))
+    roll = float(np.arcsin(np.clip(-x / (np.sqrt(max(1 - z**2, 0.0)) + eps), -1.0, 1.0)))
+    if y >= 0:  # upside-down camera: reflect and offset
+        roll = -roll - np.pi * np.sign(x)
+    return roll, pitch
+
+
+def _householder_vector(x: NDArray) -> tuple[NDArray, float]:
+    """v (v[-1] = 1) and beta with (I - beta v v^T) x = |x| e_n; last-element pivot."""
+    sigma = float(np.sum(x[:-1] ** 2))
+    x_pivot = float(x[-1])
+    norm = float(np.linalg.norm(x))
+    sigma = max(sigma, 1e-7)
+    v_pivot = x_pivot - norm if x_pivot < 0 else -sigma / (x_pivot + norm)
+    beta = 2 * v_pivot**2 / (sigma + v_pivot**2)
+    v = np.concatenate([x[:-1] / v_pivot, [1.0]])
+    return v, beta
+
+
+def spherical_plus(x: NDArray, delta: NDArray) -> NDArray:
+    """Move on the unit sphere: exponential map of the tangent step, then rotate to x."""
+    eps = 1e-7
+    norm_delta = float(np.linalg.norm(delta))
+    sinc = 1.0 if norm_delta < eps else np.sin(norm_delta) / norm_delta
+    exp_delta = np.concatenate([sinc * delta, [np.cos(norm_delta)]])
+    v, beta = _householder_vector(x)
+    householder_applied = exp_delta - v * (beta * float(np.dot(v, exp_delta)))
+    return float(np.linalg.norm(x)) * householder_applied
+
+
+def spherical_j_plus(x: NDArray) -> NDArray:
+    """(3, 2) Jacobian of spherical_plus at delta = 0: the tangent basis at x."""
+    v, beta = _householder_vector(x)
+    householder = np.eye(3) - beta * np.outer(v, v)
+    return householder[:, :2]
+
+
+def j_roll_pitch(vec: NDArray) -> NDArray:
+    """(3, 2) Jacobian of the up vector w.r.t. (roll, pitch), for uncertainty only."""
+    roll, pitch = roll_pitch_from_gravity_vec(vec)
+    sin_roll, cos_roll = np.sin(roll), np.cos(roll)
+    sin_pitch, cos_pitch = np.sin(pitch), np.cos(pitch)
+    j_roll = np.array([-cos_roll * cos_pitch, sin_roll * cos_pitch, 0.0])
+    j_pitch = np.array([sin_roll * sin_pitch, cos_roll * sin_pitch, cos_pitch])
+    return np.stack([j_roll, j_pitch], axis=-1)
+
+
+def _huber(x: NDArray) -> tuple[NDArray, NDArray]:
+    """Huber loss and first derivative on already-squared costs (GeoCalib's form)."""
+    mask = x <= 1
+    sqrt_x = np.sqrt(x + 1e-8)
+    inv_sqrt_x = np.maximum(np.finfo(np.float32).eps, 1 / sqrt_x)
+    loss = np.where(mask, x, 2 * sqrt_x - 1)
+    weight = np.where(mask, 1.0, inv_sqrt_x)
+    return loss, weight
+
+
+def _scaled_huber(squared: NDArray, scale: float) -> tuple[NDArray, NDArray]:
+    """GeoCalib's scaled_loss: pre-divide by scale^2, post-multiply the loss."""
+    scale2 = scale**2
+    loss, weight = _huber(squared / scale2)
+    return loss * scale2, weight
+
+
+class _PerspectiveGeometry:
+    """Per-image constants: the pixel grid, its rays, and the field targets."""
+
+    def __init__(
+        self,
+        up_field: NDArray,
+        up_confidence: NDArray,
+        latitude_field: NDArray,
+        latitude_confidence: NDArray,
+        focal_x_px: float,
+        focal_y_px: float,
+    ) -> None:
+        height, width = up_confidence.shape[-2:]
+        # Pixel grid in GeoCalib's row-major (h, w) order, origin at pixel (0, 0),
+        # principal point at the image center.
+        xs, ys = np.meshgrid(np.arange(width), np.arange(height))
+        xy = np.stack([xs, ys], axis=-1).reshape(-1, 2).astype(np.float64)
+        center = np.array([width / 2, height / 2])
+        focal = np.array([focal_x_px, focal_y_px])
+        self.uv = (xy - center) / focal  # (N, 2) normalized image coords
+
+        rays = np.concatenate([self.uv, np.ones((self.uv.shape[0], 1))], axis=-1)
+        self.rays = rays / np.linalg.norm(rays, axis=-1, keepdims=True)  # (N, 3)
+
+        self.target_up = np.asarray(up_field, dtype=np.float64).reshape(2, -1).T  # (N, 2)
+        self.target_sin_lat = np.sin(np.asarray(latitude_field, dtype=np.float64).reshape(-1))
+        self.up_confidence = np.asarray(up_confidence, dtype=np.float64).reshape(-1)
+        self.lat_confidence = np.asarray(latitude_confidence, dtype=np.float64).reshape(-1)
+
+    def render(self, vec: NDArray) -> tuple[NDArray, NDArray, NDArray]:
+        """Fields a camera tilted to `vec` would produce.
+
+        Returns (up_normalized (N, 2), up_unnormalized (N, 2), sin_latitude (N,)).
+        The up vector at a pixel is the image-plane projection of world up:
+        (a, b) - c * uv for gravity vec (a, b, c). Latitude's sine is the dot of
+        the pixel ray with the up vector -- GeoCalib compares sines, so the
+        arcsine never enters the solver.
+        """
+        up_unnormalized = vec[:2][None, :] - vec[2] * self.uv  # (N, 2)
+        norms = np.linalg.norm(up_unnormalized, axis=-1, keepdims=True)
+        up_normalized = up_unnormalized / np.maximum(norms, 1e-12)
+        sin_latitude = np.clip(self.rays @ vec, -1 + 1e-6, 1 - 1e-6)
+        return up_normalized, up_unnormalized, sin_latitude
+
+    def residuals_and_costs(self, vec: NDArray) -> tuple[NDArray, NDArray, NDArray, NDArray, float]:
+        """Residuals (target - rendered) and confidence-weighted Huber costs."""
+        up_normalized, _, sin_latitude = self.render(vec)
+        up_residual = self.target_up - up_normalized  # (N, 2)
+        lat_residual = self.target_sin_lat - sin_latitude  # (N,)
+
+        up_cost, up_weight = _scaled_huber((up_residual**2).sum(axis=-1), UP_LOSS_SCALE)
+        lat_cost, lat_weight = _scaled_huber(lat_residual**2, LAT_LOSS_SCALE)
+        up_weight = up_weight * self.up_confidence
+        lat_weight = lat_weight * self.lat_confidence
+        total_cost = float((up_cost * self.up_confidence).mean() + (lat_cost * self.lat_confidence).mean())
+        return up_residual, up_weight, lat_residual, lat_weight, total_cost
+
+    def gradient_and_hessian(self, vec: NDArray, tangent_basis: NDArray) -> tuple[NDArray, NDArray]:
+        """Confidence-weighted J^T r and J^T J over both fields, 2 parameters.
+
+        tangent_basis (3, 2) maps parameter steps to gravity-vector changes:
+        the spherical manifold basis during optimization, d(vec)/d(roll, pitch)
+        for the uncertainty readout.
+        """
+        up_residual, up_weight, lat_residual, lat_weight, _ = self.residuals_and_costs(vec)
+        up_normalized, up_unnormalized, _ = self.render(vec)
+
+        # Up-field Jacobian: normalize(...) of a linear map of the gravity vec.
+        # d(up_unnorm)/d(abc) at each pixel is [[1, 0, -u], [0, 1, -v]].
+        norms = np.maximum(np.linalg.norm(up_unnormalized, axis=-1, keepdims=True)[..., None], 1e-6)
+        outer = up_unnormalized[..., :, None] * up_unnormalized[..., None, :]
+        j_normalize = np.eye(2)[None] / norms - outer / norms**3  # (N, 2, 2)
+
+        j_proj_abc = np.zeros((self.uv.shape[0], 2, 3))
+        j_proj_abc[:, 0, 0] = 1.0
+        j_proj_abc[:, 1, 1] = 1.0
+        j_proj_abc[:, :, 2] = -self.uv
+        j_up = j_normalize @ (j_proj_abc @ tangent_basis)  # (N, 2, 2)
+
+        # Latitude Jacobian: d(sin lat)/d(abc) is the ray itself.
+        j_lat = self.rays @ tangent_basis  # (N, 2)
+
+        gradient = (up_weight[:, None] * np.einsum("nij,ni->nj", j_up, up_residual)).sum(axis=0)
+        gradient += (lat_weight[:, None] * j_lat * lat_residual[:, None]).sum(axis=0)
+
+        hessian = (up_weight[:, None, None] * np.einsum("nij,nik->njk", j_up, j_up)).sum(axis=0)
+        hessian += (lat_weight[:, None, None] * j_lat[:, :, None] * j_lat[:, None, :]).sum(axis=0)
+        return gradient, hessian
+
+
+def fit_gravity(
+    up_field: NDArray,
+    up_confidence: NDArray,
+    latitude_field: NDArray,
+    latitude_confidence: NDArray,
+    focal_x_px: float,
+    focal_y_px: float,
+    num_steps: int = DEFAULT_NUM_STEPS,
+) -> GravityFit:
+    """Fit roll and pitch to the field-net outputs, focal fixed.
+
+    Args:
+        up_field: (2, h, w) or (1, 2, h, w) predicted up directions.
+        up_confidence: (h, w) or (1, h, w) per-pixel confidence in [0, 1].
+        latitude_field: (1, h, w) or (1, 1, h, w) predicted latitudes, radians.
+        latitude_confidence: (h, w) or (1, h, w) per-pixel confidence.
+        focal_x_px / focal_y_px: fixed focal in net-resolution pixels
+            (original focal times the preprocessor's per-axis resize scale).
+        num_steps: LM iteration budget (GeoCalib default 30, early stop active).
+    """
+    geometry = _PerspectiveGeometry(
+        np.asarray(up_field).squeeze(),
+        np.asarray(up_confidence).squeeze(),
+        np.asarray(latitude_field).squeeze(),
+        np.asarray(latitude_confidence).squeeze(),
+        focal_x_px,
+        focal_y_px,
+    )
+
+    vec = gravity_vec_from_roll_pitch(0.0, 0.0)
+    lambda_damping = DEFAULT_INITIAL_LAMBDA
+    *_, initial_cost = geometry.residuals_and_costs(vec)
+    prev_cost = initial_cost
+    stop_step = num_steps
+
+    for step in range(num_steps):
+        gradient, hessian = geometry.gradient_and_hessian(vec, spherical_j_plus(vec))
+
+        damping = np.maximum(np.diag(hessian) * lambda_damping, 1e-6)
+        try:
+            delta = np.linalg.solve(hessian + np.diag(damping), gradient)
+        except np.linalg.LinAlgError:
+            delta = np.zeros(2)
+
+        vec = spherical_plus(vec, delta)  # every step is accepted, no rollback
+        *_, new_cost = geometry.residuals_and_costs(vec)
+
+        lambda_damping = float(
+            np.clip(
+                lambda_damping * (10.0 if new_cost > prev_cost else 0.1),
+                LAMBDA_MIN,
+                LAMBDA_MAX,
+            )
+        )
+
+        if abs(new_cost - prev_cost) <= STOP_ATOL + STOP_RTOL * abs(prev_cost):
+            stop_step = min(step + 1, stop_step)
+            break
+        prev_cost = new_cost
+
+    # Uncertainty: the Hessian in (roll, pitch) coordinates at the solution.
+    _, hessian_rp = geometry.gradient_and_hessian(vec, j_roll_pitch(vec))
+    covariance = np.linalg.inv(hessian_rp)
+    eigenvalues = np.linalg.eigvalsh(covariance)
+
+    roll, pitch = roll_pitch_from_gravity_vec(vec)
+    *_, final_cost = geometry.residuals_and_costs(vec)
+    return GravityFit(
+        roll_rad=roll,
+        pitch_rad=pitch,
+        roll_uncertainty_rad=float(np.sqrt(max(covariance[0, 0], 0.0))),
+        pitch_uncertainty_rad=float(np.sqrt(max(covariance[1, 1], 0.0))),
+        gravity_uncertainty_rad=float(np.sqrt(max(eigenvalues[-1], 0.0))),
+        initial_cost=float(initial_cost),
+        final_cost=float(final_cost),
+        stop_step=stop_step,
+    )

--- a/src/caliscope/gui/presenters/extrinsic_calibration_presenter.py
+++ b/src/caliscope/gui/presenters/extrinsic_calibration_presenter.py
@@ -23,9 +23,9 @@ from PySide6.QtCore import QObject, Qt, Signal
 
 from caliscope.cameras.camera_array import CameraArray, CameraData
 from caliscope.core.calibrate_extrinsics import (
-    ExtrinsicCalibrationResult,
+    CalibrationRun,
     calibrate_extrinsics,
-    refresh_result,
+    refresh_run,
 )
 from caliscope.core.coverage_analysis import compute_coverage_matrix
 from caliscope.core.point_data import ImagePoints
@@ -188,7 +188,7 @@ class ExtrinsicCalibrationPresenter(QObject):
     volumetric_accuracy_updated = Signal(object)  # VolumetricScaleReport
     coverage_updated = Signal(object, object)  # (coverage_matrix, cam_id_labels)
     capture_volume_changed = Signal(object)  # CaptureVolume
-    calibration_result_updated = Signal(object)  # ExtrinsicCalibrationResult
+    calibration_run_updated = Signal(object)  # CalibrationRun
     workflow_updated = Signal(object)  # CalibrationStepData
     view_model_updated = Signal(object)  # PlaybackViewModel
 
@@ -229,7 +229,7 @@ class ExtrinsicCalibrationPresenter(QObject):
 
         # Processing state (managed internally)
         self._capture_volume: CaptureVolume | None = existing_capture_volume
-        self._calibration_result: ExtrinsicCalibrationResult | None = None
+        self._calibration_run: CalibrationRun | None = None
         self._refine_intrinsics: bool = True
         self._task_handle: TaskHandle | None = None
         self._filter_summary: str | None = None
@@ -337,7 +337,7 @@ class ExtrinsicCalibrationPresenter(QObject):
 
         # Clear existing state to allow re-calibration from CALIBRATED state
         self._capture_volume = None
-        self._calibration_result = None
+        self._calibration_run = None
         self._filter_summary = None
 
         # Clear persisted origin — the old transform is invalidated by recalibration
@@ -351,7 +351,7 @@ class ExtrinsicCalibrationPresenter(QObject):
 
         self._refine_intrinsics = self.refine_intrinsics
 
-        def worker(token: CancellationToken, handle: TaskHandle) -> ExtrinsicCalibrationResult:
+        def worker(token: CancellationToken, handle: TaskHandle) -> CalibrationRun:
             return self._execute_calibration(image_points_path, camera_array, token, handle)
 
         self._task_handle = self._task_manager.submit(
@@ -389,7 +389,7 @@ class ExtrinsicCalibrationPresenter(QObject):
         camera_array: CameraArray,
         token: CancellationToken,
         handle: TaskHandle,
-    ) -> ExtrinsicCalibrationResult:
+    ) -> CalibrationRun:
         """Execute full calibration pipeline. Runs in background thread."""
         image_points = ImagePoints.from_csv(image_points_path)
         constraints = self._constraint_factory() if self._constraint_factory else None
@@ -662,12 +662,12 @@ class ExtrinsicCalibrationPresenter(QObject):
     # Private: Task Callbacks
     # -------------------------------------------------------------------------
 
-    def _on_calibration_completed(self, result: ExtrinsicCalibrationResult) -> None:
+    def _on_calibration_completed(self, run: CalibrationRun) -> None:
         """Handle successful full calibration completion."""
-        capture_volume = result.capture_volume
+        capture_volume = run.capture_volume
         logger.info(f"Calibration complete. RMSE: {capture_volume.reprojection_report.overall_rmse:.3f}px")
 
-        self._calibration_result = result
+        self._calibration_run = run
         self._capture_volume = capture_volume
         self._task_handle = None
 
@@ -682,7 +682,7 @@ class ExtrinsicCalibrationPresenter(QObject):
         self._refresh_volumetric_accuracy()
         self._refresh_workflow_strip()
         self.capture_volume_changed.emit(capture_volume)
-        self.calibration_result_updated.emit(result)
+        self.calibration_run_updated.emit(run)
 
     def _on_reoptimization_completed(self, capture_volume: CaptureVolume) -> None:
         """Handle successful filter re-optimization completion."""
@@ -691,8 +691,8 @@ class ExtrinsicCalibrationPresenter(QObject):
         self._capture_volume = capture_volume
         self._task_handle = None
 
-        if self._calibration_result is not None:
-            self._calibration_result = refresh_result(self._calibration_result, capture_volume)
+        if self._calibration_run is not None:
+            self._calibration_run = refresh_run(self._calibration_run, capture_volume)
 
         self._emit_state_changed()
         self._refresh_quality_panel()
@@ -702,8 +702,8 @@ class ExtrinsicCalibrationPresenter(QObject):
         self._refresh_workflow_strip()
         self.capture_volume_changed.emit(capture_volume)
 
-        if self._calibration_result is not None:
-            self.calibration_result_updated.emit(self._calibration_result)
+        if self._calibration_run is not None:
+            self.calibration_run_updated.emit(self._calibration_run)
 
     def _on_calibration_failed(self, exc_type: str, message: str) -> None:
         """Handle calibration failure."""
@@ -736,15 +736,15 @@ class ExtrinsicCalibrationPresenter(QObject):
         cv: CaptureVolume,
         depth_ratios: dict[int, float],
     ) -> list[CameraQualityRow]:
-        """Build per-camera quality rows, tagging intrinsic source when a result is available."""
+        """Build per-camera quality rows, tagging intrinsic source when a calibration run is available."""
         report = cv.reprojection_report
-        result = self._calibration_result
+        run = self._calibration_run
 
         anchors: dict[int, tuple[float, float, float]] = {}
         synthesized_ids: frozenset[int] = frozenset()
-        if result is not None:
-            synthesized_ids = result.synthesized_cam_ids
-            for est in result.intrinsic_estimates:
+        if run is not None:
+            synthesized_ids = run.synthesized_cam_ids
+            for est in run.intrinsic_estimates:
                 anchors[est.cam_id] = (est.f_initial, est.k1_initial, est.k2_initial)
 
         rows: list[CameraQualityRow] = []
@@ -759,7 +759,7 @@ class ExtrinsicCalibrationPresenter(QObject):
             delta_f: float | None = None
             delta_k1: float | None = None
             delta_k2: float | None = None
-            if result is None:
+            if run is None:
                 source = "—"
             elif cam_id in synthesized_ids:
                 source = "estimated"
@@ -829,23 +829,22 @@ class ExtrinsicCalibrationPresenter(QObject):
             )
         return rows
 
-    def _build_warnings(
-        self, status: OptimizationStatus | None, result: ExtrinsicCalibrationResult | None
-    ) -> list[str]:
-        """Build warning strings from optimization status and calibration result."""
+    def _build_warnings(self, status: OptimizationStatus | None, run: CalibrationRun | None) -> list[str]:
+        """Build warning strings from optimization status and calibration run."""
         warnings: list[str] = []
         if status is not None and not status.converged:
             warnings.append("Optimization did not converge")
 
-        if result is not None:
-            for bw in result.bound_warnings:
+        if status is not None:
+            for bw in status.bound_warnings:
                 warnings.append(f"Camera {bw.cam_id}: {bw.parameter} hit {bw.bound} bound at {bw.value:.1f}")
-            if result.dropped_static_markers:
-                ids_str = ", ".join(str(m) for m in result.dropped_static_markers)
-                warnings.append(
-                    f"Markers {ids_str} labeled static but showed too much positional "
-                    f"variance — removed from static constraint set"
-                )
+
+        if run is not None and run.dropped_static_markers:
+            ids_str = ", ".join(str(m) for m in run.dropped_static_markers)
+            warnings.append(
+                f"Markers {ids_str} labeled static but showed too much positional "
+                f"variance — removed from static constraint set"
+            )
         return warnings
 
     def _refresh_quality_panel(self) -> None:
@@ -856,7 +855,7 @@ class ExtrinsicCalibrationPresenter(QObject):
         cv = self._capture_volume
         report = cv.reprojection_report
         status = cv.optimization_status
-        result = self._calibration_result
+        run = self._calibration_run
 
         scale_report = cv.compute_volumetric_scale_accuracy()
         self._latest_scale_report = scale_report
@@ -864,7 +863,7 @@ class ExtrinsicCalibrationPresenter(QObject):
         depth_ratios = compute_depth_ratios(cv)
         camera_rows = self._build_camera_rows(cv, depth_ratios)
         marker_rows = self._build_marker_rows(scale_report)
-        warnings = self._build_warnings(status, result)
+        warnings = self._build_warnings(status, run)
 
         moving_pct, static_pct = scale_report.split_relative_rmse_pct
         has_pairs = len(scale_report.frame_errors) > 0
@@ -1107,8 +1106,8 @@ class ExtrinsicCalibrationPresenter(QObject):
         """
         self._capture_volume = capture_volume
 
-        if self._calibration_result is not None:
-            self._calibration_result = refresh_result(self._calibration_result, capture_volume)
+        if self._calibration_run is not None:
+            self._calibration_run = refresh_run(self._calibration_run, capture_volume)
 
         self._emit_state_changed()
         self._refresh_quality_panel()
@@ -1117,5 +1116,5 @@ class ExtrinsicCalibrationPresenter(QObject):
         self._refresh_workflow_strip()
         self.capture_volume_changed.emit(capture_volume)
 
-        if self._calibration_result is not None:
-            self.calibration_result_updated.emit(self._calibration_result)
+        if self._calibration_run is not None:
+            self.calibration_run_updated.emit(self._calibration_run)

--- a/src/caliscope/trackers/model_download.py
+++ b/src/caliscope/trackers/model_download.py
@@ -13,12 +13,24 @@ import urllib.request
 import zipfile
 from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from caliscope.trackers.model_card import ModelCard
+from typing import Protocol
 
 logger = logging.getLogger(__name__)
+
+
+class ModelSource(Protocol):
+    """Anything downloadable by this module: tracker ModelCards and estimator specs."""
+
+    @property
+    def name(self) -> str: ...
+    @property
+    def model_path(self) -> Path: ...
+    @property
+    def source_url(self) -> str | None: ...
+    @property
+    def sha256(self) -> str | None: ...
+    @property
+    def extraction(self) -> str | None: ...
 
 
 def _download_to_temp(
@@ -159,7 +171,7 @@ def _extract_zip_end2end(zip_path: Path, target_name: str) -> Path:
 
 
 def download_and_extract_model(
-    card: "ModelCard",
+    card: ModelSource,
     target_dir: Path,
     progress_callback: Callable[[int, int], None] | None = None,
     cancellation_check: Callable[[], bool] | None = None,

--- a/tests/synthetic/production.py
+++ b/tests/synthetic/production.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from caliscope.core.calibrate_extrinsics import ExtrinsicCalibrationResult, calibrate_extrinsics
+from caliscope.core.calibrate_extrinsics import CalibrationRun, calibrate_extrinsics
 from caliscope.core.capture_volume import CaptureVolume
 from caliscope.core.constraints import ConstraintSet
 from caliscope.core.point_data import ImagePoints
@@ -20,7 +20,7 @@ from tests.synthetic.assertions import PoseError, align_to_ground_truth, pose_er
 
 @dataclass(frozen=True)
 class ProductionRun:
-    result: ExtrinsicCalibrationResult
+    result: CalibrationRun
     aligned_volume: CaptureVolume  # Procrustes-aligned to ground truth
     pose_errors: dict[int, PoseError]  # cam_id -> error vs ground truth
 

--- a/tests/synthetic/test_epipolar_bootstrap.py
+++ b/tests/synthetic/test_epipolar_bootstrap.py
@@ -1,0 +1,254 @@
+"""Epipolar bootstrap (2D-only, no object geometry) through the production pipeline.
+
+The epipolar path recovers extrinsics from 2D-2D correspondences via the
+essential matrix, for trackers that emit only image points (body keypoints) with
+no known object geometry. These tests drive it through the real
+calibrate_extrinsics() seam with obj_loc nulled -- the same production entry
+point the PnP tests use -- plus a couple of cheap unit tests pinning the two
+convention-sensitive numerics (essential recovery, correspondence pooling).
+
+Why a box (3D) target rather than the planar grid: the essential-matrix
+decomposition is degenerate for coplanar points. The planar grid, with its
+one-sided visibility culling, leaves each camera pair co-observing a
+near-coplanar arc, so the essential estimate flips ~140 deg for a minority of
+noise seeds -- a genuine geometric degeneracy, not a solver bug. The epipolar
+path's real target is body keypoints: a 3D constellation seen from all sides.
+box_target_scene is the faithful analog (non-planar, no visibility culling) and
+recovers robustly across seeds.
+
+Tolerances are derived from measured worst-across-seeds error with headroom,
+against the framework's covariance-propagation ceiling (tests/synthetic/README.md:
+translation ~ GEOMETRY_FACTOR x pixel_sigma ~ 7.5-10mm at 0.5px). Measured worst
+over seeds 0-19: 4-cam 0.070 deg / 2.1 mm; over seeds 0-11: 2-cam 0.13 deg /
+5.3 mm. The bounds below sit ~3-4x above the measured worst and within the
+theory ceiling. A failure is a finding, not a prompt to relax the bound.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import cv2
+import numpy as np
+import pandas as pd
+import pytest
+
+from caliscope.cameras.camera_array import CameraData
+from caliscope.core.bootstrap_pose.epipolar_pose_builder import (
+    pooled_correspondences,
+    recover_pair_pose,
+)
+from caliscope.core.calibrate_extrinsics import calibrate_extrinsics
+from caliscope.core.capture_volume import CaptureVolume
+from caliscope.core.point_data import ImagePoints
+from caliscope.exceptions import CalibrationError
+from caliscope.synthetic import (
+    CameraSynthesizer,
+    SyntheticScene,
+    Trajectory,
+    strip_intrinsics,
+)
+from caliscope.synthetic.scene_factories import box_target_scene
+from caliscope.synthetic.target_factories import box_target
+from tests.synthetic.production import ProductionRun, run_production_pipeline
+
+
+def _null_obj_loc(image_points: ImagePoints) -> ImagePoints:
+    """Strip object geometry, forcing the epipolar (2D-only) bootstrap path."""
+    df = image_points.df.copy()
+    df[["obj_loc_x", "obj_loc_y", "obj_loc_z"]] = np.nan
+    return ImagePoints(df)
+
+
+def _two_camera_box_scene(random_seed: int = 42) -> SyntheticScene:
+    """A single stereo pair viewing the non-planar box target."""
+    camera_array = CameraSynthesizer().add_ring(n=2, radius=2.0, height=0.5).build()
+    calibration_object = box_target(width=0.4, height=0.4, depth=0.4)
+    trajectory = Trajectory.orbital(n_frames=20, radius=0.2, arc_extent_deg=360.0, tumble_rate=1.0)
+    return SyntheticScene.single(
+        camera_array=camera_array,
+        calibration_object=calibration_object,
+        trajectory=trajectory,
+        pixel_noise_sigma=0.5,
+        random_seed=random_seed,
+    )
+
+
+@dataclass(frozen=True)
+class Case:
+    run: ProductionRun
+    scene: SyntheticScene
+
+
+def _four_cam_case() -> Case:
+    scene = box_target_scene(random_seed=42)
+    run = run_production_pipeline(scene, image_points=_null_obj_loc(scene.image_points_noisy))
+    return Case(run=run, scene=scene)
+
+
+def _two_cam_case() -> Case:
+    scene = _two_camera_box_scene(random_seed=42)
+    run = run_production_pipeline(scene, image_points=_null_obj_loc(scene.image_points_noisy))
+    return Case(run=run, scene=scene)
+
+
+@pytest.fixture(scope="module")
+def four_cam_case() -> Case:
+    return _four_cam_case()
+
+
+@pytest.fixture(scope="module")
+def two_cam_case() -> Case:
+    return _two_cam_case()
+
+
+class TestFourCameraEpipolar:
+    def test_all_cameras_posed(self, four_cam_case: Case) -> None:
+        posed = set(four_cam_case.run.result.capture_volume.camera_array.posed_cameras)
+        assert posed == {0, 1, 2, 3}
+
+    def test_pose_recovery(self, four_cam_case: Case) -> None:
+        # 0.5 deg / 8 mm: 4-cam ring, 0.5px sigma. Rotation uses the scene's
+        # standard covariance-propagation bound (as TestCleanSceneProduction);
+        # translation is set at ~4x the measured worst-across-seeds (2.1mm) and
+        # within the README's GEOMETRY_FACTOR ceiling (~7.5-10mm at 0.5px). The
+        # epipolar path carries the looser translation bound the plan anticipated
+        # for a bootstrap that starts from 2D-2D data with no metric anchor.
+        for cam_id, err in four_cam_case.run.pose_errors.items():
+            assert err.rotation_deg < 0.5, f"cam {cam_id}: rotation {err.rotation_deg:.3f} deg > 0.5 deg"
+            assert err.translation_m < 0.008, f"cam {cam_id}: translation {err.translation_m * 1000:.2f} mm > 8 mm"
+
+    def test_intrinsics_untouched(self, four_cam_case: Case) -> None:
+        # Real intrinsics were supplied (not blind), so nothing was synthesized.
+        # The box's depth ratio (~1.2) is below the 2.0 refinement gate, so
+        # intrinsics are left exactly as provided.
+        result = four_cam_case.run.result
+        assert result.synthesized_cam_ids == frozenset()
+        assert result.intrinsic_refinement_gated
+        for est in result.intrinsic_estimates:
+            assert est.f_recovered == est.f_initial
+
+
+class TestTwoCameraEpipolar:
+    def test_both_cameras_posed(self, two_cam_case: Case) -> None:
+        posed = set(two_cam_case.run.result.capture_volume.camera_array.posed_cameras)
+        assert posed == {0, 1}
+
+    def test_pose_recovery(self, two_cam_case: Case) -> None:
+        # 0.5 deg / 10 mm: a single stereo pair has no third view for redundancy,
+        # so its covariance is higher than the 4-cam ring's. Measured worst over
+        # seeds 0-11 was 0.13 deg / 5.3mm; the bound is ~2x that and still under
+        # the two-camera minimal-redundancy precedent (TestMirrorPairZeroThickness,
+        # 20mm). Baseline scale is arbitrary; the Procrustes alignment absorbs it.
+        for cam_id, err in two_cam_case.run.pose_errors.items():
+            assert err.rotation_deg < 0.5, f"cam {cam_id}: rotation {err.rotation_deg:.3f} deg > 0.5 deg"
+            assert err.translation_m < 0.010, f"cam {cam_id}: translation {err.translation_m * 1000:.2f} mm > 10 mm"
+
+
+class TestEpipolarGates:
+    def test_uncalibrated_intrinsics_raises(self) -> None:
+        # Blind intrinsics (f=width/2) are geometrically fatal for the essential
+        # path: with no obj_loc anchor to absorb focal error, the decomposition
+        # yields wrong poses. calibrate_extrinsics must refuse before bootstrap.
+        scene = box_target_scene(random_seed=42)
+        blind_cameras = strip_intrinsics(scene.intrinsics_only_cameras())
+        with pytest.raises(CalibrationError, match="intrinsic"):
+            calibrate_extrinsics(_null_obj_loc(scene.image_points_noisy), blind_cameras, None)
+
+    def test_insufficient_overlap_raises(self) -> None:
+        # Cameras that never co-observe the subject (disjoint frame ranges) share
+        # zero correspondences, so no essential matrix can be formed.
+        scene = _two_camera_box_scene(random_seed=42)
+        df = _null_obj_loc(scene.image_points_noisy).df
+        disjoint = df[
+            ((df["cam_id"] == 0) & (df["sync_index"] < 10)) | ((df["cam_id"] == 1) & (df["sync_index"] >= 10))
+        ].reset_index(drop=True)
+        with pytest.raises(CalibrationError, match="overlap"):
+            CaptureVolume.bootstrap(ImagePoints(disjoint), scene.intrinsics_only_cameras())
+
+
+class TestEpipolarUnit:
+    def test_recover_pair_pose_exact(self) -> None:
+        # Noiseless recovery pins the convention-sensitive essential -> pose step:
+        # rotation is exact, translation is recovered up to a sign-fixed unit
+        # direction (essential geometry has no baseline scale).
+        rng = np.random.default_rng(0)
+        points_world = rng.uniform([-0.5, -0.5, 4.0], [0.5, 0.5, 6.0], size=(300, 3))
+        matrix = np.array([[1600.0, 0, 960.0], [0, 1600.0, 540.0], [0, 0, 1.0]])
+        cam_a = CameraData(cam_id=0, size=(1920, 1080), matrix=matrix, distortions=np.zeros(5))
+        cam_b = CameraData(cam_id=1, size=(1920, 1080), matrix=matrix, distortions=np.zeros(5))
+
+        rot_b = cv2.Rodrigues(np.array([0.05, 0.35, -0.1]))[0]
+        t_b = np.array([1.2, 0.1, 0.3])
+
+        pix_a = _project(points_world, np.eye(3), np.zeros(3), matrix)
+        pix_b = _project(points_world, rot_b, t_b, matrix)
+
+        pose = recover_pair_pose(pix_a, pix_b, camera_a=cam_a, camera_b=cam_b)
+        # 1e-4: noiseless recovery is exact up to the RANSAC/recoverPose numerical
+        # floor (~3e-5 here); the translation is a sign-fixed unit direction.
+        assert np.allclose(pose["rotation"], rot_b, atol=1e-4)
+        assert np.allclose(pose["translation"], t_b / np.linalg.norm(t_b), atol=1e-4)
+        assert pose["conditioning"] > 0.9  # well-conditioned 3D cloud
+
+    def test_pooled_correspondences_matches_and_drops_nan(self) -> None:
+        # Shared (object_id, keypoint_id, sync_index) rows pair up; a correspondence
+        # with a NaN pixel in either camera drops from the pool.
+        df_a = pd.DataFrame(
+            {
+                "sync_index": [0, 0, 1, 2],
+                "cam_id": [0, 0, 0, 0],
+                "object_id": [0, 0, 0, 0],
+                "keypoint_id": [1, 2, 1, 1],
+                "img_loc_x": [10.0, 20.0, 11.0, np.nan],
+                "img_loc_y": [10.0, 20.0, 11.0, 40.0],
+            }
+        )
+        df_b = pd.DataFrame(
+            {
+                "sync_index": [0, 0, 1, 2],
+                "cam_id": [1, 1, 1, 1],
+                "object_id": [0, 0, 0, 0],
+                "keypoint_id": [1, 2, 3, 1],  # (1,3) has no match in a; sync 2 kp 1 matches but a's pixel is NaN
+                "img_loc_x": [110.0, 120.0, 130.0, 140.0],
+                "img_loc_y": [110.0, 120.0, 130.0, 140.0],
+            }
+        )
+        keys, pix_a, pix_b = pooled_correspondences(df_a, df_b)
+        # Matches: (obj0,kp1,sync0), (obj0,kp2,sync0). (kp1,sync1) has no b match;
+        # (kp1,sync2) is dropped for a's NaN pixel.
+        assert len(keys) == 2
+        matched = {(int(o), int(k), int(s)) for o, k, s in keys}
+        assert matched == {(0, 1, 0), (0, 2, 0)}
+        assert np.isfinite(pix_a).all() and np.isfinite(pix_b).all()
+
+
+def _project(points_world: np.ndarray, rotation: np.ndarray, translation: np.ndarray, matrix: np.ndarray) -> np.ndarray:
+    """Pixel projection of world points under a world-to-camera pose (no distortion)."""
+    cam = points_world @ rotation.T + translation
+    image = cam @ matrix.T
+    return image[:, :2] / image[:, 2:3]
+
+
+if __name__ == "__main__":
+    print("Four-camera epipolar...")
+    four = _four_cam_case()
+    TestFourCameraEpipolar().test_all_cameras_posed(four)
+    TestFourCameraEpipolar().test_pose_recovery(four)
+    TestFourCameraEpipolar().test_intrinsics_untouched(four)
+    print(f"  worst rot {four.run.max_rotation_deg:.4f} deg, trans {four.run.max_translation_m * 1000:.3f} mm")
+
+    print("Two-camera epipolar...")
+    two = _two_cam_case()
+    TestTwoCameraEpipolar().test_both_cameras_posed(two)
+    TestTwoCameraEpipolar().test_pose_recovery(two)
+    print(f"  worst rot {two.run.max_rotation_deg:.4f} deg, trans {two.run.max_translation_m * 1000:.3f} mm")
+
+    print("Gates...")
+    TestEpipolarGates().test_uncalibrated_intrinsics_raises()
+    TestEpipolarGates().test_insufficient_overlap_raises()
+
+    print("Unit...")
+    TestEpipolarUnit().test_recover_pair_pose_exact()
+    TestEpipolarUnit().test_pooled_correspondences_matches_and_drops_nan()
+    print("  PASSED")

--- a/tests/synthetic/test_production_pipeline.py
+++ b/tests/synthetic/test_production_pipeline.py
@@ -24,6 +24,7 @@ from caliscope.core.capture_volume import CaptureVolume
 from caliscope.core.charuco import Charuco
 from caliscope.core.constraints import ConstraintSet
 from caliscope.core.point_data import STATIC_SYNC_INDEX, ImagePoints
+from caliscope.core.scale_accuracy import compute_depth_ratios
 from caliscope.synthetic import SyntheticScene
 from caliscope.synthetic.scene_factories import (
     charuco_target_scene,
@@ -248,8 +249,10 @@ class TestCleanSceneProduction:
 
         assert result.synthesized_cam_ids == frozenset()
         assert result.dropped_static_markers == ()
-        assert result.bound_warnings == ()
-        assert set(result.depth_ratios) == posed_ids
+        status = result.capture_volume.optimization_status
+        assert status is not None
+        assert status.bound_warnings == ()
+        assert set(compute_depth_ratios(result.capture_volume)) == posed_ids
         # Ring geometry: depth ratio ~1.29 < 2.0 gate, so refinement is gated off.
         assert result.intrinsic_refinement_gated
 

--- a/tests/test_calibrate_extrinsics.py
+++ b/tests/test_calibrate_extrinsics.py
@@ -6,9 +6,9 @@ import numpy as np
 import pytest
 
 from caliscope.core.calibrate_extrinsics import (
-    ExtrinsicCalibrationResult,
+    CalibrationRun,
     calibrate_extrinsics,
-    refresh_result,
+    refresh_run,
 )
 from caliscope.synthetic import strip_intrinsics
 from caliscope.synthetic.scene_factories import wand_scene_with_constraints
@@ -26,7 +26,7 @@ class TestEndToEndBlind:
             constraints,
         )
 
-        assert isinstance(result, ExtrinsicCalibrationResult)
+        assert isinstance(result, CalibrationRun)
         assert result.capture_volume.optimization_status is not None
         assert result.capture_volume.optimization_status.converged
         assert result.synthesized_cam_ids == frozenset(cameras.cameras.keys())
@@ -122,7 +122,7 @@ class TestProgressAndCancellation:
             )
 
 
-class TestRefreshResult:
+class TestRefreshRun:
     def test_preserves_anchors_updates_recovered(self):
         scene, constraints = wand_scene_with_constraints(include_static=False)
         cameras = scene.intrinsics_only_cameras()
@@ -137,7 +137,7 @@ class TestRefreshResult:
         filtered = cv.filter_by_percentile_error(2.5)
         reoptimized = filtered.optimize(refine_intrinsics=True)
 
-        refreshed = refresh_result(original, reoptimized)
+        refreshed = refresh_run(original, reoptimized)
 
         for est_orig, est_new in zip(original.intrinsic_estimates, refreshed.intrinsic_estimates):
             assert est_orig.f_initial == est_new.f_initial
@@ -173,6 +173,6 @@ if __name__ == "__main__":
     TestProgressAndCancellation().test_cancelled_token_raises()
     print("  PASSED")
 
-    print("Refresh result...")
-    TestRefreshResult().test_preserves_anchors_updates_recovered()
+    print("Refresh run...")
+    TestRefreshRun().test_preserves_anchors_updates_recovered()
     print("  PASSED")

--- a/tests/test_capture_volume_anchoring.py
+++ b/tests/test_capture_volume_anchoring.py
@@ -221,6 +221,64 @@ def test_missing_camera_cue_raises():
         volume.scaled(CameraDistance(cam_a=0, cam_b=99, meters=5.0))
 
 
+def test_unresolvable_depth_cues_skipped_survivors_scale():
+    # Bulk depth cues: one resolves, one references a keypoint with no world point.
+    cameras = {
+        0: make_camera(0, np.eye(3), np.array([0.0, 0.0, 0.0])),
+        1: make_camera(1, np.eye(3), np.array([3.0, 0.0, 0.0])),
+    }
+    rows = [world_row(5, 10, (0.0, 0.0, 2.0)), world_row(5, 11, (1.0, 0.0, 2.0))]
+    volume = make_volume(cameras, rows)
+
+    with pytest.warns(UserWarning, match="Skipped 1 of 2 depth cues"):
+        scaled = volume.scaled(
+            DepthObservation(cam_id=0, keypoint_id=10, sync_index=5, depth_m=5.0),  # resolves, depth 2
+            DepthObservation(cam_id=0, keypoint_id=99, sync_index=5, depth_m=9.0),  # no world point
+        )
+
+    # Only the survivor sets scale: depth 2 -> 5.0 exactly.
+    df = scaled.world_points.df
+    p = df[(df["sync_index"] == 5) & (df["keypoint_id"] == 10)][["x_coord", "y_coord", "z_coord"]].to_numpy()[0]
+    cam = scaled.camera_array.cameras[0]
+    assert cam.rotation is not None and cam.translation is not None
+    recovered_depth = float((cam.rotation @ p + cam.translation)[2])
+    assert abs(recovered_depth - 5.0) < 1e-10
+
+
+def test_all_depth_cues_unresolvable_raises():
+    cameras = {
+        0: make_camera(0, np.eye(3), np.array([0.0, 0.0, 0.0])),
+        1: make_camera(1, np.eye(3), np.array([3.0, 0.0, 0.0])),
+    }
+    rows = [world_row(5, 10, (0.0, 0.0, 2.0)), world_row(5, 11, (1.0, 0.0, 2.0))]
+    volume = make_volume(cameras, rows)
+
+    with pytest.raises(ValueError, match="unresolvable"):
+        volume.scaled(
+            DepthObservation(cam_id=0, keypoint_id=98, sync_index=5, depth_m=5.0),
+            DepthObservation(cam_id=0, keypoint_id=99, sync_index=5, depth_m=9.0),
+        )
+
+
+def test_negative_depth_cue_skipped_camera_distance_still_scales():
+    cameras = {
+        0: make_camera(0, np.eye(3), np.array([0.0, 0.0, 0.0])),
+        1: make_camera(1, np.eye(3), np.array([4.0, 0.0, 0.0])),
+    }
+    # Keypoint 10 sits behind camera 0 (z < 0 in its frame) -- triangulation noise.
+    rows = [world_row(0, 10, (0.0, 0.0, -3.0)), world_row(0, 11, (1.0, 0.0, 2.0))]
+    volume = make_volume(cameras, rows)
+
+    with pytest.warns(UserWarning, match="non-positive depth"):
+        scaled = volume.scaled(
+            DepthObservation(cam_id=0, keypoint_id=10, sync_index=0, depth_m=5.0),  # behind camera
+            CameraDistance(cam_a=0, cam_b=1, meters=10.0),  # good, sets scale exactly
+        )
+
+    recovered = float(np.linalg.norm(camera_center(scaled, 0) - camera_center(scaled, 1)))
+    assert abs(recovered - 10.0) < 1e-10
+
+
 # ---------------------------------------------------------------------------
 # Orientation
 # ---------------------------------------------------------------------------

--- a/tests/test_capture_volume_anchoring.py
+++ b/tests/test_capture_volume_anchoring.py
@@ -1,0 +1,346 @@
+"""Post-BA metric anchoring: CaptureVolume.scaled / oriented / grounded.
+
+These transforms are exact arithmetic on an already-solved volume, so no bundle
+adjustment runs here. Fixtures are hand-built: cameras with known extrinsics, a
+handful of world points, and matching minimal image points.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from scipy.spatial.transform import Rotation
+
+from caliscope.cameras.camera_array import CameraArray, CameraData
+from caliscope.core.capture_volume import CaptureVolume
+from caliscope.core.point_data import ImagePoints, WorldPoints
+from caliscope.core.scale_cues import CameraDistance, DepthObservation, SegmentLength
+
+DEFAULT_K = np.array([[600.0, 0.0, 320.0], [0.0, 600.0, 240.0], [0.0, 0.0, 1.0]])
+
+
+def make_camera(cam_id: int, rotation: np.ndarray, center: np.ndarray) -> CameraData:
+    """Posed camera whose world-frame center is ``center`` (t = -R @ C)."""
+    rotation = np.asarray(rotation, dtype=np.float64)
+    center = np.asarray(center, dtype=np.float64)
+    translation = -rotation @ center
+    return CameraData(
+        cam_id=cam_id,
+        size=(640, 480),
+        matrix=DEFAULT_K.copy(),
+        distortions=np.zeros(5),
+        rotation=rotation,
+        translation=translation,
+    )
+
+
+def make_volume(cameras: dict[int, CameraData], world_rows: list[dict]) -> CaptureVolume:
+    """Build a CaptureVolume from posed cameras and explicit world points.
+
+    Each world point is given a matching observation in every posed camera so the
+    image-to-object map has real correspondences. Image coordinates are dummies --
+    nothing here re-triangulates.
+    """
+    world_df = pd.DataFrame(world_rows)
+    world_df["frame_time"] = np.nan
+    world_points = WorldPoints(world_df)
+
+    img_rows = []
+    for row in world_rows:
+        for cam_id in cameras:
+            img_rows.append(
+                {
+                    "sync_index": row["sync_index"],
+                    "cam_id": cam_id,
+                    "object_id": row["object_id"],
+                    "keypoint_id": row["keypoint_id"],
+                    "img_loc_x": 100.0,
+                    "img_loc_y": 100.0,
+                }
+            )
+    image_points = ImagePoints(pd.DataFrame(img_rows))
+
+    return CaptureVolume(
+        camera_array=CameraArray(cameras),
+        image_points=image_points,
+        world_points=world_points,
+    )
+
+
+def world_row(sync_index: int, keypoint_id: int, xyz: tuple[float, float, float], object_id: int = 0) -> dict:
+    return {
+        "sync_index": sync_index,
+        "object_id": object_id,
+        "keypoint_id": keypoint_id,
+        "x_coord": float(xyz[0]),
+        "y_coord": float(xyz[1]),
+        "z_coord": float(xyz[2]),
+    }
+
+
+def camera_center(volume: CaptureVolume, cam_id: int) -> np.ndarray:
+    cam = volume.camera_array.cameras[cam_id]
+    assert cam.rotation is not None and cam.translation is not None
+    return -cam.rotation.T @ cam.translation
+
+
+# ---------------------------------------------------------------------------
+# Scale
+# ---------------------------------------------------------------------------
+
+
+def test_single_camera_distance_recovers_scale():
+    cameras = {
+        0: make_camera(0, np.eye(3), np.array([0.0, 0.0, 0.0])),
+        1: make_camera(1, np.eye(3), np.array([3.0, 0.0, 0.0])),
+        2: make_camera(2, np.eye(3), np.array([0.0, 3.0, 0.0])),
+    }
+    rows = [world_row(0, 10, (1.0, 1.0, 1.0)), world_row(0, 11, (2.0, 0.0, 1.0))]
+    volume = make_volume(cameras, rows)
+
+    scaled = volume.scaled(CameraDistance(cam_a=0, cam_b=1, meters=7.5))
+
+    recovered = float(np.linalg.norm(camera_center(scaled, 0) - camera_center(scaled, 1)))
+    assert abs(recovered - 7.5) < 1e-10
+
+
+def test_single_segment_length_recovers_scale():
+    cameras = {
+        0: make_camera(0, np.eye(3), np.array([0.0, 0.0, 0.0])),
+        1: make_camera(1, np.eye(3), np.array([3.0, 0.0, 0.0])),
+    }
+    # Keypoints 10 and 11 are exactly one BA-unit apart in every frame,
+    # so the median segment length is 1.0.
+    rows = [
+        world_row(0, 10, (0.0, 0.0, 0.0)),
+        world_row(0, 11, (0.0, 0.0, 1.0)),
+        world_row(1, 10, (1.0, 0.0, 0.0)),
+        world_row(1, 11, (1.0, 0.0, 1.0)),
+    ]
+    volume = make_volume(cameras, rows)
+
+    scaled = volume.scaled(SegmentLength(keypoint_id_a=10, keypoint_id_b=11, meters=2.5))
+
+    df = scaled.world_points.df
+    p10 = df[(df["sync_index"] == 0) & (df["keypoint_id"] == 10)][["x_coord", "y_coord", "z_coord"]].to_numpy()[0]
+    p11 = df[(df["sync_index"] == 0) & (df["keypoint_id"] == 11)][["x_coord", "y_coord", "z_coord"]].to_numpy()[0]
+    recovered = float(np.linalg.norm(p10 - p11))
+    assert abs(recovered - 2.5) < 1e-10
+
+
+def test_single_depth_observation_recovers_scale():
+    # Camera 0 at origin looking down +Z; a point at BA-depth 2 along its axis.
+    cameras = {
+        0: make_camera(0, np.eye(3), np.array([0.0, 0.0, 0.0])),
+        1: make_camera(1, np.eye(3), np.array([3.0, 0.0, 0.0])),
+    }
+    rows = [world_row(5, 10, (0.0, 0.0, 2.0)), world_row(5, 11, (1.0, 0.0, 2.0))]
+    volume = make_volume(cameras, rows)
+
+    scaled = volume.scaled(DepthObservation(cam_id=0, keypoint_id=10, sync_index=5, depth_m=5.0))
+
+    df = scaled.world_points.df
+    p = df[(df["sync_index"] == 5) & (df["keypoint_id"] == 10)][["x_coord", "y_coord", "z_coord"]].to_numpy()[0]
+    cam = scaled.camera_array.cameras[0]
+    recovered_depth = float((cam.rotation @ p + cam.translation)[2])
+    assert abs(recovered_depth - 5.0) < 1e-10
+
+
+def test_multiple_cues_weighted_between_estimates():
+    cameras = {
+        0: make_camera(0, np.eye(3), np.array([0.0, 0.0, 0.0])),
+        1: make_camera(1, np.eye(3), np.array([1.0, 0.0, 0.0])),  # d = 1
+        2: make_camera(2, np.eye(3), np.array([0.0, 1.0, 0.0])),  # d = 1
+    }
+    rows = [world_row(0, 10, (0.5, 0.5, 1.0)), world_row(0, 11, (0.2, 0.3, 1.0))]
+    volume = make_volume(cameras, rows)
+
+    # Cue A implies scale 2.0 (tight), cue B implies scale 3.0 (loose).
+    scaled = volume.scaled(
+        CameraDistance(cam_a=0, cam_b=1, meters=2.0, sigma_m=0.001),
+        CameraDistance(cam_a=0, cam_b=2, meters=3.0, sigma_m=1.0),
+    )
+
+    recovered = float(np.linalg.norm(camera_center(scaled, 0) - camera_center(scaled, 1)))
+    assert 2.0 < recovered < 3.0
+    assert abs(recovered - 2.0) < abs(recovered - 3.0)
+
+
+def test_disagreeing_cues_emit_warning():
+    cameras = {
+        0: make_camera(0, np.eye(3), np.array([0.0, 0.0, 0.0])),
+        1: make_camera(1, np.eye(3), np.array([1.0, 0.0, 0.0])),
+        2: make_camera(2, np.eye(3), np.array([0.0, 1.0, 0.0])),
+    }
+    rows = [world_row(0, 10, (0.5, 0.5, 1.0)), world_row(0, 11, (0.2, 0.3, 1.0))]
+    volume = make_volume(cameras, rows)
+
+    with pytest.warns(UserWarning):
+        volume.scaled(
+            CameraDistance(cam_a=0, cam_b=1, meters=2.0, sigma_m=0.01),
+            CameraDistance(cam_a=0, cam_b=2, meters=3.0, sigma_m=0.01),
+        )
+
+
+def test_two_camera_volume_scales():
+    cameras = {
+        0: make_camera(0, np.eye(3), np.array([0.0, 0.0, 0.0])),
+        1: make_camera(1, np.eye(3), np.array([4.0, 0.0, 0.0])),
+    }
+    rows = [world_row(0, 10, (1.0, 1.0, 1.0)), world_row(0, 11, (2.0, 1.0, 1.0))]
+    volume = make_volume(cameras, rows)
+
+    scaled = volume.scaled(CameraDistance(cam_a=0, cam_b=1, meters=10.0))
+
+    recovered = float(np.linalg.norm(camera_center(scaled, 0) - camera_center(scaled, 1)))
+    assert abs(recovered - 10.0) < 1e-10
+
+
+def test_zero_cues_raises():
+    cameras = {
+        0: make_camera(0, np.eye(3), np.array([0.0, 0.0, 0.0])),
+        1: make_camera(1, np.eye(3), np.array([3.0, 0.0, 0.0])),
+    }
+    rows = [world_row(0, 10, (1.0, 1.0, 1.0)), world_row(0, 11, (2.0, 0.0, 1.0))]
+    volume = make_volume(cameras, rows)
+
+    with pytest.raises(ValueError):
+        volume.scaled()
+
+
+def test_missing_camera_cue_raises():
+    cameras = {
+        0: make_camera(0, np.eye(3), np.array([0.0, 0.0, 0.0])),
+        1: make_camera(1, np.eye(3), np.array([3.0, 0.0, 0.0])),
+    }
+    rows = [world_row(0, 10, (1.0, 1.0, 1.0)), world_row(0, 11, (2.0, 0.0, 1.0))]
+    volume = make_volume(cameras, rows)
+
+    with pytest.raises(ValueError):
+        volume.scaled(CameraDistance(cam_a=0, cam_b=99, meters=5.0))
+
+
+# ---------------------------------------------------------------------------
+# Orientation
+# ---------------------------------------------------------------------------
+
+
+def _tilted_rig() -> tuple[CaptureVolume, dict[int, np.ndarray], np.ndarray]:
+    """A rig whose true vertical is a non-axis direction in the BA frame.
+
+    Returns the volume, the per-camera up dict (up expressed in each camera frame),
+    and the true BA-frame vertical. A vertical segment (keypoints 10->11) lies along
+    that vertical, so orientation should map it onto +Z.
+    """
+    true_up = np.array([0.1, 1.0, -0.05])
+    true_up = true_up / np.linalg.norm(true_up)
+
+    rotations = {
+        0: Rotation.from_euler("xyz", [10, 20, 5], degrees=True).as_matrix(),
+        1: Rotation.from_euler("xyz", [-15, 40, 10], degrees=True).as_matrix(),
+        2: Rotation.from_euler("xyz", [5, -30, -8], degrees=True).as_matrix(),
+    }
+    centers = {
+        0: np.array([0.0, 0.0, 0.0]),
+        1: np.array([2.0, 0.0, 0.0]),
+        2: np.array([0.0, 2.0, 0.0]),
+    }
+    cameras = {cid: make_camera(cid, rotations[cid], centers[cid]) for cid in rotations}
+
+    p_low = np.array([1.0, 2.0, 3.0])
+    p_high = p_low + 2.0 * true_up
+    rows = [
+        world_row(0, 10, tuple(p_low)),
+        world_row(0, 11, tuple(p_high)),
+        world_row(1, 10, tuple(p_low + 0.3 * true_up)),
+        world_row(1, 11, tuple(p_high + 0.3 * true_up)),
+    ]
+    volume = make_volume(cameras, rows)
+
+    # Up in each camera frame is R_cam @ true_up (world direction -> camera frame).
+    up = {cid: rotations[cid] @ true_up for cid in rotations}
+    return volume, up, true_up
+
+
+def test_oriented_levels_known_tilt():
+    volume, up, _ = _tilted_rig()
+
+    oriented = volume.oriented(up=up)
+
+    df = oriented.world_points.df
+    p10 = df[(df["sync_index"] == 0) & (df["keypoint_id"] == 10)][["x_coord", "y_coord", "z_coord"]].to_numpy()[0]
+    p11 = df[(df["sync_index"] == 0) & (df["keypoint_id"] == 11)][["x_coord", "y_coord", "z_coord"]].to_numpy()[0]
+    segment = p11 - p10
+    # The vertical segment now points straight up +Z with length 2.
+    assert np.allclose(segment, [0.0, 0.0, 2.0], atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Grounding
+# ---------------------------------------------------------------------------
+
+
+def test_grounded_puts_floor_at_zero_and_cam0_over_origin():
+    cameras = {
+        0: make_camera(0, np.eye(3), np.array([5.0, 7.0, 3.0])),
+        1: make_camera(1, np.eye(3), np.array([8.0, 7.0, 3.0])),
+    }
+    rows = [
+        world_row(0, 10, (1.0, 1.0, 2.0)),  # lowest z = 2.0
+        world_row(0, 11, (1.0, 1.0, 4.0)),
+    ]
+    volume = make_volume(cameras, rows)
+
+    grounded = volume.grounded("lowest_point")
+
+    assert abs(float(grounded.world_points.df["z_coord"].min())) < 1e-10
+    c0 = camera_center(grounded, 0)
+    assert abs(c0[0]) < 1e-10
+    assert abs(c0[1]) < 1e-10
+
+
+def test_grounded_rejects_unknown_mode():
+    cameras = {
+        0: make_camera(0, np.eye(3), np.array([0.0, 0.0, 0.0])),
+        1: make_camera(1, np.eye(3), np.array([3.0, 0.0, 0.0])),
+    }
+    rows = [world_row(0, 10, (1.0, 1.0, 1.0)), world_row(0, 11, (2.0, 0.0, 1.0))]
+    volume = make_volume(cameras, rows)
+
+    with pytest.raises(ValueError):
+        volume.grounded("centroid")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Chain order invariance
+# ---------------------------------------------------------------------------
+
+
+def test_chain_order_invariance_scale_and_orient():
+    volume, up, _ = _tilted_rig()
+    cue = CameraDistance(cam_a=0, cam_b=1, meters=6.0)
+
+    a = volume.scaled(cue).oriented(up=up)
+    b = volume.oriented(up=up).scaled(cue)
+
+    assert np.allclose(a.world_points.points, b.world_points.points, atol=1e-12)
+    for cam_id in a.camera_array.cameras:
+        assert np.allclose(camera_center(a, cam_id), camera_center(b, cam_id), atol=1e-12)
+
+
+if __name__ == "__main__":
+    from pathlib import Path
+
+    debug_dir = Path(__file__).parent / "tmp"
+    debug_dir.mkdir(parents=True, exist_ok=True)
+
+    test_single_camera_distance_recovers_scale()
+    test_single_segment_length_recovers_scale()
+    test_single_depth_observation_recovers_scale()
+    test_multiple_cues_weighted_between_estimates()
+    test_two_camera_volume_scales()
+    test_oriented_levels_known_tilt()
+    test_grounded_puts_floor_at_zero_and_cam0_over_origin()
+    test_chain_order_invariance_scale_and_orient()
+    print("anchoring debug run complete")

--- a/tests/test_moge_runner.py
+++ b/tests/test_moge_runner.py
@@ -1,0 +1,79 @@
+"""Tests for the MoGe runner and focal-based CameraArray construction.
+
+The full ``run_moge`` integration test is skipped unless the (>1 GB) model is
+already present in MODELS_DIR — it is never downloaded here.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from caliscope.cameras.camera_array import CameraArray
+from caliscope.core.point_data import ImagePoints
+from caliscope.estimators.moge import MOGE_MODEL_SPEC, run_moge
+
+SESSION = Path(__file__).parent / "sessions" / "4_cam_recording" / "calibration" / "extrinsic"
+
+
+def _videos() -> dict[int, Path]:
+    return {cam_id: SESSION / f"cam_{cam_id}.mp4" for cam_id in (0, 1, 2, 3)}
+
+
+def test_from_focal_estimates_builds_pinhole_intrinsics():
+    videos = _videos()
+    focal_per_cam = {0: 512.0, 2: 640.0}
+
+    cameras = CameraArray.from_focal_estimates(focal_per_cam, videos)
+
+    assert set(cameras.cameras.keys()) == {0, 2}
+    for cam_id, focal in focal_per_cam.items():
+        cam = cameras[cam_id]
+        width, height = cam.size
+        assert cam.matrix is not None
+        assert cam.matrix[0, 0] == pytest.approx(focal)
+        assert cam.matrix[1, 1] == pytest.approx(focal)
+        assert cam.matrix[0, 2] == pytest.approx(width / 2.0)
+        assert cam.matrix[1, 2] == pytest.approx(height / 2.0)
+        assert cam.distortions is not None and np.allclose(cam.distortions, 0.0)
+        # intrinsics only — no pose
+        assert cam.rotation is None and cam.translation is None
+
+
+def test_from_focal_estimates_missing_video_raises():
+    with pytest.raises(ValueError, match="No video provided for cam_id 5"):
+        CameraArray.from_focal_estimates({5: 500.0}, _videos())
+
+
+@pytest.mark.skipif(
+    not MOGE_MODEL_SPEC.model_path.exists(),
+    reason="MoGe model not present in MODELS_DIR (>1 GB; not downloaded in tests)",
+)
+def test_run_moge_produces_focals_and_depths():
+    videos = _videos()
+
+    # A handful of fake keypoint detections near frame center for two cameras.
+    rows = []
+    for cam_id in (0, 1):
+        for sync_index in range(0, 20, 5):
+            for keypoint_id in range(3):
+                rows.append(
+                    {
+                        "sync_index": sync_index,
+                        "cam_id": cam_id,
+                        "object_id": 0,
+                        "keypoint_id": keypoint_id,
+                        "img_loc_x": 300.0 + 20 * keypoint_id,
+                        "img_loc_y": 240.0 + 10 * keypoint_id,
+                    }
+                )
+    points = ImagePoints(pd.DataFrame(rows))
+
+    result = run_moge(videos, points, frames_per_camera=2)
+
+    assert set(result.focal_per_cam.keys()) <= {0, 1}
+    assert all(f > 0 for f in result.focal_per_cam.values())
+    for obs in result.depth_observations:
+        assert obs.cam_id in (0, 1)
+        assert obs.depth_m > 0

--- a/tests/test_moge_runner.py
+++ b/tests/test_moge_runner.py
@@ -46,6 +46,102 @@ def test_from_focal_estimates_missing_video_raises():
         CameraArray.from_focal_estimates({5: 500.0}, _videos())
 
 
+def _pinhole_point_map(height: int, width: int, focal_px: float) -> np.ndarray:
+    """A valid pinhole point map so recover_focal_shift returns a sane focal + positive depth."""
+    j = np.arange(width, dtype=np.float64)
+    i = np.arange(height, dtype=np.float64)
+    jj, ii = np.meshgrid(j, i, indexing="xy")
+    cx, cy = (width - 1) / 2.0, (height - 1) / 2.0
+    depth = 3.0 + 0.002 * ii + 0.001 * jj
+    x = (jj - cx) * depth / focal_px
+    y = (ii - cy) * depth / focal_px
+    return np.stack([x, y, depth], axis=-1).astype(np.float32)
+
+
+def test_run_moge_decodes_by_frame_index_but_keys_by_sync_index(monkeypatch):
+    """When frame_index diverges from sync_index, decode by frame_index, emit by sync_index."""
+    import caliscope.estimators.moge as moge
+
+    requested_frames: dict[int, list[int]] = {}
+
+    def fake_decode(video_path, cam_id, frame_indices):
+        requested_frames[cam_id] = list(frame_indices)
+        return {fi: np.zeros((32, 32, 3), dtype=np.uint8) for fi in frame_indices}
+
+    def fake_infer(session, rgb):
+        h, w = rgb.shape[:2]
+        return _pinhole_point_map(h, w, 500.0), np.ones((h, w), dtype=bool), 1.0
+
+    monkeypatch.setattr(moge, "_build_session", lambda: object())
+    monkeypatch.setattr(moge, "_decode_frames", fake_decode)
+    monkeypatch.setattr(moge, "_infer_frame", fake_infer)
+
+    # frame_index is offset from sync_index by +2 (staggered start / dropped frames).
+    rows = []
+    for sync_index in (0, 5, 10, 15):
+        for keypoint_id in range(2):
+            rows.append(
+                {
+                    "sync_index": sync_index,
+                    "cam_id": 0,
+                    "object_id": 0,
+                    "keypoint_id": keypoint_id,
+                    "img_loc_x": 12.0 + keypoint_id,
+                    "img_loc_y": 12.0,
+                    "frame_index": sync_index + 2,
+                }
+            )
+    points = ImagePoints(pd.DataFrame(rows))
+
+    result = run_moge({0: SESSION / "cam_0.mp4"}, points, frames_per_camera=4)
+
+    # Decoding requested frame_index values, not sync_index values.
+    assert sorted(requested_frames[0]) == [2, 7, 12, 17]
+
+    # Observations carry sync_index, never frame_index.
+    emitted_syncs = {obs.sync_index for obs in result.depth_observations}
+    assert emitted_syncs == {0, 5, 10, 15}
+    assert emitted_syncs.isdisjoint({2, 7, 12, 17})
+    assert 0 in result.focal_per_cam
+
+
+def test_run_moge_without_frame_index_uses_sync_as_frame(monkeypatch):
+    """Absent a frame_index column, sync_index is the frame index (single-video path)."""
+    import caliscope.estimators.moge as moge
+
+    requested_frames: dict[int, list[int]] = {}
+
+    def fake_decode(video_path, cam_id, frame_indices):
+        requested_frames[cam_id] = list(frame_indices)
+        return {fi: np.zeros((32, 32, 3), dtype=np.uint8) for fi in frame_indices}
+
+    def fake_infer(session, rgb):
+        h, w = rgb.shape[:2]
+        return _pinhole_point_map(h, w, 500.0), np.ones((h, w), dtype=bool), 1.0
+
+    monkeypatch.setattr(moge, "_build_session", lambda: object())
+    monkeypatch.setattr(moge, "_decode_frames", fake_decode)
+    monkeypatch.setattr(moge, "_infer_frame", fake_infer)
+
+    rows = [
+        {
+            "sync_index": sync_index,
+            "cam_id": 0,
+            "object_id": 0,
+            "keypoint_id": 0,
+            "img_loc_x": 12.0,
+            "img_loc_y": 12.0,
+        }
+        for sync_index in (3, 8, 11)
+    ]
+    points = ImagePoints(pd.DataFrame(rows))
+
+    result = run_moge({0: SESSION / "cam_0.mp4"}, points, frames_per_camera=4)
+
+    assert sorted(requested_frames[0]) == [3, 8, 11]
+    assert {obs.sync_index for obs in result.depth_observations} == {3, 8, 11}
+
+
 @pytest.mark.skipif(
     not MOGE_MODEL_SPEC.model_path.exists(),
     reason="MoGe model not present in MODELS_DIR (>1 GB; not downloaded in tests)",

--- a/tests/test_moge_utils.py
+++ b/tests/test_moge_utils.py
@@ -1,0 +1,63 @@
+"""Validate the vendored MoGe focal/shift recovery against a synthetic pinhole.
+
+Builds a perfect pinhole point map from a known focal length (project a grid of
+3D points through a pinhole; the point map is the camera-frame 3D coordinates per
+pixel), then checks that ``recover_focal_shift_numpy`` + the runner's pixel
+conversion recover the focal within tight tolerance. This exercises the whole
+vendored chain (masked resize, view-plane UV, least squares) without the model.
+"""
+
+import numpy as np
+
+from caliscope.estimators.moge import _focal_to_pixels
+from caliscope.estimators.moge_utils import recover_focal_shift_numpy
+
+
+def _synthetic_pinhole_point_map(width: int, height: int, focal_px: float) -> np.ndarray:
+    """A (H, W, 3) point map for a pinhole camera with a tilted-plane depth.
+
+    Principal point sits at ((W-1)/2, (H-1)/2), matching the center of MoGe's
+    normalized view-plane UV grid, so the recovered focal maps back to ``focal_px``
+    exactly. Depth varies across the frame (a tilted plane) to break the
+    focal/shift degeneracy that a frontoparallel plane would leave.
+    """
+    j = np.arange(width, dtype=np.float64)
+    i = np.arange(height, dtype=np.float64)
+    jj, ii = np.meshgrid(j, i, indexing="xy")
+
+    cx, cy = (width - 1) / 2.0, (height - 1) / 2.0
+    depth = 3.0 + 0.002 * ii + 0.001 * jj  # tilted plane, ~3 m
+
+    x = (jj - cx) * depth / focal_px
+    y = (ii - cy) * depth / focal_px
+    return np.stack([x, y, depth], axis=-1).astype(np.float32)
+
+
+def test_recover_focal_shift_matches_known_focal():
+    width, height, focal_px = 640, 480, 500.0
+    point_map = _synthetic_pinhole_point_map(width, height, focal_px)
+    mask = np.ones((height, width), dtype=bool)
+
+    focal, shift = recover_focal_shift_numpy(point_map, mask)
+    recovered_px = _focal_to_pixels(float(focal), width, height)
+
+    assert abs(recovered_px - focal_px) / focal_px < 0.005
+    assert abs(float(shift)) < 0.01  # points already carry true depth; no shift needed
+
+
+def test_recover_focal_shift_portrait_aspect():
+    """Aspect-ratio handling in the pixel conversion holds for a portrait frame."""
+    width, height, focal_px = 480, 640, 700.0
+    point_map = _synthetic_pinhole_point_map(width, height, focal_px)
+    mask = np.ones((height, width), dtype=bool)
+
+    focal, _ = recover_focal_shift_numpy(point_map, mask)
+    recovered_px = _focal_to_pixels(float(focal), width, height)
+
+    assert abs(recovered_px - focal_px) / focal_px < 0.005
+
+
+if __name__ == "__main__":
+    test_recover_focal_shift_matches_known_focal()
+    test_recover_focal_shift_portrait_aspect()
+    print("moge_utils recovery validated")

--- a/tests/test_vertical.py
+++ b/tests/test_vertical.py
@@ -1,0 +1,144 @@
+"""Tests for the vertical estimator: preprocessing contract and a gated run.
+
+The preprocessing tests pin the GeoCalib input geometry (short side 320, edges
+divisible by 32, resize scales, dtype/range) without touching the network. The
+integration test runs the real field net and is skipped unless the weights are
+already present in MODELS_DIR -- it never downloads the 118 MB model.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from caliscope.cameras.camera_array import CameraArray, CameraData
+from caliscope.estimators.vertical import (
+    GEOCALIB_FIELDS_SPEC,
+    VerticalEstimate,
+    _net_size,
+    estimate_vertical,
+    preprocess_frame,
+    sample_frame_indices,
+)
+from caliscope.recording.video_utils import read_video_properties
+
+TESTS_ROOT = __import__("pathlib").Path(__file__).parent
+EXTRINSIC_VIDEOS = {
+    0: TESTS_ROOT / "sessions" / "h264_extrinsic" / "cam_0.mp4",
+    1: TESTS_ROOT / "sessions" / "h264_extrinsic" / "cam_1.mp4",
+}
+
+
+def _synthetic_frame(height: int, width: int) -> np.ndarray:
+    """A BGR frame with spatial structure so downsampling has something to average."""
+    xs = np.linspace(0, 255, width, dtype=np.uint8)
+    ys = np.linspace(0, 255, height, dtype=np.uint8)
+    blue = np.broadcast_to(xs, (height, width))
+    green = np.broadcast_to(ys[:, None], (height, width))
+    red = ((blue.astype(int) + green.astype(int)) // 2).astype(np.uint8)
+    return np.stack([blue, green, red], axis=-1).copy()
+
+
+@pytest.mark.parametrize(
+    "height, width, expected_net",
+    [
+        (1080, 1920, (320, 568)),  # landscape: short side is height
+        (1920, 1080, (568, 320)),  # portrait: short side is width
+        (1000, 1000, (320, 320)),  # square
+    ],
+)
+def test_net_size_short_side(height: int, width: int, expected_net: tuple[int, int]) -> None:
+    assert _net_size(height, width) == expected_net
+    net_h, net_w = _net_size(height, width)
+    assert min(net_h, net_w) == 320
+
+
+def test_preprocess_shape_divisible_by_32() -> None:
+    frame = _synthetic_frame(1080, 1920)
+    image, _, _ = preprocess_frame(frame)
+
+    assert image.shape[0] == 1
+    assert image.shape[1] == 3
+    net_h, net_w = image.shape[2], image.shape[3]
+    assert net_h % 32 == 0
+    assert net_w % 32 == 0
+    # Short side (320) is already a multiple of 32, so it survives the crop.
+    assert min(net_h, net_w) == 320
+
+
+def test_preprocess_dtype_and_range() -> None:
+    frame = _synthetic_frame(720, 1280)
+    image, _, _ = preprocess_frame(frame)
+
+    assert image.dtype == np.float32
+    assert image.min() >= 0.0
+    assert image.max() <= 1.0
+
+
+def test_preprocess_scales_are_net_over_original() -> None:
+    frame = _synthetic_frame(1080, 1920)
+    _, scale_x, scale_y = preprocess_frame(frame)
+
+    # net_w = int(320 * 1920 / 1080) = 568; net_h = 320. Scales are pre-crop.
+    assert np.isclose(scale_x, 568 / 1920)
+    assert np.isclose(scale_y, 320 / 1080)
+
+
+def test_preprocess_rgb_channel_order() -> None:
+    # A pure-blue BGR frame (B=255) must land in the last RGB channel.
+    frame = np.zeros((320, 320, 3), dtype=np.uint8)
+    frame[..., 0] = 255  # blue in BGR
+    image, _, _ = preprocess_frame(frame)
+
+    assert image[0, 2].mean() > 0.9  # blue -> RGB channel 2
+    assert image[0, 0].mean() < 0.1  # red channel empty
+
+
+def test_sample_frame_indices_spans_clip() -> None:
+    indices = sample_frame_indices(100, 12)
+    assert indices[0] == 0
+    assert indices[-1] == 99
+    assert list(indices) == sorted(set(indices))
+    assert len(indices) == 12
+
+    # Fewer frames than samples returns every frame.
+    assert sample_frame_indices(5, 12) == (0, 1, 2, 3, 4)
+
+
+def _camera_array_for_videos() -> CameraArray:
+    """Build a CameraArray with a synthesized focal prior for the test videos."""
+    cameras = {}
+    for cam_id, path in EXTRINSIC_VIDEOS.items():
+        props = read_video_properties(path)
+        w, h = props["width"], props["height"]
+        matrix = np.array([[w, 0.0, w / 2.0], [0.0, w, h / 2.0], [0.0, 0.0, 1.0]])
+        cameras[cam_id] = CameraData(cam_id=cam_id, size=(w, h), matrix=matrix)
+    return CameraArray(cameras=cameras)
+
+
+@pytest.mark.skipif(
+    not GEOCALIB_FIELDS_SPEC.model_path.exists(),
+    reason="GeoCalib field net not present in MODELS_DIR (not downloaded in tests)",
+)
+@pytest.mark.skipif(
+    not all(path.exists() for path in EXTRINSIC_VIDEOS.values()),
+    reason="extrinsic test videos not available",
+)
+def test_estimate_vertical_runs_on_real_videos() -> None:
+    cameras = _camera_array_for_videos()
+    estimate = estimate_vertical(EXTRINSIC_VIDEOS, cameras, frames_per_camera=4)
+
+    assert isinstance(estimate, VerticalEstimate)
+    assert set(estimate.up_per_cam) == set(EXTRINSIC_VIDEOS)
+    for cam_id in EXTRINSIC_VIDEOS:
+        up = estimate.up_per_cam[cam_id]
+        assert up.shape == (3,)
+        assert np.isclose(np.linalg.norm(up), 1.0)
+        # Frame-to-frame spread should be small and non-negative on real footage.
+        assert 0.0 <= estimate.spread_per_cam[cam_id] < 5.0
+
+
+if __name__ == "__main__":
+    frame = _synthetic_frame(1080, 1920)
+    image, sx, sy = preprocess_frame(frame)
+    print(f"preprocessed {frame.shape} -> {image.shape}, scales ({sx:.4f}, {sy:.4f})")

--- a/tests/test_vertical_solver.py
+++ b/tests/test_vertical_solver.py
@@ -1,0 +1,119 @@
+"""Analytic-field tests for the numpy gravity solver.
+
+The solver's forward model renders the up and latitude fields a tilted pinhole
+camera produces. Feeding it perfect fields built from a known (roll, pitch) with
+uniform confidence, it must recover that orientation to well under 0.1 deg. The
+round-trip between the up vector and (roll, pitch) is also checked directly.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from caliscope.estimators.vertical_solver import (
+    fit_gravity,
+    gravity_vec_from_roll_pitch,
+    roll_pitch_from_gravity_vec,
+)
+
+
+def _analytic_fields(
+    roll: float, pitch: float, focal: float, height: int, width: int
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Perfect up/latitude fields for a camera at (roll, pitch), uniform confidence.
+
+    Replicates the solver's pixel-grid geometry independently: principal point
+    at the image center, rays through the pinhole, up = image-plane projection
+    of world up, latitude = arcsin(ray . up).
+    """
+    vec = gravity_vec_from_roll_pitch(roll, pitch)
+    xs, ys = np.meshgrid(np.arange(width), np.arange(height))
+    xy = np.stack([xs, ys], axis=-1).reshape(-1, 2).astype(np.float64)
+    center = np.array([width / 2, height / 2])
+    uv = (xy - center) / np.array([focal, focal])
+
+    up_unnormalized = vec[:2][None, :] - vec[2] * uv
+    up_normalized = up_unnormalized / np.linalg.norm(up_unnormalized, axis=-1, keepdims=True)
+
+    rays = np.concatenate([uv, np.ones((uv.shape[0], 1))], axis=-1)
+    rays = rays / np.linalg.norm(rays, axis=-1, keepdims=True)
+    sin_lat = np.clip(rays @ vec, -1 + 1e-6, 1 - 1e-6)
+
+    up_field = up_normalized.T.reshape(2, height, width)
+    latitude_field = np.arcsin(sin_lat).reshape(height, width)
+    confidence = np.ones((height, width), dtype=np.float64)
+    return up_field, confidence, latitude_field, confidence
+
+
+@pytest.mark.parametrize(
+    "roll, pitch",
+    [
+        (0.0, 0.0),
+        (0.10, 0.05),
+        (-0.20, 0.15),
+        (0.35, -0.25),
+        (-0.45, -0.10),
+    ],
+)
+def test_fit_gravity_recovers_known_orientation(roll: float, pitch: float) -> None:
+    focal = 300.0
+    up_field, up_conf, lat_field, lat_conf = _analytic_fields(roll, pitch, focal, 96, 128)
+
+    fit = fit_gravity(up_field, up_conf, lat_field, lat_conf, focal, focal)
+
+    recovered = gravity_vec_from_roll_pitch(fit.roll_rad, fit.pitch_rad)
+    truth = gravity_vec_from_roll_pitch(roll, pitch)
+    angle_deg = np.degrees(np.arccos(np.clip(np.dot(recovered, truth), -1.0, 1.0)))
+    assert angle_deg < 0.1
+
+
+def test_fit_gravity_reports_low_cost_and_finite_uncertainty() -> None:
+    focal = 300.0
+    up_field, up_conf, lat_field, lat_conf = _analytic_fields(0.1, -0.08, focal, 96, 128)
+
+    fit = fit_gravity(up_field, up_conf, lat_field, lat_conf, focal, focal)
+
+    # Perfect fields drive the cost far below its starting value and leave a
+    # finite, positive Hessian uncertainty.
+    assert fit.final_cost < fit.initial_cost
+    assert fit.gravity_uncertainty_rad > 0.0
+    assert np.isfinite(fit.gravity_uncertainty_rad)
+    assert 1 <= fit.stop_step <= 30
+
+
+@pytest.mark.parametrize(
+    "roll, pitch",
+    [
+        (0.0, 0.0),
+        (0.5, 0.4),
+        (-0.7, -0.5),
+        (0.6, 0.3),
+        (-0.3, 0.7),
+    ],
+)
+def test_roll_pitch_vector_round_trip(roll: float, pitch: float) -> None:
+    # Angles stay within the near-upright envelope the estimator operates in.
+    # The eps in the roll denominator amplifies near the arcsin knee (roll
+    # approaching +/-90 deg), where the round-trip degrades to ~3e-4 rad.
+    vec = gravity_vec_from_roll_pitch(roll, pitch)
+    assert np.isclose(np.linalg.norm(vec), 1.0)
+
+    recovered_roll, recovered_pitch = roll_pitch_from_gravity_vec(vec)
+    # roll_pitch_from_gravity_vec carries GeoCalib's eps = 1e-4 in the roll
+    # denominator (a deliberate port quirk), so the round-trip is only exact to
+    # that scale, not to machine precision.
+    assert np.isclose(recovered_roll, roll, atol=2e-4)
+    assert np.isclose(recovered_pitch, pitch, atol=2e-4)
+
+
+if __name__ == "__main__":
+    focal = 300.0
+    for roll, pitch in [(0.0, 0.0), (0.2, -0.15)]:
+        fields = _analytic_fields(roll, pitch, focal, 96, 128)
+        fit = fit_gravity(*fields, focal, focal)
+        print(
+            f"truth roll={np.degrees(roll):.3f} pitch={np.degrees(pitch):.3f} -> "
+            f"fit roll={np.degrees(fit.roll_rad):.3f} pitch={np.degrees(fit.pitch_rad):.3f} "
+            f"(stop_step={fit.stop_step}, final_cost={fit.final_cost:.3e})"
+        )


### PR DESCRIPTION
## Summary

Calibrate a camera rig from strictly 2D image points (body keypoints from any tracker), with metric scale, vertical orientation, and ground plane supplied by independent cues. Implements M1–M4 of the calibration-anchoring arc; M5 (segment-length constancy in BA) stays deferred.

- **Epipolar bootstrap (M1):** ImagePoints with all-NaN obj_loc now bootstrap through an essential-matrix pair network instead of hard-failing. Correspondences pool across frames to break coplanarity; candidate scaffolds are ranked by third-view resection residual, which survives the twisted-pair degeneracy that a cheirality-only pick does not. Requires calibrated intrinsics (a gate in calibrate_extrinsics rejects blind-synthesized ones on this path).
- **Metric anchoring (M2):** fluent `scaled(*cues)` / `oriented(up=...)` / `grounded()` on CaptureVolume, each returning a new frozen volume. Cue types: CameraDistance, SegmentLength, DepthObservation; one cue scales exactly, several combine by sigma-weighted least squares with a disagreement warning.
- **MoGe runner (M3):** `run_moge()` emits per-camera focal estimates (pixels) and metric depth cues at tracked keypoints from the MoGe-2 ONNX export; numpy post-processing vendored from microsoft/MoGe (MIT). `CameraArray.from_focal_estimates()` builds pinhole intrinsics from the result.
- **Vertical estimation (M4):** `estimate_vertical()` runs the GeoCalib field-net ONNX export and a numpy LM gravity solver (ported verbatim from the validated monokin implementation) to produce per-camera up vectors with spread diagnostics.
- Estimator models are frozen `EstimatorModelSpec` constants downloaded on demand into the app models dir; no torch anywhere.

## Testing

- Full suite: 716 passed, 1 skipped (MoGe integration, gated on the ~1.3 GB model being present).
- Synthetic epipolar tolerances derived from measured worst-case over 20 noise seeds through the production seam: 4-camera 0.070°/2.11 mm observed → 0.5°/8 mm asserted; 2-camera 0.133°/5.32 mm → 0.5°/10 mm.
- GeoCalib chain validated with real weights (sha256-verified download + live inference test).
- Two independent CV reviews (math-scoped and whole-arc) found the core math clean; the two confirmed seam findings are fixed in this branch (frame_index-vs-sync_index decode in run_moge, bulk depth-cue tolerance in scaled()). Remaining findings are tracked as tasks gating the markerless-calibration-release milestone: decode seeking, epipolar-scale subsampling, cv2-vs-torch preprocessing parity, robust grounding, and OpenCap corpus validation.