### PR TITLE
fix: OpenCV 5 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "caliscope"
-version = "0.11.2"
+version = "0.11.3"
 description = "Rapid and reliable multicamera calibration with GUI and scripting API"
 authors = [{name = "Mac Prible", email = "prible@gmail.com"}]
 license = { text = "BSD-2-Clause" }

--- a/src/caliscope/core/calibrate_intrinsics.py
+++ b/src/caliscope/core/calibrate_intrinsics.py
@@ -152,8 +152,11 @@ def calibrate_intrinsics(
         obj_pts = [p.astype(np.float32) for p in obj_points_list]
         img_pts = [p.astype(np.float32) for p in img_points_list]
 
-        # Pre-initialize output matrices (required by type checker, works at runtime)
-        camera_matrix = np.zeros((3, 3), dtype=np.float64)
+        camera_matrix = np.eye(3, dtype=np.float64)
+        camera_matrix[0, 0] = max(width, height)
+        camera_matrix[1, 1] = max(width, height)
+        camera_matrix[0, 2] = (width - 1) * 0.5
+        camera_matrix[1, 2] = (height - 1) * 0.5
         dist_coeffs = np.zeros(5, dtype=np.float64)
 
         error, mtx, dist, rvecs, tvecs = cv2.calibrateCamera(
@@ -162,6 +165,7 @@ def calibrate_intrinsics(
             (width, height),
             camera_matrix,
             dist_coeffs,
+            flags=cv2.CALIB_USE_INTRINSIC_GUESS,
         )
         # calibrateCamera returns dist as (1, 5), flatten it
         dist = dist.ravel()

--- a/src/caliscope/trackers/charuco_tracker.py
+++ b/src/caliscope/trackers/charuco_tracker.py
@@ -110,8 +110,8 @@ class CharucoTracker(Tracker):
             except Exception as e:
                 logger.debug(f"Sub pixel detection failed: {e}")
 
-            ids = _ids[:, 0]
-            img_loc = _img_loc[:, 0]
+            ids = _ids.squeeze()
+            img_loc = _img_loc.squeeze(axis=1) if _img_loc.ndim == 3 else _img_loc
 
             # flip coordinates if mirrored image fed in
             frame_width = gray_frame.shape[1]

--- a/tests/test_calibrate_intrinsics.py
+++ b/tests/test_calibrate_intrinsics.py
@@ -43,8 +43,7 @@ class TestCalibrateIntrinsics:
         """Calibration produces reasonable camera matrix and distortions."""
         image_points, cam0_frames = _load_test_data()
 
-        # Use first 20 frames for calibration
-        selected = cam0_frames[:20]
+        selected = cam0_frames[:30]
 
         result = calibrate_intrinsics(
             image_points,

--- a/uv.lock
+++ b/uv.lock
@@ -104,7 +104,7 @@ wheels = [
 
 [[package]]
 name = "caliscope"
-version = "0.11.2"
+version = "0.11.3"
 source = { editable = "." }
 dependencies = [
     { name = "av" },


### PR DESCRIPTION
## Summary

- Charuco detectBoard shape change: ids returned as (N,) instead of (N, 1) in OpenCV 5. Fixed with squeeze.
- calibrateCamera solver change: OpenCV 5's Schur-complement LM converges to bad local minima without an explicit initial guess. Fixed with CALIB_USE_INTRINSIC_GUESS.
- Intrinsic test uses 30 frames instead of 20 so the principal point is well-constrained across solver implementations.
- Bump to 0.11.3.

## Test plan

- [x] Full suite passes on OpenCV 4.13 (766 passed)
- [x] Full suite passes on OpenCV 5.0 (766 passed)
- [x] Type check clean (basedpyright)
- [x] Confirmed Schur solver root cause via CALIB_DISABLE_SCHUR_COMPLEMENT diagnostic