### PR TITLE
fix: handle single charuco detection across OpenCV 4 and 5

### DIFF
--- a/src/caliscope/trackers/charuco_tracker.py
+++ b/src/caliscope/trackers/charuco_tracker.py
@@ -110,8 +110,8 @@ class CharucoTracker(Tracker):
             except Exception as e:
                 logger.debug(f"Sub pixel detection failed: {e}")
 
-            ids = _ids.squeeze() if _ids.ndim == 2 else _ids
-            img_loc = _img_loc.squeeze(axis=1) if _img_loc.ndim == 3 else _img_loc
+            ids = _ids.reshape(-1)
+            img_loc = _img_loc.reshape(-1, 2)
 
             # flip coordinates if mirrored image fed in
             frame_width = gray_frame.shape[1]

--- a/src/caliscope/trackers/charuco_tracker.py
+++ b/src/caliscope/trackers/charuco_tracker.py
@@ -110,7 +110,7 @@ class CharucoTracker(Tracker):
             except Exception as e:
                 logger.debug(f"Sub pixel detection failed: {e}")
 
-            ids = _ids.squeeze()
+            ids = _ids.squeeze() if _ids.ndim == 2 else _ids
             img_loc = _img_loc.squeeze(axis=1) if _img_loc.ndim == 3 else _img_loc
 
             # flip coordinates if mirrored image fed in

--- a/tests/test_charuco_tracker.py
+++ b/tests/test_charuco_tracker.py
@@ -259,6 +259,40 @@ def test_thick_board_front_view_unchanged(scene):
     assert np.all(packet.obj_loc[:, 2] == 0.0)
 
 
+@pytest.mark.parametrize(
+    "id_shape",
+    [
+        (1,),  # OpenCV 5 single-detection shape
+        (1, 1),  # OpenCV 4 single-detection shape
+    ],
+    ids=["1d", "2d"],
+)
+def test_single_detection_does_not_collapse_to_scalar(scene, id_shape):
+    """Regression: .squeeze() on a single-element id array collapses it to a
+    0D scalar, making len(ids) raise TypeError downstream. GH-1016.
+    Both OpenCV 4 shape (1,1) and OpenCV 5 shape (1,) must survive."""
+    charuco, board_img, board_w_m, board_h_m, to_px = scene
+    tracker = CharucoTracker(charuco)
+    gray = np.full(IMG_SIZE[::-1], 128, dtype=np.uint8)
+
+    single_id = np.array([5]).reshape(id_shape)
+    single_loc = np.array([[100.0, 200.0]])
+
+    class StubDetector:
+        def detectBoard(self, frame):
+            return single_loc, single_id, None, None
+
+    tracker.detector = StubDetector()
+    ids, img_loc = tracker.find_corners_single_frame(gray, mirror=False)
+
+    assert ids.ndim == 1, f"ids collapsed to {ids.ndim}D"
+    assert len(ids) == 1
+    assert ids[0] == 5
+
+    packet = tracker._detect(gray, cam_id=0)
+    assert len(packet.keypoint_id) == 1
+
+
 def test_mirror_hint_is_remembered_per_camera(scene):
     """The flip-hint cache: after a mirrored detection, the next frame for the
     same cam_id tries the mirrored orientation first; a different cam_id is


### PR DESCRIPTION
## Summary

When I added OpenCV 5 compatibility in #1008, I changed the charuco id handling from `_ids[:, 0]` to `_ids.squeeze()`. That fixed the multi-detection case but broke single-detection frames. When only one charuco corner is detected, `squeeze()` collapses the array to a 0D scalar, and `len(ids)` throws `TypeError` downstream.

@TimSeizinger reported this in #1016 with a clear diagnosis and a fix suggestion. @caenrigen opened #1017 with a PR implementing that fix, guarding the squeeze with an `ndim` check. That fix works for OpenCV 5's `(1,)` return shape, and their commit is included here as the first commit on this branch.

The second commit replaces the conditional squeeze with `reshape(-1)`, which handles all return shapes from both OpenCV versions: `(N,)`, `(N, 1)`, `(1,)`, and `(1, 1)`. A parametrized regression test covers both the OpenCV 4 and OpenCV 5 single-detection shapes.

Closes #1016
Supersedes #1017

## Test plan

- [x] New parametrized test fails on main, passes with fix
- [x] All 8 charuco tracker tests pass