### PR TITLE
docs(api): add shared-video calibration demos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,10 @@ scripts/*
 !scripts/benchmark_frame_seeking.py
 !scripts/demo/
 scripts/demo/*
+!scripts/demo/demo_joint_intrinsic_extrinsic_calibration.py
 !scripts/demo/demo_markerless_calibration.py
 !scripts/demo/demo_opencap_calibration.py
+!scripts/demo/demo_shared_video_calibration.py
 scripts/ralph_wiggum_viz/output/
 tests/debug/*
 *context.txt

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -13,6 +13,10 @@ uv pip install caliscope[gui]   # adds desktop app, 3D visualization, and pose t
 Everything below uses the `caliscope.api` module.
 A complete working script is in `scripts/demo_api.py`.
 
+For an alternate workflow, `scripts/demo/demo_shared_video_calibration.py` calibrates both intrinsics and extrinsics from one synchronized ChArUco recording.
+The script detects the board once, uses each camera's observations for intrinsic calibration, then uses the combined observations for extrinsic calibration.
+The recording must include varied board positions and tilts in every camera as well as simultaneous views across cameras.
+
 ## Imports
 
 ```python

--- a/scripts/demo/demo_joint_intrinsic_extrinsic_calibration.py
+++ b/scripts/demo/demo_joint_intrinsic_extrinsic_calibration.py
@@ -1,0 +1,62 @@
+"""Experimental demo: recover intrinsics and extrinsics in one calibration.
+
+The cameras begin with image dimensions only. Caliscope supplies an initial
+pinhole estimate, then refines focal length and radial distortion together
+with camera poses and 3D points.
+"""
+
+from pathlib import Path
+
+from caliscope.api import (
+    CameraArray,
+    Charuco,
+    CharucoTracker,
+    ConstraintSet,
+    calibrate_extrinsics,
+    extract_image_points_multicam,
+)
+from caliscope.reporting import print_extrinsic_report
+
+# --- Recording and output paths ---
+VIDEO_DIR = Path("calibration_videos")
+OUTPUT_DIR = Path("capture_volume")
+CAM_IDS = [0, 1, 2]
+
+videos = {cam_id: VIDEO_DIR / f"cam_{cam_id}.mp4" for cam_id in CAM_IDS}
+TIMESTAMPS: Path | None = None
+
+# --- 1. Define the calibration target ---
+# These dimensions must match the physical board in the recording.
+charuco = Charuco.from_squares(columns=4, rows=5, square_size_cm=3.0)
+tracker = CharucoTracker(charuco)
+constraints = ConstraintSet.from_charuco(charuco)
+
+# --- 2. Build cameras with image dimensions but no calibration ---
+cameras = CameraArray.from_video_metadata(videos)
+
+# --- 3. Detect the board across the synchronized videos ---
+points = extract_image_points_multicam(
+    videos,
+    tracker,
+    frame_step=5,
+    timestamps=TIMESTAMPS,
+)
+
+# --- 4. Recover intrinsics and extrinsics together ---
+# Each standard camera starts with fx = fy = image_width / 2, a centered
+# principal point, and zero distortion. Bundle adjustment refines focal length,
+# k1, and k2. Move the board toward and away from every camera so those
+# parameters can be distinguished from camera position and scene scale.
+run = calibrate_extrinsics(
+    points,
+    cameras,
+    constraints,
+    refine_intrinsics=True,
+)
+volume = run.capture_volume
+
+if run.intrinsic_refinement_gated:
+    print("Intrinsic refinement was disabled because the recording lacked depth variation.")
+
+print_extrinsic_report(volume)
+volume.save(OUTPUT_DIR)

--- a/scripts/demo/demo_shared_video_calibration.py
+++ b/scripts/demo/demo_shared_video_calibration.py
@@ -1,0 +1,75 @@
+"""Demo: intrinsic and extrinsic calibration from the same video files.
+
+This example uses one synchronized ChArUco recording for both calibration
+stages. The recording must show varied board positions and tilts in each
+camera, with enough simultaneous views to connect the camera rig.
+"""
+
+from pathlib import Path
+
+from caliscope.api import (
+    CameraArray,
+    Charuco,
+    CharucoTracker,
+    ConstraintSet,
+    calibrate_extrinsics,
+    calibrate_intrinsics,
+    extract_image_points_multicam,
+)
+from caliscope.reporting import (
+    print_camera_pair_coverage,
+    print_extrinsic_report,
+    print_intrinsic_report,
+)
+
+# --- Recording and output paths ---
+VIDEO_DIR = Path("calibration_videos")
+OUTPUT_DIR = Path("capture_volume")
+CAM_IDS = [0, 1, 2]
+
+videos = {cam_id: VIDEO_DIR / f"cam_{cam_id}.mp4" for cam_id in CAM_IDS}
+
+# Use a timestamps file when the cameras did not start at exactly the same time.
+# Hardware-synchronized recordings can infer timestamps from the videos.
+TIMESTAMPS: Path | None = None
+
+# --- 1. Define the calibration target ---
+# These dimensions must match the physical board in the recording.
+charuco = Charuco.from_squares(columns=4, rows=5, square_size_cm=3.0)
+tracker = CharucoTracker(charuco)
+constraints = ConstraintSet.from_charuco(charuco)
+
+# --- 2. Build uncalibrated cameras from the shared videos ---
+cameras = CameraArray.from_video_metadata(videos)
+
+# --- 3. Detect the board once across all synchronized videos ---
+# The resulting table contains observations from every camera. Each intrinsic
+# solve selects one camera's rows; the extrinsic solve uses the full table.
+points = extract_image_points_multicam(
+    videos,
+    tracker,
+    frame_step=5,
+    timestamps=TIMESTAMPS,
+)
+print_camera_pair_coverage(points)
+
+# --- 4. Calibrate each camera's intrinsics ---
+for cam_id in CAM_IDS:
+    result = calibrate_intrinsics(points, cameras[cam_id])
+    cameras[cam_id] = result.camera
+    print_intrinsic_report(result)
+
+# --- 5. Calibrate the camera poses from the same observations ---
+# Keep the intrinsics fixed so the two calibration stages remain distinct.
+run = calibrate_extrinsics(
+    points,
+    cameras,
+    constraints,
+    refine_intrinsics=False,
+)
+volume = run.capture_volume
+print_extrinsic_report(volume)
+
+# --- 6. Save the calibrated camera system and observations ---
+volume.save(OUTPUT_DIR)
+print(f"Saved capture volume to {OUTPUT_DIR}")


### PR DESCRIPTION
A synchronized ChArUco recording can support two related calibration workflows, but the existing API demo uses separate intrinsic and extrinsic recordings. Readers had no compact example showing how the same observations flow through both stages.

Add one linear example that calibrates each camera intrinsically before solving the rig with locked intrinsics. Add a second, deliberately undocumented experimental example that starts from video dimensions and jointly recovers focal length, radial distortion, camera poses, and 3D points. Both avoid CLI scaffolding so the calibration calls remain visible.

The sequential example completed against the four-camera `charuco_calibration` session with a converged 1.615 px extrinsic RMSE. The blind-start synthetic calibration test passed. Ruff, basedpyright, the strict MkDocs build, and the full test suite passed with 772 tests.
