### PR TITLE
Do not squeeze ids when ndim < 2

### DIFF
--- a/src/caliscope/trackers/charuco_tracker.py
+++ b/src/caliscope/trackers/charuco_tracker.py
@@ -110,7 +110,7 @@ class CharucoTracker(Tracker):
             except Exception as e:
                 logger.debug(f"Sub pixel detection failed: {e}")
 
-            ids = _ids.squeeze()
+            ids = _ids.squeeze() if _ids.ndim == 2 else _ids
             img_loc = _img_loc.squeeze(axis=1) if _img_loc.ndim == 3 else _img_loc
 
             # flip coordinates if mirrored image fed in


### PR DESCRIPTION
This prevents downstream `len(ids)` hitting `TypeError`.
Fixes #1016

Same fix as suggested in #1016 by @TimSeizinger