### PR TITLE
fix(core): restore exact grounding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,7 @@ AGENTS.md
 CLAUDE.md
 plan.md
 progress.txt
-tasks.json
+tasks
 tests/tmp
 specs/
 journal

--- a/docs/scripting.md
+++ b/docs/scripting.md
@@ -24,7 +24,7 @@ from pathlib import Path
 from caliscope.api import (
     Charuco, CharucoTracker, CameraArray, CaptureVolume, ConstraintSet,
     extract_image_points, extract_image_points_multicam,
-    calibrate_intrinsics, calibrate_extrinsics,
+    calibrate_intrinsics, calibrate_extrinsics, estimate_vertical,
 )
 from caliscope.reporting import (
     print_intrinsic_report, print_extrinsic_report, print_camera_pair_coverage,
@@ -249,11 +249,13 @@ Shape and scale do not change, only where the rig sits in world coordinates.
 Positive z raises everything.
 This is the primitive `grounded` and `centered` are built on, exposed for the shifts they do not cover.
 
-### Anchoring without a board
+### Orienting to gravity without a board
 
-A markerless calibration has no board to align to, so the frame comes from the scene instead:
+A markerless calibration has no board to align to, so the orientation comes from the scene instead.
+Estimate the vertical direction from the extrinsic calibration videos before you orient the volume:
 
 ```python
+vertical = estimate_vertical(extrinsic_videos, cameras)
 volume = volume.oriented(up=vertical.up_per_cam)   # +Z becomes vertical
 volume = volume.scaled(CameraDistance(cam_a=0, cam_b=3, meters=4.2))
 volume = volume.grounded()                          # floor at Z=0
@@ -264,15 +266,35 @@ Call them in that order.
 `grounded` assumes Z is already vertical, and `centered` assumes the floor is already at zero.
 `oriented` takes a per-camera up vector, which `estimate_vertical` produces from the video.
 
-By default `grounded` rests the lowest triangulated point on Z=0, and that point is a marker, not the floor.
-A toe marker rides above the ground on the shoe and its own thickness, so the floor ends up buried.
-Measure that height and hand it over:
+### Aligning to the floor without a board
+
+You may have one point that should align with the ground plane, such as a marker on the foot.
+The `grounded` method will shift the cameras and tracked subject such that the lowest point intersects with the ground plane.
+
+```python
+volume = volume.grounded()
+```
+
+It may be the case that the lowest tracked point is not aligned with the floor (tracked foot points may for example float a centimeter or two above the floor).
+In this case, you can add an additional vertical shift to pad out the lowest point:
+
+For example, a pose tracker might place its lowest point 2 cm above the bottom of a shoe:
 
 ```python
 volume = volume.grounded(lowest_point_height_m=0.02)
 ```
 
-The marker then sits at 0.02 and the floor it stands on is zero.
+The above will place the lowest point 2cm above the ground plane.
+
+Sometimes one bad 3D point appears far below the person.
+The default setting would use that point and place the rest of the reconstruction too high.
+Use this mode to ignore the extreme points.
+
+```python
+volume = volume.grounded(mode="pooled_1st_percentile")
+```
+
+Use this option only when you can see bad points below the real floor.
 
 ## Step 7: Inspect results
 

--- a/src/caliscope/core/capture_volume.py
+++ b/src/caliscope/core/capture_volume.py
@@ -1283,38 +1283,56 @@ class CaptureVolume:
 
     def grounded(
         self,
-        mode: Literal["lowest_point"] = "lowest_point",
+        mode: Literal["lowest_point", "pooled_1st_percentile"] = "lowest_point",
         *,
         lowest_point_height_m: float = 0.0,
     ) -> "CaptureVolume":
-        """Translate so the ground sits at Z=0 and the XY origin lies under the anchor camera.
+        """Move the reconstruction so a selected low point has the requested height.
 
-        ``mode="lowest_point"`` places the floor at Z=0, taken as a robust low
-        percentile (1st, as an order statistic) of world Z so a single spurious
-        low triangulation cannot bury the floor. On small point sets the order
-        statistic degrades to the exact minimum. Call after ``oriented()`` so Z
-        is vertical. XY origin is set under the anchor camera (lowest posed
-        cam_id). No rotation or scale change.
+        Use ``mode="lowest_point"`` when the lowest 3D point is reliable. This
+        is the default. Use ``mode="pooled_1st_percentile"`` when one or more
+        bad points appear below the real floor. This mode sorts all WorldPoints
+        rows by Z and selects the lower 1st-percentile point. It can ignore a
+        real floor contact when only a few rows contain it.
+
+        Both modes place the selected point at ``lowest_point_height_m``. They
+        also place the XY origin below the lowest posed camera ID. Call this
+        method after ``oriented()`` so Z is vertical. Rotation and scale do not
+        change.
 
         Args:
-            mode: How the floor is located. Only ``"lowest_point"`` is supported.
-            lowest_point_height_m: How far the lowest point actually sits above
-                the ground, in meters. The lowest point is a marker or keypoint,
-                not the floor: a toe marker rides above it on the shoe and its
-                own thickness. Give that measured height and the floor lands at
-                Z=0 with the point resting above it, instead of the point being
-                buried at zero. Defaults to 0.0, the historical behavior.
-        """
-        if mode != "lowest_point":
-            raise ValueError(f"grounded() only supports mode='lowest_point', got {mode!r}.")
+            mode: How to select the vertical anchor.
+            lowest_point_height_m: Height of the selected point above Z=0, in
+                meters. For example, use 0.02 when you know that the selected
+                point is 2 cm above the desired floor. Defaults to 0.0.
 
-        min_z = float(np.percentile(self.world_points.df["z_coord"].to_numpy(), 1.0, method="lower"))
+        Returns:
+            A new CaptureVolume with the translated coordinate system.
+
+        Raises:
+            ValueError: If ``mode`` is not one of the two supported values.
+        """
+        if mode == "lowest_point":
+            selected_z = float(self.world_points.df["z_coord"].min())
+        elif mode == "pooled_1st_percentile":
+            selected_z = float(
+                np.percentile(
+                    self.world_points.df["z_coord"].to_numpy(),
+                    1.0,
+                    method="lower",
+                )
+            )
+        else:
+            raise ValueError(
+                f"Unsupported grounding mode {mode!r}; expected 'lowest_point' or 'pooled_1st_percentile'."
+            )
+
         anchor_center = self._camera_center(self._anchor_cam_id())
 
         return self.translate(
             x=-anchor_center[0],
             y=-anchor_center[1],
-            z=-min_z + lowest_point_height_m,
+            z=-selected_z + lowest_point_height_m,
         )
 
     def centered(self) -> "CaptureVolume":

--- a/tests/test_capture_volume_anchoring.py
+++ b/tests/test_capture_volume_anchoring.py
@@ -362,26 +362,43 @@ def test_oriented_logs_cross_camera_disagreement(caplog: pytest.LogCaptureFixtur
 # ---------------------------------------------------------------------------
 
 
-def test_grounded_puts_floor_at_zero_and_cam0_over_origin():
+def _grounding_regression_rows() -> list[dict]:
+    z_values = [-3.0, 1.0, *([2.0] * 198)]
+    return [world_row(i, 10, (0.01 * i, -0.02 * i, z)) for i, z in enumerate(z_values)]
+
+
+@pytest.mark.parametrize("explicit_mode", [False, True])
+def test_grounded_lowest_point_uses_exact_minimum(explicit_mode: bool):
     cameras = {
         0: make_camera(0, np.eye(3), np.array([5.0, 7.0, 3.0])),
         1: make_camera(1, np.eye(3), np.array([8.0, 7.0, 3.0])),
     }
-    rows = [
-        world_row(0, 10, (1.0, 1.0, 2.0)),  # lowest z = 2.0
-        world_row(0, 11, (1.0, 1.0, 4.0)),
-    ]
-    volume = make_volume(cameras, rows)
+    volume = make_volume(cameras, _grounding_regression_rows())
 
-    grounded = volume.grounded("lowest_point")
+    grounded = volume.grounded("lowest_point") if explicit_mode else volume.grounded()
 
-    assert abs(float(grounded.world_points.df["z_coord"].min())) < 1e-10
+    assert float(grounded.world_points.df["z_coord"].min()) == pytest.approx(0.0)
     c0 = camera_center(grounded, 0)
-    assert abs(c0[0]) < 1e-10
-    assert abs(c0[1]) < 1e-10
+    assert c0[:2] == pytest.approx([0.0, 0.0], abs=1e-10)
 
 
-def test_grounded_floor_robust_to_low_outlier():
+def test_grounded_pooled_percentile_uses_fixed_lower_order_statistic():
+    cameras = {
+        0: make_camera(0, np.eye(3), np.array([5.0, 7.0, 3.0])),
+        1: make_camera(1, np.eye(3), np.array([8.0, 7.0, 3.0])),
+    }
+    volume = make_volume(cameras, _grounding_regression_rows())
+
+    grounded = volume.grounded("pooled_1st_percentile")
+
+    df = grounded.world_points.df
+    selected_z = float(df.loc[df["sync_index"] == 1, "z_coord"].iloc[0])
+    isolated_min = float(df.loc[df["sync_index"] == 0, "z_coord"].iloc[0])
+    assert selected_z == pytest.approx(0.0)
+    assert isolated_min == pytest.approx(-4.0)
+
+
+def test_grounded_pooled_percentile_does_not_anchor_to_isolated_low_outlier():
     cameras = {
         0: make_camera(0, np.eye(3), np.array([5.0, 7.0, 3.0])),
         1: make_camera(1, np.eye(3), np.array([8.0, 7.0, 3.0])),
@@ -393,7 +410,7 @@ def test_grounded_floor_robust_to_low_outlier():
     rows.append(world_row(999, 10, (1.0, 1.0, -3.0)))
     volume = make_volume(cameras, rows)
 
-    grounded = volume.grounded("lowest_point")
+    grounded = volume.grounded("pooled_1st_percentile")
 
     df = grounded.world_points.df
     band_min = float(df[df["sync_index"] != 999]["z_coord"].min())
@@ -403,20 +420,18 @@ def test_grounded_floor_robust_to_low_outlier():
     assert outlier_z < 0.0
 
 
-def test_grounded_floor_matches_min_on_clean_dense_volume():
+def test_grounded_pooled_percentile_height_places_selected_anchor():
     cameras = {
         0: make_camera(0, np.eye(3), np.array([5.0, 7.0, 3.0])),
         1: make_camera(1, np.eye(3), np.array([8.0, 7.0, 3.0])),
     }
-    band_z = np.linspace(1.0, 2.0, 200)
-    rows = [world_row(i, 10, (1.0, 1.0, float(z))) for i, z in enumerate(band_z)]
-    volume = make_volume(cameras, rows)
+    volume = make_volume(cameras, _grounding_regression_rows())
 
-    grounded = volume.grounded("lowest_point")
+    grounded = volume.grounded("pooled_1st_percentile", lowest_point_height_m=0.02)
 
-    # With no outlier the percentile floor sits within a point-spacing of the
-    # true minimum (~0.005 here).
-    assert abs(float(grounded.world_points.df["z_coord"].min())) < 0.02
+    df = grounded.world_points.df
+    selected_z = float(df.loc[df["sync_index"] == 1, "z_coord"].iloc[0])
+    assert selected_z == pytest.approx(0.02)
 
 
 def test_grounded_lowest_point_height_lifts_the_floor():
@@ -451,8 +466,49 @@ def test_grounded_rejects_unknown_mode():
     rows = [world_row(0, 10, (1.0, 1.0, 1.0)), world_row(0, 11, (2.0, 0.0, 1.0))]
     volume = make_volume(cameras, rows)
 
-    with pytest.raises(ValueError):
+    message = "Unsupported grounding mode 'centroid'; expected 'lowest_point' or 'pooled_1st_percentile'."
+    with pytest.raises(ValueError, match=re.escape(message)):
         volume.grounded("centroid")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("mode", "selected_z"),
+    [("lowest_point", -3.0), ("pooled_1st_percentile", 1.0)],
+)
+@pytest.mark.parametrize("height", [0.0, 0.02])
+def test_grounded_translates_points_and_cameras_without_mutating_source(mode, selected_z: float, height: float):
+    rotations = {
+        2: Rotation.from_euler("xyz", [10.0, -20.0, 5.0], degrees=True).as_matrix(),
+        7: Rotation.from_euler("xyz", [-15.0, 30.0, 12.0], degrees=True).as_matrix(),
+    }
+    centers = {
+        2: np.array([5.0, 7.0, 3.0]),
+        7: np.array([8.0, -2.0, 4.0]),
+    }
+    cameras = {cam_id: make_camera(cam_id, rotations[cam_id], centers[cam_id]) for cam_id in rotations}
+    volume = make_volume(cameras, _grounding_regression_rows())
+    source_points = volume.world_points.points.copy()
+    source_centers = {cam_id: camera_center(volume, cam_id).copy() for cam_id in cameras}
+    source_rotations = {}
+    for cam_id in cameras:
+        rotation = volume.camera_array.cameras[cam_id].rotation
+        assert rotation is not None
+        source_rotations[cam_id] = rotation.copy()
+    expected_translation = np.array([-source_centers[2][0], -source_centers[2][1], -selected_z + height])
+
+    grounded = volume.grounded(mode, lowest_point_height_m=height)
+
+    point_deltas = grounded.world_points.points - source_points
+    assert point_deltas == pytest.approx(np.tile(expected_translation, (len(source_points), 1)))
+    for cam_id in cameras:
+        assert camera_center(grounded, cam_id) - source_centers[cam_id] == pytest.approx(expected_translation)
+        assert grounded.camera_array.cameras[cam_id].rotation == pytest.approx(source_rotations[cam_id])
+
+    assert grounded is not volume
+    assert volume.world_points.points == pytest.approx(source_points)
+    for cam_id in cameras:
+        assert camera_center(volume, cam_id) == pytest.approx(source_centers[cam_id])
+        assert volume.camera_array.cameras[cam_id].rotation == pytest.approx(source_rotations[cam_id])
 
 
 # ---------------------------------------------------------------------------
@@ -528,6 +584,6 @@ if __name__ == "__main__":
     test_multiple_cues_weighted_between_estimates()
     test_two_camera_volume_scales()
     test_oriented_levels_known_tilt()
-    test_grounded_puts_floor_at_zero_and_cam0_over_origin()
+    test_grounded_lowest_point_uses_exact_minimum(explicit_mode=False)
     test_chain_order_invariance_scale_and_orient()
     print("anchoring debug run complete")


### PR DESCRIPTION
## Summary

- Restore exact lowest-point grounding as the default and keep the pooled lower 1st percentile behind an explicit mode.
- Preserve the optional point-height offset and add numeric regression, transform, and source-nonmutation coverage.
- Document vertical estimation and floor alignment in the scripting guide.
- Update the ignored workflow path from `tasks.json` to the `tasks/` directory.

Closes #1023

## Test plan

- [x] Full suite under Xvfb: 780 passed
- [x] BasedPyright: 0 errors, warnings, or notes
- [x] Ruff check and format check
- [x] MkDocs strict build
