### PR TITLE
Add CameraData.from_intrinsics named constructor

### DIFF
--- a/src/caliscope/cameras/camera_array.py
+++ b/src/caliscope/cameras/camera_array.py
@@ -48,6 +48,49 @@ class CameraData:
         props = read_video_properties(Path(video_path))
         return cls(cam_id=cam_id, size=(props["width"], props["height"]))
 
+    @classmethod
+    def from_intrinsics(
+        cls,
+        cam_id: int,
+        size: tuple[int, int],
+        focal_length: float | None = None,
+        *,
+        fx: float | None = None,
+        fy: float | None = None,
+        cx: float | None = None,
+        cy: float | None = None,
+        distortions: np.ndarray | None = None,
+    ) -> CameraData:
+        """Create a CameraData with a pinhole matrix built from scalar intrinsics.
+
+        Pass ``focal_length`` for square pixels, or both ``fx`` and ``fy`` for
+        non-square. The principal point defaults to the image center. No
+        extrinsics are set.
+        """
+        if focal_length is not None:
+            if fx is not None or fy is not None:
+                raise ValueError("Pass either focal_length or fx/fy, not both.")
+            fx, fy = focal_length, focal_length
+        elif fx is None or fy is None:
+            raise ValueError("Pass either focal_length or both fx and fy.")
+
+        width, height = size
+        cx = width / 2.0 if cx is None else cx
+        cy = height / 2.0 if cy is None else cy
+        matrix = np.array(
+            [
+                [fx, 0.0, cx],
+                [0.0, fy, cy],
+                [0.0, 0.0, 1.0],
+            ]
+        )
+        return cls(
+            cam_id=cam_id,
+            size=size,
+            matrix=matrix,
+            distortions=np.zeros(5) if distortions is None else distortions,
+        )
+
     @property
     def transformation(self):
         """

--- a/tests/test_camera_array.py
+++ b/tests/test_camera_array.py
@@ -215,6 +215,33 @@ class TestSynthesizeDefaultIntrinsics:
             cam.synthesize_default_intrinsics()
 
 
+class TestFromIntrinsics:
+    def test_square_pixels_with_default_center(self):
+        cam = CameraData.from_intrinsics(cam_id=0, size=(1920, 1080), focal_length=910.0)
+
+        assert cam.matrix is not None
+        assert cam.distortions is not None
+        np.testing.assert_array_equal(
+            cam.matrix,
+            np.array([[910.0, 0.0, 960.0], [0.0, 910.0, 540.0], [0.0, 0.0, 1.0]]),
+        )
+        np.testing.assert_array_equal(cam.distortions, np.zeros(5))
+        assert cam.rotation is None and cam.translation is None
+
+    def test_non_square_pixels_with_explicit_center(self):
+        cam = CameraData.from_intrinsics(cam_id=1, size=(1280, 720), fx=1077.5, fy=1078.1, cx=637.9, cy=366.1)
+
+        assert cam.matrix is not None
+        np.testing.assert_array_equal(
+            cam.matrix,
+            np.array([[1077.5, 0.0, 637.9], [0.0, 1078.1, 366.1], [0.0, 0.0, 1.0]]),
+        )
+
+    def test_rejects_ambiguous_focal_spec(self):
+        with pytest.raises(ValueError, match="not both"):
+            CameraData.from_intrinsics(cam_id=0, size=(1920, 1080), focal_length=910.0, fx=900.0, fy=905.0)
+
+
 class TestAllCamerasHaveResolution:
     def test_empty_array_returns_false(self):
         arr = CameraArray({})


### PR DESCRIPTION
## Summary

Adds a named constructor that builds a pinhole camera matrix from scalar intrinsics. First step of the markerless calibration demo spec: lets a script declare measured intrinsics as literal numbers instead of loading a TOML.

- `focal_length` for square pixels, or `fx`/`fy` for non-square
- `cx`/`cy` default to the image center
- distortions default to zeros, no extrinsics set

Follows the `from_video` named-constructor pattern (src/caliscope/cameras/camera_array.py:43). Matrix construction mirrors `CameraArray.from_focal_estimates` (camera_array.py:342).

## Testing

- `uv run pytest tests/test_camera_array.py -k FromIntrinsics`: 3 passed
- `uv run basedpyright` on changed files: clean