### PR TITLE
fix: guard Qt3D widget against missing OpenGL context

### DIFF
--- a/src/caliscope/gui/views/extrinsic_calibration_view.py
+++ b/src/caliscope/gui/views/extrinsic_calibration_view.py
@@ -48,7 +48,7 @@ from caliscope.gui.widgets.calibration_step_strip import CalibrationStepStrip
 from caliscope.gui.widgets.coverage_heatmap import CoverageHeatmapWidget
 from caliscope.gui.widgets.distance_sparkline import DistanceSparkline
 from caliscope.gui.widgets.lens_model_dialog import LensModelDialog
-from caliscope.gui.widgets.qt3d_playback_widget import Qt3DPlaybackWidget
+from caliscope.gui.widgets.qt3d_playback_widget import Qt3DPlaybackWidget, opengl_available
 from caliscope.gui.widgets.scale_detail_dialog import ScaleDetailDialog
 
 logger = logging.getLogger(__name__)
@@ -782,6 +782,16 @@ class ExtrinsicCalibrationView(QWidget):
         logger.debug("Creating Qt3D visualization widget")
 
         self._viz_placeholder.hide()
+
+        if not opengl_available():
+            self._viz_placeholder.setText(
+                "3D preview requires a graphics driver that is not available.\n"
+                "Your calibration data is saved and usable.\n\n"
+                "To enable the preview, relaunch with:\n"
+                "LIBGL_ALWAYS_SOFTWARE=1 caliscope"
+            )
+            self._viz_placeholder.show()
+            return
 
         self._viz_widget = Qt3DPlaybackWidget(
             view_model,

--- a/src/caliscope/gui/views/reconstruction_widget.py
+++ b/src/caliscope/gui/views/reconstruction_widget.py
@@ -29,7 +29,7 @@ from caliscope.gui.presenters.reconstruction_presenter import (
     ReconstructionState,
 )
 from caliscope.gui.view_models.playback_view_model import PlaybackViewModel
-from caliscope.gui.widgets.qt3d_playback_widget import Qt3DPlaybackWidget
+from caliscope.gui.widgets.qt3d_playback_widget import Qt3DPlaybackWidget, opengl_available
 from caliscope import MODELS_DIR
 from caliscope.gui.theme import Colors
 from caliscope.trackers import tracker_registry
@@ -401,6 +401,23 @@ class ReconstructionWidget(QWidget):
         camera_array = self._presenter.camera_array
         output_path = self._presenter.xyz_output_path
 
+        if not opengl_available():
+            if self._viz_container.count() == 0:
+                fallback = QLabel(
+                    "3D preview requires a graphics driver that is not available.\n"
+                    "Calibration and reconstruction results are unaffected.\n\n"
+                    "To enable the preview, relaunch with:\n"
+                    "LIBGL_ALWAYS_SOFTWARE=1 caliscope"
+                )
+                fallback.setAlignment(Qt.AlignmentFlag.AlignCenter)
+                fallback.setStyleSheet(
+                    f"QLabel {{ color: {Colors.TEXT_MUTED}; font-size: 14px; "
+                    f"background-color: {Colors.SURFACE}; border: 1px dashed {Colors.BORDER}; border-radius: 4px; }}"
+                )
+                fallback.setFixedHeight(150)
+                self._viz_container.addWidget(fallback)
+            return
+
         # Determine what data we have
         try:
             if output_path and output_path.exists():
@@ -414,8 +431,6 @@ class ReconstructionWidget(QWidget):
             else:
                 # Camera-only mode - show frustums without points
                 view_model = PlaybackViewModel.from_camera_array_only(camera_array)
-
-            # Create or update widget
             if self._viz_widget is None:
                 self._viz_widget = Qt3DPlaybackWidget(
                     view_model,

--- a/src/caliscope/gui/widgets/qt3d_playback_widget.py
+++ b/src/caliscope/gui/widgets/qt3d_playback_widget.py
@@ -43,6 +43,33 @@ from caliscope.gui.view_models.playback_view_model import PlaybackViewModel
 
 logger = logging.getLogger(__name__)
 
+_opengl_ok: bool | None = None
+
+
+def opengl_available() -> bool:
+    """Probe whether a usable OpenGL context can be created.
+
+    Cached after first call. Must be called after QApplication exists.
+    """
+    global _opengl_ok
+    if _opengl_ok is not None:
+        return _opengl_ok
+
+    from PySide6.QtGui import QOffscreenSurface, QOpenGLContext
+
+    surface = QOffscreenSurface()
+    surface.create()
+    ctx = QOpenGLContext()
+    if not ctx.create() or not ctx.makeCurrent(surface):
+        logger.warning("OpenGL context creation failed; 3D view will be unavailable")
+        _opengl_ok = False
+    else:
+        ctx.doneCurrent()
+        _opengl_ok = True
+    surface.destroy()
+    return _opengl_ok
+
+
 # Default sphere radius in meters (12mm). Used as the 1.0x baseline
 # for the sphere size slider.
 _DEFAULT_SPHERE_RADIUS = 0.012


### PR DESCRIPTION
## Summary

- Adds `opengl_available()` probe that checks whether a usable OpenGL context can be created. Cached after first call.
- Both Qt3D widget construction sites (extrinsic calibration view, reconstruction widget) check the probe before building the widget.
- On failure, a styled fallback label explains the problem and gives the `LIBGL_ALWAYS_SOFTWARE=1` workaround.

Without this change, Qt3D segfaults in the C++ render thread when no OpenGL context is available. Common on Linux systems accessed via SSH, running in containers, or with missing GPU drivers.

Addresses #1015

## Test plan

- [x] Type check clean (basedpyright, 0 errors)
- [x] Fallback label visually verified via widget preview script
- [x] PySide6 specialist review (probe correctness, lifecycle, cleanup)
- [x] Senior dev review (code quality, consistency, edge cases)