### PR TITLE
feat(gui): welcome screen on launch, workflow status fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "caliscope"
-version = "0.11.0"
+version = "0.11.1"
 description = "Rapid and reliable multicamera calibration with GUI and scripting API"
 authors = [{name = "Mac Prible", email = "prible@gmail.com"}]
 license = { text = "BSD-2-Clause" }

--- a/src/caliscope/cameras/camera_array.py
+++ b/src/caliscope/cameras/camera_array.py
@@ -390,7 +390,14 @@ class CameraArray:
         return not self.unposed_cameras
 
     def all_intrinsics_calibrated(self) -> bool:
-        """Checks if ALL cameras in the array have intrinsic data."""
+        """Checks if ALL cameras in the array have intrinsic data.
+
+        An empty array is not calibrated — `all()` over no cameras is vacuously
+        True, which would report a zero-camera project as COMPLETE. Guard the
+        empty case explicitly, matching `all_cameras_have_resolution`.
+        """
+        if not self.cameras:
+            return False
         return all(cam.matrix is not None and cam.distortions is not None for cam in self.cameras.values())
 
     def all_cameras_have_resolution(self) -> bool:

--- a/src/caliscope/core/calibrate_extrinsics.py
+++ b/src/caliscope/core/calibrate_extrinsics.py
@@ -249,8 +249,9 @@ def calibrate_extrinsics(
     _progress(90, "Re-optimizing")
     capture_volume = capture_volume.optimize(refine_intrinsics=effective_refine)
 
-    # 9. Assemble result
-    _progress(100, "Done")
+    # 9. Assemble result. Not "Done": the GUI still builds the quality panel
+    # and 3D visualization after this returns.
+    _progress(100, "Optimization complete")
     return _build_run(
         capture_volume=capture_volume,
         anchors=anchors,

--- a/src/caliscope/gui/extrinsic_calibration_tab.py
+++ b/src/caliscope/gui/extrinsic_calibration_tab.py
@@ -68,6 +68,12 @@ class ExtrinsicCalibrationTab(QWidget):
         if self._presenter is None:
             return
 
+        # Extraction runs on the Multi-Camera tab, possibly after this tab was
+        # built. status_changed fires after image_points.csv is written (and on
+        # watched filesystem changes); the presenter re-checks for extraction
+        # output so the workflow strip and Calibrate button catch up.
+        self._coordinator.status_changed.connect(self._presenter.refresh_extraction_status)
+
     # -------------------------------------------------------------------------
     # Rendering Lifecycle
     # -------------------------------------------------------------------------
@@ -97,6 +103,12 @@ class ExtrinsicCalibrationTab(QWidget):
             self._view = None
 
         if self._presenter is not None:
+            # The coordinator outlives this tab, so drop the status_changed
+            # connection before discarding the presenter to avoid firing into it.
+            try:
+                self._coordinator.status_changed.disconnect(self._presenter.refresh_extraction_status)
+            except (RuntimeError, TypeError):
+                pass
             logger.info("Cleaning up extrinsic calibration presenter")
             self._presenter.cleanup()
             self._presenter = None

--- a/src/caliscope/gui/main_widget.py
+++ b/src/caliscope/gui/main_widget.py
@@ -38,6 +38,10 @@ class MainWindow(QMainWindow):
 
         self.app_settings = rtoml.load(APP_SETTINGS_PATH)
 
+        # Bumped on every launch_workspace so a relaunch invalidates any pending
+        # deferred tab build from a previous project (see _build_next_deferred_tab).
+        self._build_generation: int = 0
+
         self.setWindowTitle("Caliscope")
         self.setWindowIcon(QIcon(str(ICONS_DIR / "box3d-center.svg")))
         self.setMinimumSize(500, 500)
@@ -63,7 +67,27 @@ class MainWindow(QMainWindow):
         """
         logger.info("Application exit initiated")
 
+        # Invalidate any pending deferred tab tick or queued completed signal so
+        # neither builds tabs against the coordinator cleaned up below.
+        self._build_generation += 1
+
+        self._cleanup_tabs()
+
+        # Coordinator cleanup (TaskManager shutdown)
+        if hasattr(self, "coordinator"):
+            self.coordinator.cleanup()
+
+        logger.info("Application cleanup complete")
+        super().closeEvent(event)
+
+    def _cleanup_tabs(self) -> None:
+        """Release per-tab resources (background threads, Qt3D scene graphs).
+
+        Shared by closeEvent and launch_workspace so the two teardown paths
+        can't drift. Safe to call before any tabs exist.
+        """
         from caliscope.gui.cameras_tab_widget import CamerasTabWidget
+        from caliscope.gui.extrinsic_calibration_tab import ExtrinsicCalibrationTab
         from caliscope.gui.multi_camera_processing_tab import MultiCameraProcessingTab
         from caliscope.gui.reconstruction_tab import ReconstructionTab
 
@@ -73,16 +97,18 @@ class MainWindow(QMainWindow):
         multi = getattr(self, "multi_camera_tab", None)
         if isinstance(multi, MultiCameraProcessingTab):
             multi.cleanup()
+        extrinsic = getattr(self, "extrinsic_calibration_tab", None)
+        if isinstance(extrinsic, ExtrinsicCalibrationTab):
+            extrinsic.cleanup()
         recon = getattr(self, "reconstruction_tab", None)
         if isinstance(recon, ReconstructionTab):
             recon.cleanup()
 
-        # Coordinator cleanup (TaskManager shutdown)
-        if hasattr(self, "coordinator"):
-            self.coordinator.cleanup()
-
-        logger.info("Application cleanup complete")
-        super().closeEvent(event)
+        # Drop the attributes so a second call (project switch, then app close)
+        # never touches widgets whose C++ side setCentralWidget already deleted.
+        for name in ("cameras_tab_widget", "multi_camera_tab", "extrinsic_calibration_tab", "reconstruction_tab"):
+            if hasattr(self, name):
+                delattr(self, name)
 
     def connect_menu_actions(self):
         self.open_project_action.triggered.connect(self.create_new_project_folder)
@@ -114,7 +140,12 @@ class MainWindow(QMainWindow):
         self.exit_pyxy3d_action = QAction("Exit", self)
         self.file_menu.addAction(self.exit_pyxy3d_action)
 
-    def build_central_tabs(self, _result: object = None) -> None:
+    def build_central_tabs(self, gen: int) -> None:
+        # Same invalidation contract as _build_next_deferred_tab: a relaunch or
+        # app close bumped the generation, so a queued completed signal from a
+        # torn-down coordinator must not build tabs against it.
+        if gen != self._build_generation:
+            return
         self.central_tab = QTabWidget(self)
         self.setCentralWidget(self.central_tab)
 
@@ -130,10 +161,11 @@ class MainWindow(QMainWindow):
         self.coordinator.status_changed.connect(self._refresh_tab_enablement)
         self._previous_tab_index: int = 0
         self.central_tab.currentChanged.connect(self._on_tab_changed)
-        self.open_project_action.setEnabled(True)
-        self.open_recent_project_submenu.setEnabled(True)
 
-        # Remaining tabs added one per event loop tick so the UI stays responsive
+        # Remaining tabs added one per event loop tick so the UI stays responsive.
+        # Capture the current build generation so a relaunch mid-build abandons this
+        # chain instead of touching a torn-down coordinator (see _build_next_deferred_tab).
+        gen = self._build_generation
         self._deferred_tab_builders: deque[tuple[str, Callable[[], None]]] = deque(
             [
                 ("Cameras", self._add_cameras_tab),
@@ -142,11 +174,14 @@ class MainWindow(QMainWindow):
                 ("Reconstruction", self._add_reconstruction_tab),
             ]
         )
-        QTimer.singleShot(0, self._build_next_deferred_tab)
+        QTimer.singleShot(0, lambda: self._build_next_deferred_tab(gen))
 
-    def _build_next_deferred_tab(self) -> None:
+    def _build_next_deferred_tab(self, gen: int) -> None:
+        # A relaunch bumped the generation; abandon this stale build chain.
+        if gen != self._build_generation:
+            return
         if not self._deferred_tab_builders:
-            self.statusBar().showMessage("Ready", 3000)
+            self._on_deferred_build_complete()
             return
         label, builder = self._deferred_tab_builders.popleft()
         self.statusBar().showMessage(f"Building {label} tab…")
@@ -155,11 +190,26 @@ class MainWindow(QMainWindow):
             app.processEvents()
         builder()
         if self._deferred_tab_builders:
-            QTimer.singleShot(0, self._build_next_deferred_tab)
+            QTimer.singleShot(0, lambda: self._build_next_deferred_tab(gen))
         else:
-            self.statusBar().showMessage("Ready", 3000)
+            self._on_deferred_build_complete()
 
-    def _add_cameras_tab(self) -> None:
+    def _on_deferred_build_complete(self) -> None:
+        """Deferred tab chain finished: restore Open Project access, clear status.
+
+        Open Project stays disabled through the whole build so a second launch
+        can't race a half-built tab set.
+        """
+        self.open_project_action.setEnabled(True)
+        self.open_recent_project_submenu.setEnabled(True)
+        self.statusBar().showMessage("Ready", 3000)
+
+    # Each _make_*_tab constructs a tab widget (real or placeholder) and reports
+    # whether it should be enabled. The _add_* builders append at the end during the
+    # initial deferred build; _replace_placeholder_tab swaps one in at its existing
+    # index once it becomes enabled. Construction lives here so the two paths share it.
+
+    def _make_cameras_tab(self) -> tuple[QWidget, bool]:
         from caliscope.gui.cameras_tab_widget import CamerasTabWidget
         from caliscope.gui.widgets.cameras_info_placeholder import CamerasInfoPlaceholder
 
@@ -169,9 +219,10 @@ class MainWindow(QMainWindow):
         else:
             logger.info("No intrinsic videos - Cameras tab shows skip-intrinsics placeholder")
             self.cameras_tab_widget = CamerasInfoPlaceholder()
-        self.central_tab.addTab(self.cameras_tab_widget, "Cameras")
+        # Cameras stays interactive even as a placeholder (it explains skip-intrinsics).
+        return self.cameras_tab_widget, True
 
-    def _add_multi_camera_tab(self) -> None:
+    def _make_multi_camera_tab(self) -> tuple[QWidget, bool]:
         from caliscope.gui.multi_camera_processing_tab import MultiCameraProcessingTab
 
         enabled = self.coordinator.multi_camera_tab_enabled
@@ -180,10 +231,9 @@ class MainWindow(QMainWindow):
             self.multi_camera_tab: QWidget = MultiCameraProcessingTab(self.coordinator)
         else:
             self.multi_camera_tab = QWidget()
-        self.central_tab.addTab(self.multi_camera_tab, "Multi-Camera")
-        self.central_tab.setTabEnabled(self.find_tab_index_by_title("Multi-Camera"), enabled)
+        return self.multi_camera_tab, enabled
 
-    def _add_calibrate_tab(self) -> None:
+    def _make_calibrate_tab(self) -> tuple[QWidget, bool]:
         from caliscope.gui.extrinsic_calibration_tab import ExtrinsicCalibrationTab
 
         enabled = self.coordinator.capture_volume_tab_enabled
@@ -193,10 +243,9 @@ class MainWindow(QMainWindow):
             self.extrinsic_calibration_tab.navigation_requested.connect(self._navigate_to_tab)  # type: ignore[union-attr]
         else:
             self.extrinsic_calibration_tab = QWidget()
-        self.central_tab.addTab(self.extrinsic_calibration_tab, "Calibrate")
-        self.central_tab.setTabEnabled(self.find_tab_index_by_title("Calibrate"), enabled)
+        return self.extrinsic_calibration_tab, enabled
 
-    def _add_reconstruction_tab(self) -> None:
+    def _make_reconstruction_tab(self) -> tuple[QWidget, bool]:
         from caliscope.gui.reconstruction_tab import ReconstructionTab
 
         enabled = self.coordinator.reconstruction_tab_enabled
@@ -209,7 +258,25 @@ class MainWindow(QMainWindow):
             )
         else:
             self.reconstruction_tab = QWidget()
-        self.central_tab.addTab(self.reconstruction_tab, "Reconstruction")
+        return self.reconstruction_tab, enabled
+
+    def _add_cameras_tab(self) -> None:
+        widget, _enabled = self._make_cameras_tab()
+        self.central_tab.addTab(widget, "Cameras")
+
+    def _add_multi_camera_tab(self) -> None:
+        widget, enabled = self._make_multi_camera_tab()
+        self.central_tab.addTab(widget, "Multi-Camera")
+        self.central_tab.setTabEnabled(self.find_tab_index_by_title("Multi-Camera"), enabled)
+
+    def _add_calibrate_tab(self) -> None:
+        widget, enabled = self._make_calibrate_tab()
+        self.central_tab.addTab(widget, "Calibrate")
+        self.central_tab.setTabEnabled(self.find_tab_index_by_title("Calibrate"), enabled)
+
+    def _add_reconstruction_tab(self) -> None:
+        widget, enabled = self._make_reconstruction_tab()
+        self.central_tab.addTab(widget, "Reconstruction")
         self.central_tab.setTabEnabled(self.find_tab_index_by_title("Reconstruction"), enabled)
 
     def _replace_placeholder_tab(self, tab_name: str) -> None:
@@ -217,53 +284,31 @@ class MainWindow(QMainWindow):
         from caliscope.gui.extrinsic_calibration_tab import ExtrinsicCalibrationTab
         from caliscope.gui.multi_camera_processing_tab import MultiCameraProcessingTab
         from caliscope.gui.reconstruction_tab import ReconstructionTab
-        from caliscope.gui.widgets.cameras_info_placeholder import CamerasInfoPlaceholder
+
+        real_tab_types: dict[str, type[QWidget]] = {
+            "Cameras": CamerasTabWidget,
+            "Multi-Camera": MultiCameraProcessingTab,
+            "Calibrate": ExtrinsicCalibrationTab,
+            "Reconstruction": ReconstructionTab,
+        }
+        makers: dict[str, Callable[[], tuple[QWidget, bool]]] = {
+            "Cameras": self._make_cameras_tab,
+            "Multi-Camera": self._make_multi_camera_tab,
+            "Calibrate": self._make_calibrate_tab,
+            "Reconstruction": self._make_reconstruction_tab,
+        }
 
         idx = self.find_tab_index_by_title(tab_name)
         if idx < 0:
             return
         old = self.central_tab.widget(idx)
+        if isinstance(old, real_tab_types[tab_name]):
+            return
 
-        if tab_name == "Cameras":
-            if isinstance(old, CamerasTabWidget):
-                return
-            if self.coordinator.cameras_tab_enabled:
-                logger.info("Building Cameras tab with intrinsic calibration")
-                self.cameras_tab_widget = CamerasTabWidget(self.coordinator)
-            else:
-                logger.info("No intrinsic videos - Cameras tab shows skip-intrinsics placeholder")
-                self.cameras_tab_widget = CamerasInfoPlaceholder()
-            self.central_tab.removeTab(idx)
-            self.central_tab.insertTab(idx, self.cameras_tab_widget, "Cameras")
-
-        elif tab_name == "Multi-Camera":
-            if isinstance(old, MultiCameraProcessingTab):
-                return
-            logger.info("Building Multi-Camera processing tab")
-            self.multi_camera_tab = MultiCameraProcessingTab(self.coordinator)
-            self.central_tab.removeTab(idx)
-            self.central_tab.insertTab(idx, self.multi_camera_tab, "Multi-Camera")
-
-        elif tab_name == "Calibrate":
-            if isinstance(old, ExtrinsicCalibrationTab):
-                return
-            logger.info("Creating ExtrinsicCalibrationTab")
-            self.extrinsic_calibration_tab = ExtrinsicCalibrationTab(self.coordinator)
-            self.extrinsic_calibration_tab.navigation_requested.connect(self._navigate_to_tab)
-            self.central_tab.removeTab(idx)
-            self.central_tab.insertTab(idx, self.extrinsic_calibration_tab, "Calibrate")
-
-        elif tab_name == "Reconstruction":
-            if isinstance(old, ReconstructionTab):
-                return
-            logger.info("Creating reconstruction tab")
-            presenter = self.coordinator.create_reconstruction_presenter()
-            self.reconstruction_tab = ReconstructionTab(presenter)
-            self.coordinator.capture_volume_updated.connect(
-                lambda: presenter.refresh_camera_array(self.coordinator.camera_array)
-            )
-            self.central_tab.removeTab(idx)
-            self.central_tab.insertTab(idx, self.reconstruction_tab, "Reconstruction")
+        widget, enabled = makers[tab_name]()
+        self.central_tab.removeTab(idx)
+        self.central_tab.insertTab(idx, widget, tab_name)
+        self.central_tab.setTabEnabled(idx, enabled)
 
         if old is not None:
             old.deleteLater()
@@ -316,6 +361,23 @@ class MainWindow(QMainWindow):
 
     def launch_workspace(self, path_to_workspace: str) -> TaskHandle | None:
         """Launch workspace and return TaskHandle for additional callbacks."""
+        # Invalidate any in-flight deferred tab build from a previous project so its
+        # timer chain can't touch the coordinator we are about to tear down.
+        self._build_generation += 1
+
+        # If a project is already open, release its tabs' resources while the
+        # coordinator is still alive (same order as closeEvent), then swap in a
+        # fresh welcome screen — setCentralWidget deletes the old central widget,
+        # and Qt3D scene graphs must be torn down before that. The swap gives
+        # set_loading/_on_load_failed a valid target on every load path.
+        central = self.centralWidget()
+        if not isinstance(central, WelcomeWidget):
+            self._cleanup_tabs()
+            central = WelcomeWidget(self.recent_projects())
+            central.open_project_requested.connect(self.create_new_project_folder)
+            central.recent_project_selected.connect(self.launch_workspace)
+            self.setCentralWidget(central)
+
         # Tear down existing coordinator to avoid orphaned thread pools
         if hasattr(self, "coordinator"):
             self.coordinator.cleanup()
@@ -323,9 +385,7 @@ class MainWindow(QMainWindow):
 
         # Show loading state on welcome widget and flush the paint
         # before the blocking WorkspaceCoordinator constructor
-        central = self.centralWidget()
-        if isinstance(central, WelcomeWidget):
-            central.set_loading(path_to_workspace)
+        central.set_loading(path_to_workspace)
 
         self.open_project_action.setEnabled(False)
         self.open_recent_project_submenu.setEnabled(False)
@@ -337,6 +397,9 @@ class MainWindow(QMainWindow):
         from caliscope.workspace_coordinator import WorkspaceCoordinator
 
         logger.info(f"Launching session with config file stored in {path_to_workspace}")
+        # Leak-safety invariant: a settings error raises inside WorkspaceCoordinator.__init__
+        # before its TaskManager is constructed, so the synchronous failure path below leaks
+        # nothing (no threads exist yet to orphan).
         try:
             self.coordinator = WorkspaceCoordinator(Path(path_to_workspace))
             logger.info("Initiate coordinator loading")
@@ -345,7 +408,7 @@ class MainWindow(QMainWindow):
             self._on_load_failed(type(e).__name__, str(e))
             return None
 
-        handle.completed.connect(lambda _result: self.build_central_tabs())
+        handle.completed.connect(lambda _result, gen=self._build_generation: self.build_central_tabs(gen))
         handle.failed.connect(self._on_load_failed)
         self.coordinator.start_load(handle)
         return handle

--- a/src/caliscope/gui/main_widget.py
+++ b/src/caliscope/gui/main_widget.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
 import logging
 import os
 import subprocess
 import sys
+from collections import deque
+from collections.abc import Callable
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import rtoml
-from PySide6.QtCore import Qt
+from PySide6.QtCore import QTimer, Qt
 from PySide6.QtGui import QAction, QCloseEvent, QIcon
 from PySide6.QtWidgets import (
     QApplication,
@@ -19,15 +24,10 @@ from PySide6.QtWidgets import (
 
 from caliscope import APP_SETTINGS_PATH, LOG_DIR
 from caliscope.gui import ICONS_DIR
-from caliscope.workspace_coordinator import WorkspaceCoordinator
-from caliscope.task_manager import TaskHandle
-from caliscope.gui.cameras_tab_widget import CamerasTabWidget
-from caliscope.gui.widgets.cameras_info_placeholder import CamerasInfoPlaceholder
-from caliscope.gui.log_widget import LogWidget
-from caliscope.gui.multi_camera_processing_tab import MultiCameraProcessingTab
-from caliscope.gui.reconstruction_tab import ReconstructionTab
-from caliscope.gui.extrinsic_calibration_tab import ExtrinsicCalibrationTab
-from caliscope.gui.views.project_setup_view import ProjectSetupView
+from caliscope.gui.widgets.welcome_widget import WelcomeWidget
+
+if TYPE_CHECKING:
+    from caliscope.task_manager import TaskHandle
 
 logger = logging.getLogger(__name__)
 
@@ -41,13 +41,18 @@ class MainWindow(QMainWindow):
         self.setWindowTitle("Caliscope")
         self.setWindowIcon(QIcon(str(ICONS_DIR / "box3d-center.svg")))
         self.setMinimumSize(500, 500)
-        self.central_tab = QTabWidget(self)
-        self.setCentralWidget(self.central_tab)
 
         self.build_menus()
         self.connect_menu_actions()
-        # Log dock removed for cleaner UI
-        # self.build_docked_logger()
+
+        welcome = WelcomeWidget(self.recent_projects())
+        welcome.open_project_requested.connect(self.create_new_project_folder)
+        welcome.recent_project_selected.connect(self.launch_workspace)
+        self.setCentralWidget(welcome)
+
+    def recent_projects(self) -> list[str]:
+        """Newest-first recent project paths whose directories still exist."""
+        return [p for p in reversed(self.app_settings["recent_projects"]) if Path(p).is_dir()]
 
     def closeEvent(self, event: QCloseEvent) -> None:
         """Graceful shutdown on app exit.
@@ -58,7 +63,10 @@ class MainWindow(QMainWindow):
         """
         logger.info("Application exit initiated")
 
-        # Clean up tabs that have presenter resources
+        from caliscope.gui.cameras_tab_widget import CamerasTabWidget
+        from caliscope.gui.multi_camera_processing_tab import MultiCameraProcessingTab
+        from caliscope.gui.reconstruction_tab import ReconstructionTab
+
         cameras = getattr(self, "cameras_tab_widget", None)
         if isinstance(cameras, CamerasTabWidget):
             cameras.cleanup()
@@ -95,9 +103,7 @@ class MainWindow(QMainWindow):
         ####################  Open Recent  ################################
         self.open_recent_project_submenu = QMenu("Recent Projects...", self)
 
-        # Populate the submenu with recent project paths;
-        # reverse so that last one appended is at the top of the list
-        for project_path in reversed(self.app_settings["recent_projects"]):
+        for project_path in self.recent_projects():
             self.add_to_recent_project(project_path)
 
         self.file_menu.addMenu(self.open_recent_project_submenu)
@@ -108,81 +114,159 @@ class MainWindow(QMainWindow):
         self.exit_pyxy3d_action = QAction("Exit", self)
         self.file_menu.addAction(self.exit_pyxy3d_action)
 
-    def build_central_tabs(self):
+    def build_central_tabs(self, _result: object = None) -> None:
         self.central_tab = QTabWidget(self)
         self.setCentralWidget(self.central_tab)
 
-        # Project tab (always enabled)
+        self.statusBar().showMessage("Building Project tab…")
+
+        from caliscope.gui.views.project_setup_view import ProjectSetupView
+
         logger.info("Building Project setup tab")
         self.project_tab = ProjectSetupView(self.coordinator)
         self.project_tab.tab_navigation_requested.connect(self._navigate_to_tab)
         self.central_tab.addTab(self.project_tab, "Project")
 
-        # Cameras tab - always enabled. Without intrinsic videos it shows an
-        # info placeholder describing the skip-intrinsics path (a disabled tab
-        # can't be clicked, so it could never explain itself).
+        self.coordinator.status_changed.connect(self._refresh_tab_enablement)
+        self._previous_tab_index: int = 0
+        self.central_tab.currentChanged.connect(self._on_tab_changed)
+        self.open_project_action.setEnabled(True)
+        self.open_recent_project_submenu.setEnabled(True)
+
+        # Remaining tabs added one per event loop tick so the UI stays responsive
+        self._deferred_tab_builders: deque[tuple[str, Callable[[], None]]] = deque(
+            [
+                ("Cameras", self._add_cameras_tab),
+                ("Multi-Camera", self._add_multi_camera_tab),
+                ("Calibrate", self._add_calibrate_tab),
+                ("Reconstruction", self._add_reconstruction_tab),
+            ]
+        )
+        QTimer.singleShot(0, self._build_next_deferred_tab)
+
+    def _build_next_deferred_tab(self) -> None:
+        if not self._deferred_tab_builders:
+            self.statusBar().showMessage("Ready", 3000)
+            return
+        label, builder = self._deferred_tab_builders.popleft()
+        self.statusBar().showMessage(f"Building {label} tab…")
+        app = QApplication.instance()
+        if app is not None:
+            app.processEvents()
+        builder()
+        if self._deferred_tab_builders:
+            QTimer.singleShot(0, self._build_next_deferred_tab)
+        else:
+            self.statusBar().showMessage("Ready", 3000)
+
+    def _add_cameras_tab(self) -> None:
+        from caliscope.gui.cameras_tab_widget import CamerasTabWidget
+        from caliscope.gui.widgets.cameras_info_placeholder import CamerasInfoPlaceholder
+
         if self.coordinator.cameras_tab_enabled:
             logger.info("Building Cameras tab with intrinsic calibration")
-            self.cameras_tab_widget = CamerasTabWidget(self.coordinator)
+            self.cameras_tab_widget: QWidget = CamerasTabWidget(self.coordinator)
         else:
             logger.info("No intrinsic videos - Cameras tab shows skip-intrinsics placeholder")
             self.cameras_tab_widget = CamerasInfoPlaceholder()
         self.central_tab.addTab(self.cameras_tab_widget, "Cameras")
 
-        # Multi-Camera tab - enabled based on computed property
-        multi_camera_enabled = self.coordinator.multi_camera_tab_enabled
-        if multi_camera_enabled:
+    def _add_multi_camera_tab(self) -> None:
+        from caliscope.gui.multi_camera_processing_tab import MultiCameraProcessingTab
+
+        enabled = self.coordinator.multi_camera_tab_enabled
+        if enabled:
             logger.info("Building Multi-Camera processing tab")
-            self.multi_camera_tab = MultiCameraProcessingTab(self.coordinator)
+            self.multi_camera_tab: QWidget = MultiCameraProcessingTab(self.coordinator)
         else:
-            logger.info("Multi-Camera tab disabled - prerequisites not met")
             self.multi_camera_tab = QWidget()
         self.central_tab.addTab(self.multi_camera_tab, "Multi-Camera")
-        self.central_tab.setTabEnabled(
-            self.find_tab_index_by_title("Multi-Camera"),
-            multi_camera_enabled,
-        )
+        self.central_tab.setTabEnabled(self.find_tab_index_by_title("Multi-Camera"), enabled)
 
-        # Calibrate tab - enabled based on computed property
-        capture_volume_enabled = self.coordinator.capture_volume_tab_enabled
-        if capture_volume_enabled:
+    def _add_calibrate_tab(self) -> None:
+        from caliscope.gui.extrinsic_calibration_tab import ExtrinsicCalibrationTab
+
+        enabled = self.coordinator.capture_volume_tab_enabled
+        if enabled:
             logger.info("Creating ExtrinsicCalibrationTab")
-            self.extrinsic_calibration_tab = ExtrinsicCalibrationTab(self.coordinator)
-            self.extrinsic_calibration_tab.navigation_requested.connect(self._navigate_to_tab)
+            self.extrinsic_calibration_tab: QWidget = ExtrinsicCalibrationTab(self.coordinator)
+            self.extrinsic_calibration_tab.navigation_requested.connect(self._navigate_to_tab)  # type: ignore[union-attr]
         else:
-            logger.info("Creating dummy widget for Calibrate")
             self.extrinsic_calibration_tab = QWidget()
         self.central_tab.addTab(self.extrinsic_calibration_tab, "Calibrate")
-        self.central_tab.setTabEnabled(
-            self.find_tab_index_by_title("Calibrate"),
-            capture_volume_enabled,
-        )
+        self.central_tab.setTabEnabled(self.find_tab_index_by_title("Calibrate"), enabled)
 
-        # Reconstruction tab - enabled based on computed property
-        reconstruction_enabled = self.coordinator.reconstruction_tab_enabled
-        if reconstruction_enabled:
+    def _add_reconstruction_tab(self) -> None:
+        from caliscope.gui.reconstruction_tab import ReconstructionTab
+
+        enabled = self.coordinator.reconstruction_tab_enabled
+        if enabled:
             logger.info("Creating reconstruction tab")
             presenter = self.coordinator.create_reconstruction_presenter()
-            self.reconstruction_tab = ReconstructionTab(presenter)
-            # Update camera array when new capture volume is saved
+            self.reconstruction_tab: QWidget = ReconstructionTab(presenter)
             self.coordinator.capture_volume_updated.connect(
                 lambda: presenter.refresh_camera_array(self.coordinator.camera_array)
             )
         else:
-            logger.info("Creating dummy widget for Reconstruction")
             self.reconstruction_tab = QWidget()
         self.central_tab.addTab(self.reconstruction_tab, "Reconstruction")
-        self.central_tab.setTabEnabled(
-            self.find_tab_index_by_title("Reconstruction"),
-            reconstruction_enabled,
-        )
+        self.central_tab.setTabEnabled(self.find_tab_index_by_title("Reconstruction"), enabled)
 
-        # Subscribe to status_changed for dynamic tab enablement
-        self.coordinator.status_changed.connect(self._refresh_tab_enablement)
+    def _replace_placeholder_tab(self, tab_name: str) -> None:
+        from caliscope.gui.cameras_tab_widget import CamerasTabWidget
+        from caliscope.gui.extrinsic_calibration_tab import ExtrinsicCalibrationTab
+        from caliscope.gui.multi_camera_processing_tab import MultiCameraProcessingTab
+        from caliscope.gui.reconstruction_tab import ReconstructionTab
+        from caliscope.gui.widgets.cameras_info_placeholder import CamerasInfoPlaceholder
 
-        # Track current tab for Qt3D suspend/resume (QTabWidget doesn't fire hideEvent)
-        self._previous_tab_index: int = 0
-        self.central_tab.currentChanged.connect(self._on_tab_changed)
+        idx = self.find_tab_index_by_title(tab_name)
+        if idx < 0:
+            return
+        old = self.central_tab.widget(idx)
+
+        if tab_name == "Cameras":
+            if isinstance(old, CamerasTabWidget):
+                return
+            if self.coordinator.cameras_tab_enabled:
+                logger.info("Building Cameras tab with intrinsic calibration")
+                self.cameras_tab_widget = CamerasTabWidget(self.coordinator)
+            else:
+                logger.info("No intrinsic videos - Cameras tab shows skip-intrinsics placeholder")
+                self.cameras_tab_widget = CamerasInfoPlaceholder()
+            self.central_tab.removeTab(idx)
+            self.central_tab.insertTab(idx, self.cameras_tab_widget, "Cameras")
+
+        elif tab_name == "Multi-Camera":
+            if isinstance(old, MultiCameraProcessingTab):
+                return
+            logger.info("Building Multi-Camera processing tab")
+            self.multi_camera_tab = MultiCameraProcessingTab(self.coordinator)
+            self.central_tab.removeTab(idx)
+            self.central_tab.insertTab(idx, self.multi_camera_tab, "Multi-Camera")
+
+        elif tab_name == "Calibrate":
+            if isinstance(old, ExtrinsicCalibrationTab):
+                return
+            logger.info("Creating ExtrinsicCalibrationTab")
+            self.extrinsic_calibration_tab = ExtrinsicCalibrationTab(self.coordinator)
+            self.extrinsic_calibration_tab.navigation_requested.connect(self._navigate_to_tab)
+            self.central_tab.removeTab(idx)
+            self.central_tab.insertTab(idx, self.extrinsic_calibration_tab, "Calibrate")
+
+        elif tab_name == "Reconstruction":
+            if isinstance(old, ReconstructionTab):
+                return
+            logger.info("Creating reconstruction tab")
+            presenter = self.coordinator.create_reconstruction_presenter()
+            self.reconstruction_tab = ReconstructionTab(presenter)
+            self.coordinator.capture_volume_updated.connect(
+                lambda: presenter.refresh_camera_array(self.coordinator.camera_array)
+            )
+            self.central_tab.removeTab(idx)
+            self.central_tab.insertTab(idx, self.reconstruction_tab, "Reconstruction")
+
+        if old is not None:
+            old.deleteLater()
 
     def _refresh_tab_enablement(self) -> None:
         """Refresh tab enabled states from computed properties.
@@ -210,61 +294,18 @@ class MainWindow(QMainWindow):
 
     def _maybe_replace_dummy_tabs(self) -> None:
         """Replace dummy widgets with real tabs when they become enabled."""
-        # Cameras tab
-        cameras_idx = self.find_tab_index_by_title("Cameras")
-        if self.coordinator.cameras_tab_enabled and not isinstance(
-            self.central_tab.widget(cameras_idx), CamerasTabWidget
-        ):
-            old = self.central_tab.widget(cameras_idx)
-            self.cameras_tab_widget = CamerasTabWidget(self.coordinator)
-            self.central_tab.removeTab(cameras_idx)
-            self.central_tab.insertTab(cameras_idx, self.cameras_tab_widget, "Cameras")
-            if old:
-                old.deleteLater()
-
-        # Multi-Camera tab
-        multi_idx = self.find_tab_index_by_title("Multi-Camera")
-        if self.coordinator.multi_camera_tab_enabled and not isinstance(
-            self.central_tab.widget(multi_idx), MultiCameraProcessingTab
-        ):
-            old = self.central_tab.widget(multi_idx)
-            self.multi_camera_tab = MultiCameraProcessingTab(self.coordinator)
-            self.central_tab.removeTab(multi_idx)
-            self.central_tab.insertTab(multi_idx, self.multi_camera_tab, "Multi-Camera")
-            if old:
-                old.deleteLater()
-
-        # Calibrate tab
-        cv_idx = self.find_tab_index_by_title("Calibrate")
-        if self.coordinator.capture_volume_tab_enabled and not isinstance(
-            self.central_tab.widget(cv_idx), ExtrinsicCalibrationTab
-        ):
-            old = self.central_tab.widget(cv_idx)
-            self.extrinsic_calibration_tab = ExtrinsicCalibrationTab(self.coordinator)
-            self.extrinsic_calibration_tab.navigation_requested.connect(self._navigate_to_tab)
-            self.central_tab.removeTab(cv_idx)
-            self.central_tab.insertTab(cv_idx, self.extrinsic_calibration_tab, "Calibrate")
-            if old:
-                old.deleteLater()
-
-        # Reconstruction tab
-        recon_idx = self.find_tab_index_by_title("Reconstruction")
-        if self.coordinator.reconstruction_tab_enabled and not isinstance(
-            self.central_tab.widget(recon_idx), ReconstructionTab
-        ):
-            old = self.central_tab.widget(recon_idx)
-            presenter = self.coordinator.create_reconstruction_presenter()
-            self.reconstruction_tab = ReconstructionTab(presenter)
-            self.coordinator.capture_volume_updated.connect(
-                lambda: presenter.refresh_camera_array(self.coordinator.camera_array)
-            )
-            self.central_tab.removeTab(recon_idx)
-            self.central_tab.insertTab(recon_idx, self.reconstruction_tab, "Reconstruction")
-            if old:
-                old.deleteLater()
+        if self.coordinator.cameras_tab_enabled:
+            self._replace_placeholder_tab("Cameras")
+        if self.coordinator.multi_camera_tab_enabled:
+            self._replace_placeholder_tab("Multi-Camera")
+        if self.coordinator.capture_volume_tab_enabled:
+            self._replace_placeholder_tab("Calibrate")
+        if self.coordinator.reconstruction_tab_enabled:
+            self._replace_placeholder_tab("Reconstruction")
 
     def build_docked_logger(self):
-        # create log window which is fixed below main window
+        from caliscope.gui.log_widget import LogWidget
+
         self.docked_logger = QDockWidget("Log", self)
         self.docked_logger.setFeatures(QDockWidget.DockWidgetFeature.DockWidgetMovable)
         self.docked_logger.setAllowedAreas(Qt.DockWidgetArea.BottomDockWidgetArea)
@@ -273,22 +314,49 @@ class MainWindow(QMainWindow):
 
         self.addDockWidget(Qt.DockWidgetArea.BottomDockWidgetArea, self.docked_logger)
 
-    def launch_workspace(self, path_to_workspace: str) -> TaskHandle:
-        """Launch workspace and return TaskHandle for additional callbacks.
+    def launch_workspace(self, path_to_workspace: str) -> TaskHandle | None:
+        """Launch workspace and return TaskHandle for additional callbacks."""
+        # Tear down existing coordinator to avoid orphaned thread pools
+        if hasattr(self, "coordinator"):
+            self.coordinator.cleanup()
+            del self.coordinator
 
-        Returns:
-            TaskHandle for connecting additional completion callbacks.
-        """
-        logger.info(f"Launching session with config file stored in {path_to_workspace}")
-        self.coordinator = WorkspaceCoordinator(Path(path_to_workspace))
-        logger.info("Initiate coordinator loading")
-        # TaskHandle.completed safe to connect after start - Qt queues cross-thread signals
-        handle = self.coordinator.load_workspace()
-        handle.completed.connect(self.build_central_tabs)
+        # Show loading state on welcome widget and flush the paint
+        # before the blocking WorkspaceCoordinator constructor
+        central = self.centralWidget()
+        if isinstance(central, WelcomeWidget):
+            central.set_loading(path_to_workspace)
 
         self.open_project_action.setEnabled(False)
         self.open_recent_project_submenu.setEnabled(False)
+
+        app = QApplication.instance()
+        if app is not None:
+            app.processEvents()
+
+        from caliscope.workspace_coordinator import WorkspaceCoordinator
+
+        logger.info(f"Launching session with config file stored in {path_to_workspace}")
+        try:
+            self.coordinator = WorkspaceCoordinator(Path(path_to_workspace))
+            logger.info("Initiate coordinator loading")
+            handle = self.coordinator.load_workspace()
+        except Exception as e:
+            self._on_load_failed(type(e).__name__, str(e))
+            return None
+
+        handle.completed.connect(lambda _result: self.build_central_tabs())
+        handle.failed.connect(self._on_load_failed)
+        self.coordinator.start_load(handle)
         return handle
+
+    def _on_load_failed(self, exc_type: str, message: str) -> None:
+        logger.error(f"Workspace load failed: {exc_type}: {message}")
+        central = self.centralWidget()
+        if isinstance(central, WelcomeWidget):
+            central.set_error(message)
+        self.open_project_action.setEnabled(True)
+        self.open_recent_project_submenu.setEnabled(True)
 
     def find_tab_index_by_title(self, title):
         # Iterate through tabs to find the index of the tab with the given title
@@ -316,6 +384,9 @@ class MainWindow(QMainWindow):
         tabs - it only stops painting them. We manually notify 3D rendering widgets
         when their tab becomes inactive to reduce CPU usage.
         """
+        from caliscope.gui.extrinsic_calibration_tab import ExtrinsicCalibrationTab
+        from caliscope.gui.reconstruction_tab import ReconstructionTab
+
         _3d_tab_types = (ExtrinsicCalibrationTab, ReconstructionTab)
 
         # Suspend rendering on previous tab if it supports it
@@ -331,30 +402,6 @@ class MainWindow(QMainWindow):
             new_widget.resume_rendering()
 
         self._previous_tab_index = new_index
-
-    def reload_workspace(self):
-        # Clear all existing tabs
-        logger.info("Clearing workspace")
-        # Iterate backwards through the tabs and remove them
-        for index in range(self.central_tab.count() - 1, -1, -1):
-            widget_to_remove = self.central_tab.widget(index)
-            logger.info(f"Removing tab with index {index}")
-            self.central_tab.removeTab(index)
-            if widget_to_remove is not None:
-                # Explicit cleanup for widgets that need it
-                # (closeEvent not triggered by removeTab + deleteLater)
-                _cleanable = (CamerasTabWidget, MultiCameraProcessingTab, ExtrinsicCalibrationTab, ReconstructionTab)
-                if isinstance(widget_to_remove, _cleanable):
-                    widget_to_remove.cleanup()
-                widget_to_remove.deleteLater()
-
-            self.central_tab.clear()
-
-        workspace = self.coordinator.workspace
-        del self.coordinator
-        self.coordinator = WorkspaceCoordinator(workspace_dir=workspace)
-        handle = self.coordinator.load_workspace()
-        handle.completed.connect(self.build_central_tabs)
 
     def add_to_recent_project(self, project_path: str):
         recent_project_action = QAction(project_path, self)
@@ -423,4 +470,3 @@ def launch_main(workspace: str | None = None):
 
 if __name__ == "__main__":
     launch_main()
-    # pass

--- a/src/caliscope/gui/presenters/extrinsic_calibration_presenter.py
+++ b/src/caliscope/gui/presenters/extrinsic_calibration_presenter.py
@@ -230,7 +230,9 @@ class ExtrinsicCalibrationPresenter(QObject):
         # Processing state (managed internally)
         self._capture_volume: CaptureVolume | None = existing_capture_volume
         self._calibration_run: CalibrationRun | None = None
-        self._refine_intrinsics: bool = True
+        # Seed from the settings repository (the single source of the default)
+        # rather than a hardcoded literal, so the two can't diverge.
+        self._refine_intrinsics: bool = self.refine_intrinsics
         self._task_handle: TaskHandle | None = None
         self._filter_summary: str | None = None
         self._latest_scale_report: VolumetricScaleReport | None = None
@@ -290,6 +292,15 @@ class ExtrinsicCalibrationPresenter(QObject):
     def current_sync_index(self) -> int:
         """Current frame index for 3D visualization."""
         return self._current_sync_index
+
+    @property
+    def has_extraction_data(self) -> bool:
+        """Whether extraction output (image_points.csv) has been loaded.
+
+        Calibration cannot run without it; the view uses this to gate the
+        Calibrate button. Computed from internal reality, never cached.
+        """
+        return self._initial_image_points is not None
 
     @property
     def intrinsics_available(self) -> bool:
@@ -899,7 +910,7 @@ class ExtrinsicCalibrationPresenter(QObject):
             n_obs = len(self._initial_image_points.df)
             extract = (StepStatus.COMPLETE, f"{n_obs:,} observations")
         else:
-            extract = (StepStatus.NOT_STARTED, "run extraction on the Cameras tab")
+            extract = (StepStatus.NOT_STARTED, "run extraction on the Multi-Camera tab")
 
         # Calibrate step
         state = self.state
@@ -977,6 +988,35 @@ class ExtrinsicCalibrationPresenter(QObject):
         except Exception as e:
             logger.warning(f"Could not load initial image points: {e}")
             self._initial_image_points = None
+
+    def refresh_extraction_status(self) -> None:
+        """Pick up extraction output that appeared after the tab was built.
+
+        Wired to the coordinator's status_changed signal. Extraction runs on the
+        Multi-Camera tab, often after this presenter was constructed, so
+        _initial_image_points can be None at __init__ and stay that way until the
+        image_points.csv is written. On the None->loaded transition this re-emits
+        the derived state the view consumes at startup (coverage matrix, workflow
+        strip, calibration state) so the Extract step flips to complete and the
+        Calibrate button enables.
+
+        Cheap no-op when points are already loaded or a calibration task is
+        active — this fires on every status_changed, so it must not re-read the
+        CSV unconditionally. Re-extraction diffing is out of scope; only the
+        first successful load is handled here.
+        """
+        if self._initial_image_points is not None:
+            return
+        if self._is_task_active():
+            return
+
+        self._load_initial_image_points()
+        if self._initial_image_points is None:
+            return
+
+        self._refresh_initial_coverage()
+        self._emit_state_changed()
+        self._refresh_workflow_strip()
 
     def emit_initial_state(self) -> None:
         """Emit initial state for UI display after signal connections.

--- a/src/caliscope/gui/presenters/extrinsic_calibration_presenter.py
+++ b/src/caliscope/gui/presenters/extrinsic_calibration_presenter.py
@@ -676,7 +676,6 @@ class ExtrinsicCalibrationPresenter(QObject):
     def _on_calibration_completed(self, run: CalibrationRun) -> None:
         """Handle successful full calibration completion."""
         capture_volume = run.capture_volume
-        logger.info(f"Calibration complete. RMSE: {capture_volume.reprojection_report.overall_rmse:.3f}px")
 
         self._calibration_run = run
         self._capture_volume = capture_volume
@@ -686,7 +685,13 @@ class ExtrinsicCalibrationPresenter(QObject):
         if len(sync_indices) > 0:
             self._current_sync_index = int(sync_indices[0])
 
-        self._emit_state_changed()
+        # Everything below blocks the main thread (reprojection report, scale
+        # accuracy, view model, Qt3D rebuild) — tell the user before it does.
+        # The state change comes last so the progress row stays visible until
+        # the visualization is actually served.
+        self.progress_updated.emit(100, "Preparing visualization…")
+        logger.info(f"Calibration complete. RMSE: {capture_volume.reprojection_report.overall_rmse:.3f}px")
+
         self._refresh_quality_panel()
         self._refresh_coverage()
         self._refresh_view_model()
@@ -694,18 +699,21 @@ class ExtrinsicCalibrationPresenter(QObject):
         self._refresh_workflow_strip()
         self.capture_volume_changed.emit(capture_volume)
         self.calibration_run_updated.emit(run)
+        self._emit_state_changed()
 
     def _on_reoptimization_completed(self, capture_volume: CaptureVolume) -> None:
         """Handle successful filter re-optimization completion."""
-        logger.info(f"Re-optimization complete. RMSE: {capture_volume.reprojection_report.overall_rmse:.3f}px")
-
         self._capture_volume = capture_volume
         self._task_handle = None
 
         if self._calibration_run is not None:
             self._calibration_run = refresh_run(self._calibration_run, capture_volume)
 
-        self._emit_state_changed()
+        # Same ordering rationale as _on_calibration_completed: announce before
+        # the blocking refreshes, reveal the result state after them.
+        self.progress_updated.emit(100, "Preparing visualization…")
+        logger.info(f"Re-optimization complete. RMSE: {capture_volume.reprojection_report.overall_rmse:.3f}px")
+
         self._refresh_quality_panel()
         self._refresh_coverage()
         self._refresh_view_model()
@@ -715,6 +723,7 @@ class ExtrinsicCalibrationPresenter(QObject):
 
         if self._calibration_run is not None:
             self.calibration_run_updated.emit(self._calibration_run)
+        self._emit_state_changed()
 
     def _on_calibration_failed(self, exc_type: str, message: str) -> None:
         """Handle calibration failure."""

--- a/src/caliscope/gui/views/extrinsic_calibration_view.py
+++ b/src/caliscope/gui/views/extrinsic_calibration_view.py
@@ -563,7 +563,9 @@ class ExtrinsicCalibrationView(QWidget):
 
     def _on_rotate_clicked(self, axis: str, degrees: float) -> None:
         """Handle rotation button click."""
+        self._show_status(f"Rotating {axis} axis…")
         self._presenter.rotate(axis, degrees)
+        self._show_status("Ready", timeout_ms=3000)
 
     def _on_set_origin_clicked(self) -> None:
         """Handle set origin button click."""
@@ -571,14 +573,25 @@ class ExtrinsicCalibrationView(QWidget):
         if opt is None:
             return
 
+        self._show_status("Setting origin…")
+
         if opt.is_static:
             self._presenter.align_to_origin(opt.object_id, None)
-            return
+        elif len(self._valid_sync_indices) > 0:
+            actual_sync_index = int(self._valid_sync_indices[self._frame_slider.value()])
+            self._presenter.align_to_origin(opt.object_id, actual_sync_index)
 
-        if len(self._valid_sync_indices) == 0:
-            return
-        actual_sync_index = int(self._valid_sync_indices[self._frame_slider.value()])
-        self._presenter.align_to_origin(opt.object_id, actual_sync_index)
+        self._show_status("Ready", timeout_ms=3000)
+
+    def _show_status(self, message: str, timeout_ms: int = 0) -> None:
+        from PySide6.QtWidgets import QApplication, QMainWindow
+
+        window = self.window()
+        if isinstance(window, QMainWindow):
+            window.statusBar().showMessage(message, timeout_ms)
+            app = QApplication.instance()
+            if app is not None:
+                app.processEvents()
 
     def _populate_origin_combo(self) -> None:
         """Populate the origin combo from the presenter, preselecting the persisted origin."""

--- a/src/caliscope/gui/views/extrinsic_calibration_view.py
+++ b/src/caliscope/gui/views/extrinsic_calibration_view.py
@@ -573,11 +573,16 @@ class ExtrinsicCalibrationView(QWidget):
         if opt is None:
             return
 
+        # A frame-based origin needs a frame; with no valid sync indices there is
+        # nothing to align to, so avoid flashing a "Setting origin…" status for a no-op.
+        if not opt.is_static and len(self._valid_sync_indices) == 0:
+            return
+
         self._show_status("Setting origin…")
 
         if opt.is_static:
             self._presenter.align_to_origin(opt.object_id, None)
-        elif len(self._valid_sync_indices) > 0:
+        else:
             actual_sync_index = int(self._valid_sync_indices[self._frame_slider.value()])
             self._presenter.align_to_origin(opt.object_id, actual_sync_index)
 

--- a/src/caliscope/gui/views/extrinsic_calibration_view.py
+++ b/src/caliscope/gui/views/extrinsic_calibration_view.py
@@ -667,6 +667,11 @@ class ExtrinsicCalibrationView(QWidget):
         """Handle progress update from presenter."""
         self._progress_bar.setValue(percent)
         self._progress_label.setText(message)
+        # Paint now: the presenter blocks the main thread right after emitting
+        # "Preparing visualization…" (quality panel, view model, Qt3D rebuild),
+        # so a queued paint event would never run until the freeze ends.
+        self._progress_bar.repaint()
+        self._progress_label.repaint()
 
     def _on_quality_updated(self, data: CalibrationQualityData) -> None:
         """Handle quality data update from presenter."""

--- a/src/caliscope/gui/views/extrinsic_calibration_view.py
+++ b/src/caliscope/gui/views/extrinsic_calibration_view.py
@@ -463,11 +463,18 @@ class ExtrinsicCalibrationView(QWidget):
 
         if is_running:
             self._action_btn.setText("Cancel")
+            self._action_btn.setEnabled(True)
+            self._action_btn.setToolTip("")
         elif has_capture_volume:
             self._action_btn.setText("Recalibrate")
+            self._action_btn.setEnabled(True)
+            self._action_btn.setToolTip("")
         else:
             self._action_btn.setText("Calibrate")
-        self._action_btn.setEnabled(True)
+            # Nothing to calibrate until extraction has produced image_points.csv.
+            has_data = self._presenter.has_extraction_data
+            self._action_btn.setEnabled(has_data)
+            self._action_btn.setToolTip("" if has_data else "Run extraction on the Multi-Camera tab first")
 
         self._progress_bar.setVisible(is_running)
         self._progress_label.setVisible(is_running)

--- a/src/caliscope/gui/widgets/calibration_step_strip.py
+++ b/src/caliscope/gui/widgets/calibration_step_strip.py
@@ -16,6 +16,7 @@ from PySide6.QtWidgets import QHBoxLayout, QLabel, QSizePolicy, QVBoxLayout, QWi
 from caliscope.core.workflow_status import StepStatus
 from caliscope.gui.presenters.extrinsic_calibration_presenter import CalibrationStepData
 from caliscope.gui.theme import Colors
+from caliscope.gui.widgets.link_label import LinkLabel
 
 _ICONS_DIR = Path(__file__).parent.parent / "icons"
 
@@ -30,34 +31,6 @@ _STATUS_ICON = {
 def _load_colored_svg(icon: QSvgWidget, filename: str, color: str) -> None:
     svg_content = (_ICONS_DIR / filename).read_text()
     icon.load(QByteArray(svg_content.replace("currentColor", color).encode()))
-
-
-class _LinkLabel(QLabel):
-    """A QLabel styled and behaving like a hyperlink."""
-
-    clicked = Signal()
-
-    def __init__(self, parent: QWidget | None = None) -> None:
-        super().__init__(parent)
-        self.setCursor(Qt.CursorShape.PointingHandCursor)
-        self._set_underline(False)
-
-    def _set_underline(self, underline: bool) -> None:
-        decoration = "underline" if underline else "none"
-        self.setStyleSheet(f"color: {Colors.PRIMARY}; font-size: 10px; text-decoration: {decoration};")
-
-    def enterEvent(self, event) -> None:
-        self._set_underline(True)
-        super().enterEvent(event)
-
-    def leaveEvent(self, event) -> None:
-        self._set_underline(False)
-        super().leaveEvent(event)
-
-    def mousePressEvent(self, event) -> None:
-        if event.button() == Qt.MouseButton.LeftButton:
-            self.clicked.emit()
-        super().mousePressEvent(event)
 
 
 class _StepCell(QWidget):
@@ -88,7 +61,7 @@ class _StepCell(QWidget):
         self._detail_label.setStyleSheet(f"color: {Colors.TEXT_MUTED}; font-size: 10px;")
         text_layout.addWidget(self._detail_label)
 
-        self._detail_link = _LinkLabel()
+        self._detail_link = LinkLabel()
         self._detail_link.hide()
         self._detail_link.clicked.connect(self.link_clicked)
         text_layout.addWidget(self._detail_link)

--- a/src/caliscope/gui/widgets/calibration_step_strip.py
+++ b/src/caliscope/gui/widgets/calibration_step_strip.py
@@ -2,7 +2,8 @@
 
 Displays Extract -> Calibrate -> Set origin as a single-line status strip.
 Purely a status display, not a wizard — only the Extract step is clickable,
-and only while it hasn't run yet.
+and only while it hasn't run yet. The Extract link points at the Multi-Camera
+tab, where extraction runs.
 """
 
 from __future__ import annotations
@@ -86,7 +87,7 @@ class CalibrationStepStrip(QWidget):
     """Compact horizontal strip: Extract -> Calibrate -> Set origin.
 
     Status display only. The Extract step becomes a clickable link to the
-    Cameras tab while extraction hasn't been run yet; the other two steps
+    Multi-Camera tab while extraction hasn't been run yet; the other two steps
     are never clickable.
     """
 
@@ -105,7 +106,7 @@ class CalibrationStepStrip(QWidget):
         layout.setSpacing(6)
 
         self._extract_cell = _StepCell("Extract")
-        self._extract_cell.link_clicked.connect(lambda: self.navigation_requested.emit("Cameras"))
+        self._extract_cell.link_clicked.connect(lambda: self.navigation_requested.emit("Multi-Camera"))
         layout.addWidget(self._extract_cell, stretch=1)
 
         layout.addWidget(self._make_separator())

--- a/src/caliscope/gui/widgets/cameras_info_placeholder.py
+++ b/src/caliscope/gui/widgets/cameras_info_placeholder.py
@@ -17,28 +17,19 @@ DOCS_URL = "https://mprib.github.io/caliscope/extrinsic_calibration/#skipping-in
 _PLACEHOLDER_HTML = f"""
 <h3>No intrinsic calibration videos</h3>
 
-<p>This tab calibrates each camera's intrinsics (focal length, distortion) from
-per-camera videos in <code>calibration/intrinsic/</code>, and this project does not
-have one for every camera in the extrinsic set.</p>
-
-<p><b>That can be intentional.</b> Extrinsic calibration can recover focal length
-and distortion jointly with the camera poses — optional, if you capture for it:</p>
+<p>This tab calibrates each camera's lens (focal length, distortion) from videos in
+<code>calibration/intrinsic/</code>. This project has none — and that can be fine.
+Extrinsic calibration can recover lens parameters on its own if the capture supports it:</p>
 
 <ul>
-<li><b>Sweep the target through depth.</b> Move it toward and away from the
-cameras, not just across their views. Without depth variation, focal length
-cannot be recovered and the calibration falls back to a rough guess.</li>
-<li><b>Measure marker sizes accurately.</b> Marker size supplies both world scale
-and the rigid geometry that holds the solve together. Static anchor markers
-strengthen it further.</li>
-<li><b>Use markers large enough</b> to detect reliably across the volume.</li>
-<li><b>No fisheye cameras.</b> Fisheye lenses require intrinsic calibration here
-first; an extrinsic-only calibration fails for them outright.</li>
+<li>Move the target toward and away from the cameras, not just across the view.</li>
+<li>Measure marker sizes accurately — they set the world scale.</li>
+<li>No fisheye lenses. Those need intrinsic calibration first.</li>
 </ul>
 
-<p>If that matches your capture, continue on the <b>Calibrate</b> tab.
-To calibrate intrinsics here instead, add per-camera videos as
-<code>calibration/intrinsic/cam_N.mp4</code> and this tab will activate.</p>
+<p>If that matches your capture, continue on the <b>Calibrate</b> tab. To calibrate
+intrinsics here instead, add <code>calibration/intrinsic/cam_N.mp4</code> videos and
+this tab will activate.</p>
 
 <p><a href="{DOCS_URL}">Skipping intrinsic calibration — documentation</a></p>
 """

--- a/src/caliscope/gui/widgets/link_label.py
+++ b/src/caliscope/gui/widgets/link_label.py
@@ -1,0 +1,39 @@
+"""Reusable hyperlink-styled QLabel with click signal."""
+
+from __future__ import annotations
+
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtWidgets import QLabel, QWidget
+
+from caliscope.gui.theme import Colors
+
+
+class LinkLabel(QLabel):
+    """A QLabel styled and behaving like a hyperlink."""
+
+    clicked = Signal()
+
+    def __init__(self, font_size_px: int = 10, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._font_size_px = font_size_px
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._set_underline(False)
+
+    def _set_underline(self, underline: bool) -> None:
+        decoration = "underline" if underline else "none"
+        self.setStyleSheet(
+            f"color: {Colors.PRIMARY}; font-size: {self._font_size_px}px; text-decoration: {decoration};"
+        )
+
+    def enterEvent(self, event) -> None:  # type: ignore[override]
+        self._set_underline(True)
+        super().enterEvent(event)
+
+    def leaveEvent(self, event) -> None:  # type: ignore[override]
+        self._set_underline(False)
+        super().leaveEvent(event)
+
+    def mousePressEvent(self, event) -> None:  # type: ignore[override]
+        if event.button() == Qt.MouseButton.LeftButton:
+            self.clicked.emit()
+        super().mousePressEvent(event)

--- a/src/caliscope/gui/widgets/welcome_widget.py
+++ b/src/caliscope/gui/widgets/welcome_widget.py
@@ -1,0 +1,196 @@
+"""Welcome screen shown when no project is loaded."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from PySide6.QtCore import QByteArray, Qt, Signal
+from PySide6.QtGui import QPalette
+from PySide6.QtSvgWidgets import QSvgWidget
+from PySide6.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
+    QProgressBar,
+    QPushButton,
+    QScrollArea,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
+
+from caliscope.gui import ICONS_DIR
+from caliscope.gui.theme import Colors, Styles
+from caliscope.gui.widgets.link_label import LinkLabel
+
+_MAX_RECENT = 8
+
+
+class WelcomeWidget(QWidget):
+    open_project_requested = Signal()
+    recent_project_selected = Signal(str)
+
+    def __init__(self, recent_projects: list[str], parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._recent_projects = recent_projects[:_MAX_RECENT]
+        self._interactive_widgets: list[QWidget] = []
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        root = QVBoxLayout(self)
+        root.setContentsMargins(0, 0, 0, 0)
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QScrollArea.Shape.NoFrame)
+        root.addWidget(scroll)
+
+        inner = QWidget()
+        scroll.setWidget(inner)
+
+        outer = QVBoxLayout(inner)
+
+        outer.addStretch(1)
+
+        column = QVBoxLayout()
+        column.setAlignment(Qt.AlignmentFlag.AlignHCenter)
+        column.setSpacing(12)
+        outer.addLayout(column)
+
+        # --- App icon ---
+        icon_widget = self._build_icon()
+        column.addWidget(icon_widget, alignment=Qt.AlignmentFlag.AlignHCenter)
+
+        # --- Title ---
+        title = QLabel("Caliscope")
+        title.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        window_text = self.palette().color(QPalette.ColorRole.WindowText).name()
+        title.setStyleSheet(f"font-size: 28px; font-weight: bold; color: {window_text};")
+        column.addWidget(title)
+
+        # --- Subtitle ---
+        subtitle = QLabel("Multicamera Calibration for Motion Capture Workflows")
+        subtitle.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        subtitle.setStyleSheet(f"font-size: 13px; color: {window_text};")
+        column.addWidget(subtitle)
+
+        column.addSpacing(16)
+
+        # --- Primary button ---
+        self._open_button = QPushButton("New / Open Project…")
+        self._open_button.setStyleSheet(Styles.PRIMARY_BUTTON)
+        self._open_button.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        self._open_button.clicked.connect(self.open_project_requested)
+        self._interactive_widgets.append(self._open_button)
+        column.addWidget(self._open_button, alignment=Qt.AlignmentFlag.AlignHCenter)
+
+        column.addSpacing(16)
+
+        # --- Recent Projects ---
+        self._recents_container = QWidget()
+        recents_layout = QVBoxLayout(self._recents_container)
+        recents_layout.setContentsMargins(0, 0, 0, 0)
+        recents_layout.setSpacing(4)
+
+        recents_header = QLabel("Recent Projects")
+        recents_header.setStyleSheet(
+            f"font-weight: bold; font-size: 12px; color: {self.palette().color(QPalette.ColorRole.WindowText).name()};"
+        )
+        recents_layout.addWidget(recents_header)
+
+        self._recent_links: list[LinkLabel] = []
+        for project_path in self._recent_projects:
+            p = Path(project_path)
+            row = QHBoxLayout()
+            row.setContentsMargins(0, 0, 0, 0)
+            row.setSpacing(6)
+
+            link = LinkLabel(font_size_px=13)
+            link.setText(p.name)
+            link.setToolTip(str(p))
+            path_str = project_path
+            link.clicked.connect(lambda checked=False, s=path_str: self.recent_project_selected.emit(s))
+            self._interactive_widgets.append(link)
+            self._recent_links.append(link)
+            row.addWidget(link)
+
+            parent_display = str(p.parent).replace(str(Path.home()), "~")
+            dimmed = QLabel(parent_display)
+            placeholder_color = self.palette().color(QPalette.ColorRole.PlaceholderText).name()
+            dimmed.setStyleSheet(f"font-size: 13px; color: {placeholder_color};")
+            row.addWidget(dimmed)
+            row.addStretch()
+
+            recents_layout.addLayout(row)
+
+        self._recents_container.setVisible(len(self._recent_projects) > 0)
+        column.addWidget(self._recents_container, alignment=Qt.AlignmentFlag.AlignHCenter)
+
+        column.addSpacing(12)
+
+        # --- Status line ---
+        self._status_label = QLabel()
+        self._status_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._status_label.setWordWrap(True)
+        self._status_label.setMaximumWidth(400)
+        self._status_label.hide()
+        column.addWidget(self._status_label, alignment=Qt.AlignmentFlag.AlignHCenter)
+
+        # --- Progress bar ---
+        self._progress_bar = QProgressBar()
+        self._progress_bar.setRange(0, 0)
+        self._progress_bar.setMaximumWidth(300)
+        self._progress_bar.hide()
+        column.addWidget(self._progress_bar, alignment=Qt.AlignmentFlag.AlignHCenter)
+
+        # --- Helper text (first-time users only) ---
+        if not self._recent_projects:
+            helper = QLabel(
+                "A project is a folder. Choose an empty folder to start a new project, "
+                "or a previous project folder to reopen it."
+            )
+            helper.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            helper.setWordWrap(True)
+            helper.setMaximumWidth(350)
+            helper.setStyleSheet(f"font-size: 11px; color: {window_text};")
+            column.addWidget(helper, alignment=Qt.AlignmentFlag.AlignHCenter)
+
+        outer.addStretch(1)
+
+        # --- Tab order ---
+        self.setTabOrder(self._open_button, self._recent_links[0] if self._recent_links else self._open_button)
+        for i in range(len(self._recent_links) - 1):
+            self.setTabOrder(self._recent_links[i], self._recent_links[i + 1])
+
+        self._open_button.setFocus()
+
+    def _build_icon(self) -> QSvgWidget:
+        svg_path = ICONS_DIR / "box3d-center.svg"
+        svg_text = svg_path.read_text()
+        text_color = self.palette().color(QPalette.ColorRole.WindowText).name()
+        svg_text = svg_text.replace("#000000", text_color)
+        icon = QSvgWidget()
+        icon.setFixedSize(96, 96)
+        icon.load(QByteArray(svg_text.encode()))
+        return icon
+
+    def set_loading(self, project_path: str) -> None:
+        folder_name = Path(project_path).name
+        self._status_label.setText(f"Loading {folder_name}…")
+        window_text = self.palette().color(QPalette.ColorRole.WindowText).name()
+        self._status_label.setStyleSheet(f"color: {window_text};")
+        self._status_label.show()
+        self._progress_bar.show()
+        self._recents_container.hide()
+        for w in self._interactive_widgets:
+            w.setEnabled(False)
+
+    def set_error(self, message: str) -> None:
+        self._status_label.setText(f"Couldn't open this project — {message}")
+        self._status_label.setStyleSheet(f"color: {Colors.ERROR};")
+        self._status_label.show()
+        self._progress_bar.hide()
+        if self._recent_projects:
+            self._recents_container.show()
+        for w in self._interactive_widgets:
+            w.setEnabled(True)
+        self._open_button.setFocus()

--- a/src/caliscope/gui/widgets/welcome_widget.py
+++ b/src/caliscope/gui/widgets/welcome_widget.py
@@ -12,7 +12,6 @@ from PySide6.QtWidgets import (
     QLabel,
     QProgressBar,
     QPushButton,
-    QScrollArea,
     QSizePolicy,
     QVBoxLayout,
     QWidget,
@@ -36,18 +35,7 @@ class WelcomeWidget(QWidget):
         self._setup_ui()
 
     def _setup_ui(self) -> None:
-        root = QVBoxLayout(self)
-        root.setContentsMargins(0, 0, 0, 0)
-
-        scroll = QScrollArea()
-        scroll.setWidgetResizable(True)
-        scroll.setFrameShape(QScrollArea.Shape.NoFrame)
-        root.addWidget(scroll)
-
-        inner = QWidget()
-        scroll.setWidget(inner)
-
-        outer = QVBoxLayout(inner)
+        outer = QVBoxLayout(self)
 
         outer.addStretch(1)
 

--- a/src/caliscope/repositories/project_settings_repository.py
+++ b/src/caliscope/repositories/project_settings_repository.py
@@ -124,8 +124,12 @@ class ProjectSettingsRepository:
         self.save(settings)
 
     def get_refine_intrinsics(self) -> bool:
-        """Get flag for refining intrinsics during extrinsic bundle adjustment (default: True)."""
-        return bool(self._cache.get("refine_intrinsics", True))
+        """Get flag for refining intrinsics during extrinsic bundle adjustment (default: False).
+
+        Refining intrinsics during calibration is the more experimental path, so
+        it is opt-in rather than opt-out.
+        """
+        return bool(self._cache.get("refine_intrinsics", False))
 
     def set_refine_intrinsics(self, refine: bool) -> None:
         """Update refine intrinsics flag and persist immediately."""

--- a/src/caliscope/workspace_coordinator.py
+++ b/src/caliscope/workspace_coordinator.py
@@ -223,7 +223,10 @@ class WorkspaceCoordinator(QObject):
             TaskHandle for connecting completion callbacks.
         """
 
-        def worker(_token, _handle):
+        def worker(token, _handle):
+            if token.is_cancelled:
+                return
+
             # Load camera array if any calibration videos exist
             has_intrinsic = self.workspace_guide.all_instrinsic_mp4s_available()
             has_extrinsic = self.workspace_guide.all_extrinsic_mp4s_available()
@@ -232,6 +235,9 @@ class WorkspaceCoordinator(QObject):
                 self.load_camera_array()
             else:
                 logger.info("Skipping camera array load (no calibration videos)")
+
+            if token.is_cancelled:
+                return
 
             # Overlay bundle-authoritative camera state if a bundle exists
             if self.capture_volume_repository.camera_array_path.exists():
@@ -242,6 +248,9 @@ class WorkspaceCoordinator(QObject):
                             self.camera_array.cameras[cam_id] = bundle_cam
                     logger.info("Overlaid bundle-authoritative camera state")
 
+            if token.is_cancelled:
+                return
+
             if self.capture_volume_tab_enabled:
                 logger.info("Extrinsic calibration available (loaded via capture_volume property)")
             else:
@@ -249,8 +258,10 @@ class WorkspaceCoordinator(QObject):
 
         handle = self.task_manager.submit(worker, name="load_workspace", auto_start=False)
         handle.completed.connect(lambda _: self.status_changed.emit())
-        self.task_manager.start_task(handle.task_id)
         return handle
+
+    def start_load(self, handle: TaskHandle) -> None:
+        self.task_manager.start_task(handle.task_id)
 
     def all_instrinsic_mp4s_available(self) -> bool:
         """Check if all intrinsic calibration videos are present."""

--- a/tests/gui/presenters/test_extrinsic_calibration_presenter.py
+++ b/tests/gui/presenters/test_extrinsic_calibration_presenter.py
@@ -9,19 +9,40 @@ labeling is driven by the target type the coordinator hands the presenter.
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pandas as pd
+
 from caliscope.cameras.camera_array import CameraArray
+from caliscope.core.workflow_status import StepStatus
 from caliscope.gui.presenters.extrinsic_calibration_presenter import (
+    CalibrationStepData,
     ExtrinsicCalibrationPresenter,
 )
 
 
-def _make_presenter(extrinsic_target_type=None) -> ExtrinsicCalibrationPresenter:
+def _make_presenter(extrinsic_target_type=None, image_points_path=None) -> ExtrinsicCalibrationPresenter:
     return ExtrinsicCalibrationPresenter(
         task_manager=MagicMock(),
         camera_array=CameraArray({}),
-        image_points_path=Path("does_not_exist.csv"),
+        image_points_path=image_points_path or Path("does_not_exist.csv"),
         extrinsic_target_type=extrinsic_target_type,
     )
+
+
+def _write_minimal_image_points(path: Path) -> None:
+    """Write a schema-valid image_points.csv with two cameras sharing one point."""
+    pd.DataFrame(
+        {
+            "sync_index": [0, 0],
+            "cam_id": [0, 1],
+            "object_id": [0, 0],
+            "keypoint_id": [0, 0],
+            "img_loc_x": [1.0, 2.0],
+            "img_loc_y": [3.0, 4.0],
+            "obj_loc_x": [0.0, 0.0],
+            "obj_loc_y": [0.0, 0.0],
+            "obj_loc_z": [0.0, 0.0],
+        }
+    ).to_csv(path, index=False)
 
 
 def test_is_board_origin_true_for_charuco_target(qapp):
@@ -48,3 +69,37 @@ def test_is_board_origin_falls_back_to_heuristic_when_target_type_unknown(qapp):
     assert presenter._is_board_origin(object_ids=[0], static_ids=frozenset()) is True
     assert presenter._is_board_origin(object_ids=[0, 1], static_ids=frozenset()) is False
     assert presenter._is_board_origin(object_ids=[0], static_ids=frozenset({0})) is False
+
+
+def test_refresh_extraction_status_picks_up_late_extraction(qapp, tmp_path):
+    """Extraction output written after construction flips the extract step to
+    COMPLETE and enables calibration once refresh_extraction_status runs."""
+    image_points_path = tmp_path / "image_points.csv"
+    presenter = _make_presenter(image_points_path=image_points_path)
+
+    # Nothing on disk yet: extract step is not started, calibration is gated.
+    assert presenter.has_extraction_data is False
+    steps: list[CalibrationStepData] = []
+    presenter.workflow_updated.connect(steps.append)
+    presenter.emit_initial_state()
+    assert steps[-1].extract[0] == StepStatus.NOT_STARTED
+
+    # Extraction runs on the Multi-Camera tab and writes the CSV.
+    _write_minimal_image_points(image_points_path)
+    presenter.refresh_extraction_status()
+
+    assert presenter.has_extraction_data is True
+    assert steps[-1].extract[0] == StepStatus.COMPLETE
+
+
+def test_refresh_extraction_status_noop_when_already_loaded(qapp, tmp_path):
+    """A second refresh after data is loaded does not re-read or re-emit."""
+    image_points_path = tmp_path / "image_points.csv"
+    _write_minimal_image_points(image_points_path)
+    presenter = _make_presenter(image_points_path=image_points_path)
+    assert presenter.has_extraction_data is True
+
+    steps: list[CalibrationStepData] = []
+    presenter.workflow_updated.connect(steps.append)
+    presenter.refresh_extraction_status()
+    assert steps == []

--- a/tests/gui/test_main_window_welcome.py
+++ b/tests/gui/test_main_window_welcome.py
@@ -147,6 +147,101 @@ def test_fail_then_retry_cleans_up_coordinator(qapp, tmp_path):
         window.close()
 
 
+def test_close_during_load_cancels_worker(qapp, tmp_path):
+    """Closing the window mid-load cancels the running worker and never builds tabs."""
+    settings_path = _make_settings(tmp_path)
+    workspace = tmp_path / "closing_project"
+    workspace.mkdir()
+
+    gate = threading.Event()
+    captured: dict[str, object] = {}
+
+    def blocking_worker(token, handle):
+        captured["token"] = token
+        # Hold in RUNNING until cancelled; the gate is a safety release so the thread
+        # can't outlive the test. Mirrors production's cooperative cancellation checkpoints.
+        for _ in range(200):
+            if token.is_cancelled:
+                return
+            if gate.wait(timeout=0.05):
+                return
+
+    with patch("caliscope.gui.main_widget.APP_SETTINGS_PATH", settings_path):
+        window = MainWindow()
+
+        from caliscope.task_manager import TaskManager
+        from caliscope.task_manager.task_state import TaskState
+
+        task_manager = TaskManager()
+        handle = task_manager.submit(blocking_worker, name="test_load", auto_start=False)
+
+        mock_coordinator = MagicMock()
+        mock_coordinator.task_manager = task_manager
+        mock_coordinator.load_workspace = MagicMock(return_value=handle)
+        mock_coordinator.start_load = lambda h: task_manager.start_task(h.task_id)
+        # Mirror the real coordinator: cleanup shuts the TaskManager down, cancelling tokens.
+        mock_coordinator.cleanup = lambda: task_manager.shutdown(timeout_ms=2000)
+
+        with patch(
+            "caliscope.workspace_coordinator.WorkspaceCoordinator",
+            return_value=mock_coordinator,
+        ):
+            window.launch_workspace(str(workspace))
+
+        # Wait until the worker is actually running before closing.
+        for _ in range(200):
+            qapp.processEvents()
+            if handle.state == TaskState.RUNNING and "token" in captured:
+                break
+        assert handle.state == TaskState.RUNNING
+
+        window.close()  # closeEvent -> coordinator.cleanup() -> task_manager.shutdown()
+        gate.set()  # safety net if the worker somehow outlived the cancel
+
+        token = captured["token"]
+        assert token is not None and token.is_cancelled  # type: ignore[union-attr]
+        assert not hasattr(window, "central_tab")  # build_central_tabs never ran
+
+
+def test_project_switch_swaps_welcome_and_cleans_coordinator(qapp, tmp_path):
+    """Opening a new project while one is loaded tears down the old coordinator and,
+    on sync failure, lands on the welcome error state (not stale, dead-coordinator tabs)."""
+    from PySide6.QtWidgets import QTabWidget
+
+    settings_path = _make_settings(tmp_path)
+
+    with patch("caliscope.gui.main_widget.APP_SETTINGS_PATH", settings_path):
+        window = MainWindow()
+
+        # Simulate a loaded project: a coordinator plus a QTabWidget central widget
+        # (what build_central_tabs installs).
+        old_coordinator = MagicMock()
+        old_coordinator.cleanup = MagicMock()
+        window.coordinator = old_coordinator
+        window.setCentralWidget(QTabWidget())
+
+        old_gen = window._build_generation
+
+        with patch(
+            "caliscope.workspace_coordinator.WorkspaceCoordinator",
+            side_effect=ValueError("corrupt settings"),
+        ):
+            window.launch_workspace(str(tmp_path / "second_project"))
+
+        old_coordinator.cleanup.assert_called_once()
+
+        central = window.centralWidget()
+        assert isinstance(central, WelcomeWidget)
+        assert not central._status_label.isHidden()
+        assert "corrupt settings" in central._status_label.text()
+
+        # A stale deferred-build tick from the previous generation is a no-op:
+        # it must not raise and must not touch the (now deleted) coordinator.
+        window._build_next_deferred_tab(old_gen)
+
+        window.close()
+
+
 if __name__ == "__main__":
     import os
     import tempfile
@@ -154,19 +249,18 @@ if __name__ == "__main__":
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     from PySide6.QtWidgets import QApplication
 
-    app = QApplication([])
+    app = QApplication.instance() or QApplication([])
 
-    with tempfile.TemporaryDirectory() as td:
-        tmp = Path(td)
-        test_initial_central_widget_is_welcome(app, tmp)
-        print("PASS: test_initial_central_widget_is_welcome")
-
-    with tempfile.TemporaryDirectory() as td:
-        tmp = Path(td)
-        test_recent_projects_filters_nonexistent(app, tmp)
-        print("PASS: test_recent_projects_filters_nonexistent")
-
-    with tempfile.TemporaryDirectory() as td:
-        tmp = Path(td)
-        test_sync_failure_shows_error(app, tmp)
-        print("PASS: test_sync_failure_shows_error")
+    tests = [
+        test_initial_central_widget_is_welcome,
+        test_recent_projects_filters_nonexistent,
+        test_sync_failure_shows_error,
+        test_worker_failure_shows_error,
+        test_fail_then_retry_cleans_up_coordinator,
+        test_close_during_load_cancels_worker,
+        test_project_switch_swaps_welcome_and_cleans_coordinator,
+    ]
+    for test in tests:
+        with tempfile.TemporaryDirectory() as td:
+            test(app, Path(td))
+        print(f"PASS: {test.__name__}")

--- a/tests/gui/test_main_window_welcome.py
+++ b/tests/gui/test_main_window_welcome.py
@@ -154,10 +154,14 @@ def test_close_during_load_cancels_worker(qapp, tmp_path):
     workspace.mkdir()
 
     gate = threading.Event()
+    started = threading.Event()
     captured: dict[str, object] = {}
 
     def blocking_worker(token, handle):
         captured["token"] = token
+        # _WorkerThread.run() sets RUNNING before invoking the worker, so this
+        # event guarantees the handle is RUNNING when the test proceeds.
+        started.set()
         # Hold in RUNNING until cancelled; the gate is a safety release so the thread
         # can't outlive the test. Mirrors production's cooperative cancellation checkpoints.
         for _ in range(200):
@@ -188,11 +192,9 @@ def test_close_during_load_cancels_worker(qapp, tmp_path):
         ):
             window.launch_workspace(str(workspace))
 
-        # Wait until the worker is actually running before closing.
-        for _ in range(200):
-            qapp.processEvents()
-            if handle.state == TaskState.RUNNING and "token" in captured:
-                break
+        # Wait until the worker is actually running before closing. A processEvents
+        # spin is not a wait — thread startup needs real time under a loaded machine.
+        assert started.wait(timeout=5.0), "worker thread never started"
         assert handle.state == TaskState.RUNNING
 
         window.close()  # closeEvent -> coordinator.cleanup() -> task_manager.shutdown()

--- a/tests/gui/test_main_window_welcome.py
+++ b/tests/gui/test_main_window_welcome.py
@@ -1,0 +1,172 @@
+"""Integration tests for MainWindow welcome screen."""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import rtoml
+
+from caliscope.gui.main_widget import MainWindow
+from caliscope.gui.widgets.welcome_widget import WelcomeWidget
+
+
+def _make_settings(tmp_path: Path) -> Path:
+    settings_path = tmp_path / "settings.toml"
+    settings = {
+        "recent_projects": [],
+        "last_project_parent": str(tmp_path),
+    }
+    settings_path.write_text(rtoml.dumps(settings))
+    return settings_path
+
+
+def test_initial_central_widget_is_welcome(qapp, tmp_path):
+    settings_path = _make_settings(tmp_path)
+    with patch("caliscope.gui.main_widget.APP_SETTINGS_PATH", settings_path):
+        window = MainWindow()
+        assert isinstance(window.centralWidget(), WelcomeWidget)
+        window.close()
+
+
+def test_recent_projects_filters_nonexistent(qapp, tmp_path):
+    existing = tmp_path / "exists"
+    existing.mkdir()
+    settings_path = tmp_path / "settings.toml"
+    settings = {
+        "recent_projects": [str(existing), str(tmp_path / "gone")],
+        "last_project_parent": str(tmp_path),
+    }
+    settings_path.write_text(rtoml.dumps(settings))
+
+    with patch("caliscope.gui.main_widget.APP_SETTINGS_PATH", settings_path):
+        window = MainWindow()
+        recents = window.recent_projects()
+        assert str(existing) in recents
+        assert str(tmp_path / "gone") not in recents
+        window.close()
+
+
+def test_sync_failure_shows_error(qapp, tmp_path):
+    settings_path = _make_settings(tmp_path)
+    workspace = tmp_path / "bad_project"
+    workspace.mkdir()
+
+    with (
+        patch("caliscope.gui.main_widget.APP_SETTINGS_PATH", settings_path),
+        patch(
+            "caliscope.workspace_coordinator.WorkspaceCoordinator",
+            side_effect=ValueError("corrupt settings"),
+        ),
+    ):
+        window = MainWindow()
+        window.launch_workspace(str(workspace))
+
+        central = window.centralWidget()
+        assert isinstance(central, WelcomeWidget)
+        assert central._open_button.isEnabled()
+        assert not central._status_label.isHidden()
+        assert "corrupt settings" in central._status_label.text()
+        window.close()
+
+
+def test_worker_failure_shows_error(qapp, tmp_path):
+    """Worker-phase failure (background thread) routes to welcome error state."""
+    settings_path = _make_settings(tmp_path)
+    workspace = tmp_path / "worker_fail_project"
+    workspace.mkdir()
+
+    gate = threading.Event()
+
+    def failing_worker(token, handle):
+        gate.wait(timeout=5)
+        raise RuntimeError("corrupt bundle data")
+
+    with patch("caliscope.gui.main_widget.APP_SETTINGS_PATH", settings_path):
+        window = MainWindow()
+
+        mock_coordinator = MagicMock()
+        mock_coordinator.cleanup = MagicMock()
+
+        from caliscope.task_manager import TaskManager
+
+        task_manager = TaskManager()
+        mock_coordinator.task_manager = task_manager
+        handle = task_manager.submit(failing_worker, name="test_load", auto_start=False)
+
+        def start_load(h):
+            task_manager.start_task(h.task_id)
+
+        mock_coordinator.start_load = start_load
+        mock_coordinator.load_workspace = MagicMock(return_value=handle)
+
+        with patch(
+            "caliscope.workspace_coordinator.WorkspaceCoordinator",
+            return_value=mock_coordinator,
+        ):
+            window.launch_workspace(str(workspace))
+
+        received = threading.Event()
+        handle.failed.connect(lambda *_: received.set())
+        gate.set()
+
+        for _ in range(100):
+            qapp.processEvents()
+            if received.wait(timeout=0.05):
+                break
+
+        central = window.centralWidget()
+        assert isinstance(central, WelcomeWidget)
+        assert central._open_button.isEnabled()
+        assert "corrupt bundle data" in central._status_label.text()
+
+        task_manager.shutdown()
+        window.close()
+
+
+def test_fail_then_retry_cleans_up_coordinator(qapp, tmp_path):
+    """Second launch_workspace after a failure tears down the first coordinator."""
+    settings_path = _make_settings(tmp_path)
+
+    with patch("caliscope.gui.main_widget.APP_SETTINGS_PATH", settings_path):
+        window = MainWindow()
+
+        mock_coordinator = MagicMock()
+        mock_coordinator.cleanup = MagicMock()
+        window.coordinator = mock_coordinator
+
+        with patch(
+            "caliscope.workspace_coordinator.WorkspaceCoordinator",
+            side_effect=ValueError("still broken"),
+        ):
+            window.launch_workspace(str(tmp_path / "attempt2"))
+
+        mock_coordinator.cleanup.assert_called_once()
+        assert not hasattr(window, "coordinator") or window.coordinator is not mock_coordinator
+        window.close()
+
+
+if __name__ == "__main__":
+    import os
+    import tempfile
+
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    from PySide6.QtWidgets import QApplication
+
+    app = QApplication([])
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        test_initial_central_widget_is_welcome(app, tmp)
+        print("PASS: test_initial_central_widget_is_welcome")
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        test_recent_projects_filters_nonexistent(app, tmp)
+        print("PASS: test_recent_projects_filters_nonexistent")
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        test_sync_failure_shows_error(app, tmp)
+        print("PASS: test_sync_failure_shows_error")

--- a/tests/gui/test_welcome_widget.py
+++ b/tests/gui/test_welcome_widget.py
@@ -1,0 +1,108 @@
+"""Unit tests for WelcomeWidget."""
+
+from caliscope.gui.widgets.welcome_widget import WelcomeWidget
+
+
+def test_construction_empty_recents(qapp):
+    w = WelcomeWidget(recent_projects=[])
+    assert w._recents_container.isHidden()
+    assert w._open_button.isEnabled()
+
+
+def test_construction_populated_recents(qapp, tmp_path):
+    paths = [str(tmp_path / f"project_{i}") for i in range(3)]
+    for p in paths:
+        (tmp_path / p.split("/")[-1]).mkdir()
+
+    w = WelcomeWidget(recent_projects=paths)
+    assert not w._recents_container.isHidden()
+    assert len(w._recent_links) == 3
+
+
+def test_open_project_signal(qapp):
+    w = WelcomeWidget(recent_projects=[])
+    received = []
+    w.open_project_requested.connect(lambda: received.append(True))
+    w._open_button.click()
+    assert received == [True]
+
+
+def test_recent_project_signal(qapp, tmp_path):
+    project = tmp_path / "my_project"
+    project.mkdir()
+    path_str = str(project)
+
+    w = WelcomeWidget(recent_projects=[path_str])
+    received = []
+    w.recent_project_selected.connect(lambda p: received.append(p))
+    w._recent_links[0].clicked.emit()
+    assert received == [path_str]
+
+
+def test_set_loading_disables_controls(qapp, tmp_path):
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    w = WelcomeWidget(recent_projects=[str(project)])
+    w.set_loading(str(project))
+
+    assert not w._open_button.isEnabled()
+    assert not w._progress_bar.isHidden()
+    assert not w._status_label.isHidden()
+    assert "Loading" in w._status_label.text()
+    for link in w._recent_links:
+        assert not link.isEnabled()
+
+
+def test_set_error_reenables_controls(qapp, tmp_path):
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    w = WelcomeWidget(recent_projects=[str(project)])
+    w.set_loading(str(project))
+    w.set_error("bad things happened")
+
+    assert w._open_button.isEnabled()
+    assert w._progress_bar.isHidden()
+    assert not w._status_label.isHidden()
+    assert "bad things happened" in w._status_label.text()
+    for link in w._recent_links:
+        assert link.isEnabled()
+
+
+if __name__ == "__main__":
+    import os
+
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    from PySide6.QtWidgets import QApplication
+
+    app = QApplication([])
+
+    test_construction_empty_recents(app)
+    print("PASS: test_construction_empty_recents")
+
+    from pathlib import Path
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        test_construction_populated_recents(app, tmp)
+        print("PASS: test_construction_populated_recents")
+
+    test_open_project_signal(app)
+    print("PASS: test_open_project_signal")
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        test_recent_project_signal(app, tmp)
+        print("PASS: test_recent_project_signal")
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        test_set_loading_disables_controls(app, tmp)
+        print("PASS: test_set_loading_disables_controls")
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        test_set_error_reenables_controls(app, tmp)
+        print("PASS: test_set_error_reenables_controls")

--- a/tests/gui/test_welcome_widget.py
+++ b/tests/gui/test_welcome_widget.py
@@ -76,7 +76,7 @@ if __name__ == "__main__":
     os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
     from PySide6.QtWidgets import QApplication
 
-    app = QApplication([])
+    app = QApplication.instance() or QApplication([])
 
     test_construction_empty_recents(app)
     print("PASS: test_construction_empty_recents")

--- a/tests/test_camera_array.py
+++ b/tests/test_camera_array.py
@@ -239,6 +239,17 @@ class TestAllCamerasHaveResolution:
         assert arr.all_cameras_have_resolution() is True
 
 
+class TestAllIntrinsicsCalibrated:
+    def test_empty_array_returns_false(self):
+        # `all()` over no cameras is vacuously True; a zero-camera project must
+        # not report intrinsic calibration as complete.
+        assert CameraArray({}).all_intrinsics_calibrated() is False
+
+    def test_false_when_camera_lacks_intrinsics(self):
+        arr = CameraArray({0: CameraData(cam_id=0, size=(1920, 1080))})
+        assert arr.all_intrinsics_calibrated() is False
+
+
 if __name__ == "__main__":
     from caliscope.logger import setup_logging
 

--- a/tests/test_project_settings_repository.py
+++ b/tests/test_project_settings_repository.py
@@ -3,20 +3,23 @@ from pathlib import Path
 from caliscope.repositories.project_settings_repository import ProjectSettingsRepository
 
 
-def test_refine_intrinsics_defaults_true(tmp_path: Path) -> None:
+def test_refine_intrinsics_defaults_false(tmp_path: Path) -> None:
+    # Intrinsic refinement during extrinsic calibration is the more experimental
+    # path — opt-in, not opt-out.
     repo = ProjectSettingsRepository(tmp_path / "project_settings.toml")
-    assert repo.get_refine_intrinsics() is True
+    assert repo.get_refine_intrinsics() is False
 
 
 def test_refine_intrinsics_persists(tmp_path: Path) -> None:
     settings_path = tmp_path / "project_settings.toml"
     repo = ProjectSettingsRepository(settings_path)
 
-    repo.set_refine_intrinsics(False)
-    assert repo.get_refine_intrinsics() is False
+    # Persist the non-default value so this test can't pass on the default alone.
+    repo.set_refine_intrinsics(True)
+    assert repo.get_refine_intrinsics() is True
 
     reloaded = ProjectSettingsRepository(settings_path)
-    assert reloaded.get_refine_intrinsics() is False
+    assert reloaded.get_refine_intrinsics() is True
 
 
 def test_origin_object_id_defaults_none(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #972.

On macOS the menu bar floats outside the window, so a fresh launch showed an empty rectangle with nothing to click. The window now provides useful information. A number of other GUI associated cleanups happened.

## Summary

- `WelcomeWidget` replaces the empty startup `QTabWidget`: title, icon, New/Open Project button, recent projects as links (stale paths filtered, capped at 8), loading and error states

- Tabs build progressively, one per event-loop tick, with status bar messages; heavy tab imports deferred so the welcome screen doesn't pay for Qt3D/OpenCV at startup
- Calibration completion no longer says "Done" while the quality panel and 3D scene are still building — "Optimization complete", then "Preparing visualization…", and the calibrated state lands only when the visualization is served
- Status bar messages during origin set / axis rotate

**Workflow status fixes**
- Calibrate tab picks up extraction output that appears after the tab is built; Calibrate button disabled with a tooltip until extraction data exists
- Extraction link points at the Multi-Camera tab (was Cameras)
- `all_intrinsics_calibrated()` returns False for an empty camera array (vacuous `all()` showed zero-camera projects as complete, "0/0 cameras calibrated" with a green check)
- Refine Intrinsics defaults to False (experimental path, opt-in); still forced on when a camera lacks intrinsics
- No-intrinsic-videos placeholder copy cut to half length
