### PR TITLE
feat(gui): report workspace video file problems

### DIFF
--- a/src/caliscope/core/coverage_analysis.py
+++ b/src/caliscope/core/coverage_analysis.py
@@ -11,6 +11,7 @@ Design Philosophy:
 
 from __future__ import annotations
 
+from collections.abc import Collection
 from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING
@@ -194,22 +195,21 @@ def _find_leaf_cameras(
 
 def analyze_multi_camera_coverage(
     image_points: ImagePoints,
+    cam_ids: Collection[int] | None = None,
 ) -> ExtrinsicCoverageReport:
     """Analyze pairwise coverage for extrinsic calibration.
 
-    Discovers actual camera cam_ids from the data and builds cam_id-to-index mapping
-    internally. Reports use actual cam_id numbers, not matrix indices.
-
-    Args:
-        image_points: ImagePoints containing all camera observations
-
-    Returns:
-        ExtrinsicCoverageReport with coverage analysis
+    Reports use actual cam_id numbers, not matrix indices. Pass the configured
+    camera set as cam_ids so a camera with no detections at all is reported as
+    isolated. Without it, cameras are discovered from the data and a camera
+    that never saw the target is silently absent from the report.
     """
     df = image_points.df
 
-    # Build cam_id-to-index mapping from actual data
-    actual_cam_ids = sorted(df["cam_id"].unique()) if len(df) > 0 else []
+    if cam_ids is not None:
+        actual_cam_ids = sorted(cam_ids)
+    else:
+        actual_cam_ids = sorted(df["cam_id"].unique()) if len(df) > 0 else []
     cam_id_to_index = {cam_id: idx for idx, cam_id in enumerate(actual_cam_ids)}
     index_to_cam_id = {idx: cam_id for cam_id, idx in cam_id_to_index.items()}
 
@@ -263,6 +263,16 @@ def detect_structural_warnings(
         List of warnings sorted by severity (critical first)
     """
     warnings: list[StructuralWarning] = []
+
+    # Critical: nothing detected anywhere. One message, since every camera
+    # would otherwise be reported isolated for the same underlying reason.
+    if report.n_cameras > 0 and not report.pairwise_observations.any():
+        return [
+            StructuralWarning(
+                WarningSeverity.CRITICAL,
+                "No calibration target detected in any camera. Check the extrinsic target settings and the videos.",
+            )
+        ]
 
     # Critical: Disconnected cameras
     for cam_id in report.isolated_cameras:

--- a/src/caliscope/core/workflow_status.py
+++ b/src/caliscope/core/workflow_status.py
@@ -19,6 +19,15 @@ class StepStatus(Enum):
 
 
 @dataclass(frozen=True)
+class WorkspaceIssue:
+    """Actionable feedback about a workspace file."""
+
+    code: str
+    message: str
+    relative_path: str | None = None
+
+
+@dataclass(frozen=True)
 class WorkflowStatus:
     """Snapshot of calibration workflow progress.
 
@@ -35,11 +44,13 @@ class WorkflowStatus:
 
     # Step 1: Project Setup
     camera_count: int
+    cam_ids: list[int]  # Cameras the workspace expects videos for
     charuco_configured: bool  # Always True after init
 
     # Step 2: Intrinsic Calibration
     intrinsic_videos_available: bool
     intrinsic_videos_missing: list[int]  # Ports with missing videos
+    intrinsic_video_issues: tuple[WorkspaceIssue, ...]
     intrinsic_calibration_complete: bool
     cameras_needing_calibration: list[int]  # Ports without intrinsics
     cameras_have_resolution: bool
@@ -47,6 +58,7 @@ class WorkflowStatus:
     # Step 3: Extrinsic 2D Extraction
     extrinsic_videos_available: bool
     extrinsic_videos_missing: list[int]  # Ports with missing videos
+    extrinsic_video_issues: tuple[WorkspaceIssue, ...]
     extrinsic_2d_extraction_complete: bool
 
     # Step 4: Extrinsic Calibration
@@ -55,6 +67,7 @@ class WorkflowStatus:
     # Step 5: Reconstruction (optional)
     recordings_available: bool
     recording_names: list[str]
+    recording_layout_issues: tuple[WorkspaceIssue, ...]
 
     @property
     def intrinsic_step_status(self) -> StepStatus:

--- a/src/caliscope/gui/camera_list_widget.py
+++ b/src/caliscope/gui/camera_list_widget.py
@@ -8,6 +8,7 @@ Uses both icons and color for accessibility (not color-alone).
 """
 
 import logging
+from collections.abc import Collection
 
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QBrush, QColor
@@ -26,9 +27,14 @@ class CameraListWidget(QListWidget):
 
     camera_selected = Signal(int)  # cam_id
 
-    def __init__(self, camera_array: CameraArray):
+    def __init__(
+        self,
+        camera_array: CameraArray,
+        visible_cam_ids: Collection[int] | None = None,
+    ):
         super().__init__()
         self._camera_array = camera_array
+        self._visible_cam_ids = set(visible_cam_ids) if visible_cam_ids is not None else None
         self._cam_id_to_row: dict[int, int] = {}
 
         # Style for comfortable row height and strong selection highlight
@@ -50,7 +56,10 @@ class CameraListWidget(QListWidget):
         self.clear()
         self._cam_id_to_row.clear()
 
-        for row, (cam_id, camera) in enumerate(sorted(self._camera_array.cameras.items())):
+        for cam_id, camera in sorted(self._camera_array.cameras.items()):
+            if self._visible_cam_ids is not None and cam_id not in self._visible_cam_ids:
+                continue
+            row = self.count()
             self._cam_id_to_row[cam_id] = row
             item = QListWidgetItem()
             item.setData(Qt.ItemDataRole.UserRole, cam_id)
@@ -81,7 +90,11 @@ class CameraListWidget(QListWidget):
             logger.info(f"Camera selected: cam_id {cam_id}")
             self.camera_selected.emit(cam_id)
 
-    def refresh(self, camera_array: CameraArray) -> None:
+    def refresh(
+        self,
+        camera_array: CameraArray,
+        visible_cam_ids: Collection[int] | None = None,
+    ) -> None:
         """Refresh the list with updated camera array data.
 
         Preserves current selection if possible. Blocks signals during restore
@@ -92,6 +105,7 @@ class CameraListWidget(QListWidget):
         current_cam_id = current_item.data(Qt.ItemDataRole.UserRole) if current_item else None
 
         self._camera_array = camera_array
+        self._visible_cam_ids = set(visible_cam_ids) if visible_cam_ids is not None else None
         self._populate_list()
 
         # Restore selection with signals blocked - we're just updating the

--- a/src/caliscope/gui/cameras_tab_widget.py
+++ b/src/caliscope/gui/cameras_tab_widget.py
@@ -68,6 +68,7 @@ class CamerasTabWidget(QWidget):
 
         self._setup_ui()
         self._connect_signals()
+        self._refresh_camera_list()
         self._update_pattern_preview()
 
         # Auto-select first camera if available
@@ -88,7 +89,14 @@ class CamerasTabWidget(QWidget):
         left_layout.setContentsMargins(0, 0, 0, 0)
         left_layout.setSpacing(8)
 
-        self.camera_list = CameraListWidget(self.coordinator.camera_array)
+        self._file_warning_label = QLabel()
+        self._file_warning_label.setTextFormat(Qt.TextFormat.PlainText)
+        self._file_warning_label.setWordWrap(True)
+        self._file_warning_label.setStyleSheet(f"color: {Colors.WARNING};")
+        self._file_warning_label.hide()
+        left_layout.addWidget(self._file_warning_label)
+
+        self.camera_list = CameraListWidget(self.coordinator.camera_array, self._intrinsic_video_cam_ids())
         self.camera_list.setMinimumWidth(150)
         left_layout.addWidget(self.camera_list, stretch=1)
 
@@ -145,8 +153,33 @@ class CamerasTabWidget(QWidget):
     def _connect_signals(self) -> None:
         """Connect internal signals."""
         self.camera_list.camera_selected.connect(self._on_camera_selected)
+        self.coordinator.status_changed.connect(self._refresh_camera_list)
         self.coordinator.intrinsic_target_changed.connect(self._on_intrinsic_target_changed)
         self._frame_skip_spin.valueChanged.connect(self._on_frame_skip_changed)
+
+    def _refresh_camera_list(self) -> None:
+        """Refresh cameras and feedback from the current intrinsic files."""
+        available_cam_ids = self._intrinsic_video_cam_ids()
+        self.camera_list.refresh(self.coordinator.camera_array, available_cam_ids)
+
+        issues = self.coordinator.get_workflow_status().intrinsic_video_issues
+        if issues:
+            self._file_warning_label.setText(
+                "Intrinsic videos need attention:\n" + "\n".join(i.message for i in issues)
+            )
+            self._file_warning_label.show()
+        else:
+            self._file_warning_label.clear()
+            self._file_warning_label.hide()
+
+        if self._current_cam_id is not None and self._current_cam_id not in available_cam_ids:
+            missing_cam_id = self._current_cam_id
+            self._show_message(f"Intrinsic video for camera {missing_cam_id} is missing. Review the Project tab.")
+            self._current_cam_id = None
+
+    def _intrinsic_video_cam_ids(self) -> set[int]:
+        guide = self.coordinator.workspace_guide
+        return set(guide.get_cam_ids_in_dir(guide.intrinsic_dir))
 
     def _on_intrinsic_target_changed(self) -> None:
         """Update tracker in all pooled presenters and refresh preview."""
@@ -208,7 +241,7 @@ class CamerasTabWidget(QWidget):
         self.coordinator.persist_intrinsic_calibration(output, collected_points)
 
         # Refresh camera list to show updated status
-        self.camera_list.refresh(self.coordinator.camera_array)
+        self._refresh_camera_list()
 
     def _show_message(self, text: str) -> None:
         """Show a message in the content area."""

--- a/src/caliscope/gui/main_widget.py
+++ b/src/caliscope/gui/main_widget.py
@@ -219,7 +219,7 @@ class MainWindow(QMainWindow):
             self.cameras_tab_widget: QWidget = CamerasTabWidget(self.coordinator)
         else:
             logger.info("No intrinsic videos - Intrinsics tab shows skip-intrinsics placeholder")
-            self.cameras_tab_widget = CamerasInfoPlaceholder()
+            self.cameras_tab_widget = CamerasInfoPlaceholder(self.coordinator)
         # Cameras stays interactive even as a placeholder (it explains skip-intrinsics).
         return self.cameras_tab_widget, True
 

--- a/src/caliscope/gui/multi_camera_processing_tab.py
+++ b/src/caliscope/gui/multi_camera_processing_tab.py
@@ -9,11 +9,13 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from PySide6.QtWidgets import QVBoxLayout, QWidget
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
 
 from caliscope.gui.presenters.multi_camera_processing_presenter import (
     MultiCameraProcessingPresenter,
 )
+from caliscope.gui.theme import Colors
 from caliscope.gui.views.multi_camera_processing_widget import MultiCameraProcessingWidget
 
 if TYPE_CHECKING:
@@ -49,6 +51,14 @@ class MultiCameraProcessingTab(QWidget):
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
 
+        self._file_warning_label = QLabel()
+        self._file_warning_label.setTextFormat(Qt.TextFormat.PlainText)
+        self._file_warning_label.setWordWrap(True)
+        self._file_warning_label.setStyleSheet(f"color: {Colors.WARNING};")
+        self._file_warning_label.setContentsMargins(8, 8, 8, 0)
+        self._file_warning_label.hide()
+        layout.addWidget(self._file_warning_label)
+
         # Create presenter via coordinator factory
         self._presenter = self.coordinator.create_multi_camera_presenter()
 
@@ -62,6 +72,7 @@ class MultiCameraProcessingTab(QWidget):
 
         # Wire presenter signals to coordinator
         self._connect_signals()
+        self._refresh_from_workspace()
 
     def _connect_signals(self) -> None:
         """Wire presenter signals to coordinator persistence."""
@@ -73,6 +84,28 @@ class MultiCameraProcessingTab(QWidget):
 
         # Target changes invalidate the tracker - need to hot-swap it
         self.coordinator.extrinsic_target_changed.connect(self._on_extrinsic_target_changed)
+
+        # Cameras and videos can appear or disappear after this tab is built.
+        self.coordinator.status_changed.connect(self._refresh_from_workspace)
+
+    def _refresh_from_workspace(self) -> None:
+        """Follow the workspace: camera set, video files, and file feedback."""
+        if self._presenter is not None:
+            cameras = self.coordinator.camera_array.cameras
+            if set(cameras) != set(self._presenter.cameras):
+                self._presenter.set_cameras(cameras)
+            else:
+                self._presenter.refresh_videos()
+
+        issues = self.coordinator.get_workflow_status().extrinsic_video_issues
+        if issues:
+            self._file_warning_label.setText(
+                "Extrinsic videos need attention:\n" + "\n".join(issue.message for issue in issues)
+            )
+            self._file_warning_label.show()
+        else:
+            self._file_warning_label.clear()
+            self._file_warning_label.hide()
 
     def _on_extrinsic_target_changed(self) -> None:
         """Update tracker when extrinsic target config changes.
@@ -94,6 +127,12 @@ class MultiCameraProcessingTab(QWidget):
         responsible for calling this during reload_workspace or closeEvent.
         """
         if self._presenter is not None:
+            # The coordinator outlives this tab; drop the status_changed
+            # connection so it never fires into a deleted label.
+            try:
+                self.coordinator.status_changed.disconnect(self._refresh_from_workspace)
+            except (RuntimeError, TypeError):
+                pass
             logger.info("Cleaning up multi-camera processing presenter")
             self._presenter.cleanup()
             self._presenter = None

--- a/src/caliscope/gui/presenters/multi_camera_processing_presenter.py
+++ b/src/caliscope/gui/presenters/multi_camera_processing_presenter.py
@@ -88,6 +88,10 @@ class MultiCameraProcessingPresenter(QObject):
     # Rotation signals
     rotation_changed = Signal(int, int)  # (cam_id, rotation_count)
 
+    # Workspace signals
+    cameras_changed = Signal()  # Camera set replaced; view rebuilds its cards
+    video_missing = Signal(int)  # (cam_id) whose cam_N.mp4 is absent
+
     # Thumbnail throttle interval (seconds)
     THUMBNAIL_INTERVAL = 0.1  # ~10 FPS
     COVERAGE_INTERVAL = 0.5  # seconds between coverage heatmap updates
@@ -159,10 +163,18 @@ class MultiCameraProcessingPresenter(QObject):
         if self._is_task_active():
             return MultiCameraProcessingState.PROCESSING
 
-        if self._recording_dir is None or not self._cameras:
+        if self._recording_dir is None or not self._cameras or self.missing_video_cam_ids:
             return MultiCameraProcessingState.UNCONFIGURED
 
         return MultiCameraProcessingState.READY
+
+    @property
+    def missing_video_cam_ids(self) -> list[int]:
+        """Configured cameras whose cam_N.mp4 is absent from the recording directory."""
+        if self._recording_dir is None:
+            return []
+        recording_dir = self._recording_dir
+        return sorted(cam_id for cam_id in self._cameras if not (recording_dir / f"cam_{cam_id}.mp4").exists())
 
     @property
     def recording_dir(self) -> Path | None:
@@ -226,7 +238,36 @@ class MultiCameraProcessingPresenter(QObject):
         # Shallow copy - rotation_count may be modified via set_rotation()
         self._cameras = {cam_id: cam for cam_id, cam in cameras.items()}
         self._reset_results()
+        self._thumbnails = {}
         self._load_initial_thumbnails()
+        self.cameras_changed.emit()
+        self._emit_state_changed()
+
+    def refresh_videos(self) -> None:
+        """Re-read which camera videos exist after the workspace changed.
+
+        Drops thumbnails for videos that disappeared, loads thumbnails for
+        videos that appeared, and re-emits state so the view follows the files.
+        """
+        if self.state == MultiCameraProcessingState.PROCESSING or self._recording_dir is None:
+            return
+
+        missing = set(self.missing_video_cam_ids)
+        for cam_id in missing:
+            self._thumbnails.pop(cam_id, None)
+            self.video_missing.emit(cam_id)
+
+        to_load = {
+            cam_id: cam
+            for cam_id, cam in self._cameras.items()
+            if cam_id not in missing and cam_id not in self._thumbnails
+        }
+        if to_load:
+            thumbnails = get_initial_thumbnails(self._recording_dir, to_load)
+            self._thumbnails.update(thumbnails)
+            for cam_id, frame in thumbnails.items():
+                self.thumbnail_updated.emit(cam_id, frame, None)
+
         self._emit_state_changed()
 
     # -------------------------------------------------------------------------
@@ -482,7 +523,7 @@ class MultiCameraProcessingPresenter(QObject):
         logger.info(f"Multi-camera processing complete: {len(image_points.df)} points")
 
         # Compute coverage analysis
-        coverage_report = analyze_multi_camera_coverage(image_points)
+        coverage_report = analyze_multi_camera_coverage(image_points, cam_ids=sorted(self._cameras))
 
         self._result = image_points
         self._coverage_report = coverage_report

--- a/src/caliscope/gui/views/camera_thumbnail_card.py
+++ b/src/caliscope/gui/views/camera_thumbnail_card.py
@@ -88,7 +88,7 @@ class CameraThumbnailCard(QFrame):
         self._thumbnail_label = QLabel()
         self._thumbnail_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self._thumbnail_label.setMinimumSize(self.THUMBNAIL_SIZE, self.THUMBNAIL_SIZE)
-        self._thumbnail_label.setStyleSheet("background-color: #1a1a1a;")
+        self._thumbnail_label.setStyleSheet("background-color: #1a1a1a; color: #888;")
         layout.addWidget(self._thumbnail_label)
 
         # Compact rotation controls with icons
@@ -163,6 +163,11 @@ class CameraThumbnailCard(QFrame):
             Qt.AspectRatioMode.KeepAspectRatio,
         )
         self._thumbnail_label.setPixmap(pixmap)
+
+    def set_missing_video(self) -> None:
+        """Show that the camera's video file is absent instead of a stale frame."""
+        self._thumbnail_label.clear()
+        self._thumbnail_label.setText(f"No video file for cam_{self._cam_id}")
 
     def _draw_landmarks(self, frame: NDArray, points: "PointPacket") -> NDArray:
         """Draw tracked landmarks as red dots on frame.

--- a/src/caliscope/gui/views/multi_camera_processing_widget.py
+++ b/src/caliscope/gui/views/multi_camera_processing_widget.py
@@ -256,6 +256,14 @@ class MultiCameraProcessingWidget(QWidget):
                 rotation = self._presenter.cameras[cam_id].rotation_count
                 self._camera_cards[cam_id].set_thumbnail(frame, rotation)
 
+        for cam_id in self._presenter.missing_video_cam_ids:
+            self._on_video_missing(cam_id)
+
+    def _on_video_missing(self, cam_id: int) -> None:
+        """Replace a camera's thumbnail with a missing-file notice."""
+        if cam_id in self._camera_cards:
+            self._camera_cards[cam_id].set_missing_video()
+
     def _reflow_grid(self) -> None:
         """Reposition existing camera cards based on current column count.
 
@@ -286,6 +294,8 @@ class MultiCameraProcessingWidget(QWidget):
         self._presenter.state_changed.connect(self._update_ui_for_state)
         self._presenter.progress_updated.connect(self._on_progress_updated)
         self._presenter.thumbnail_updated.connect(self._on_thumbnail_updated)
+        self._presenter.cameras_changed.connect(self._rebuild_camera_grid)
+        self._presenter.video_missing.connect(self._on_video_missing)
         self._presenter.processing_complete.connect(self._on_processing_complete)
         self._presenter.processing_failed.connect(self._on_processing_failed)
         self._presenter.coverage_updated.connect(

--- a/src/caliscope/gui/views/project_setup_view.py
+++ b/src/caliscope/gui/views/project_setup_view.py
@@ -60,6 +60,14 @@ _EXTRINSIC_PAGE_ARUCO = 0
 _EXTRINSIC_PAGE_CHARUCO = 1
 
 
+def _cam_labels(cam_ids: list[int]) -> str:
+    """Comma-separated camera IDs, truncated after eight."""
+    labels = ", ".join(str(cam_id) for cam_id in cam_ids[:8])
+    if len(cam_ids) > 8:
+        labels += "..."
+    return labels
+
+
 class WorkflowStepRow(QWidget):
     """A single row in the workflow status checklist.
 
@@ -405,6 +413,12 @@ class ProjectSetupView(QWidget):
         self._camera_count_label = QLabel()
         self._camera_count_label.setStyleSheet("color: #888; font-style: italic;")
         layout.addWidget(self._camera_count_label)
+
+        self._file_feedback_label = QLabel()
+        self._file_feedback_label.setTextFormat(Qt.TextFormat.PlainText)
+        self._file_feedback_label.setWordWrap(True)
+        self._file_feedback_label.setStyleSheet("color: #888;")
+        layout.addWidget(self._file_feedback_label)
 
         # Create workflow step rows
         self._intrinsic_row = WorkflowStepRow("Intrinsic Calibration", TabName.INTRINSICS)
@@ -781,10 +795,11 @@ class ProjectSetupView(QWidget):
 
         # Update camera count display
         if status.camera_count > 0:
-            self._camera_count_label.setText(f"Detected cameras: {status.camera_count} (from extrinsic videos)")
+            self._camera_count_label.setText(f"Detected cameras: {status.camera_count}")
         else:
             self._camera_count_label.setText("No cameras detected (add cam_N.mp4 files to calibration/extrinsic/)")
 
+        self._update_file_feedback(status)
         self._update_intrinsic_row(status)
         self._update_extraction_row(status)
         self._update_extrinsic_row(status)
@@ -792,42 +807,74 @@ class ProjectSetupView(QWidget):
 
         logger.debug("ProjectSetupView status refreshed")
 
+    def _update_file_feedback(self, status: WorkflowStatus) -> None:
+        intrinsic_is_optional_absence = (
+            status.camera_count > 0
+            and len(status.intrinsic_videos_missing) == status.camera_count
+            and all(issue.code == "missing_camera_video" for issue in status.intrinsic_video_issues)
+        )
+        issue_groups = (
+            (
+                "Intrinsic videos",
+                () if intrinsic_is_optional_absence else status.intrinsic_video_issues,
+            ),
+            ("Extrinsic videos", status.extrinsic_video_issues),
+            ("Recordings", status.recording_layout_issues),
+        )
+        if not any(issues for _, issues in issue_groups):
+            detail = "Calibration video file names and locations look correct."
+            if intrinsic_is_optional_absence:
+                detail += "\nIntrinsic videos: none found."
+            self._file_feedback_label.setText(detail)
+            return
+
+        lines = ["Review video file setup:"]
+        for heading, issues in issue_groups:
+            if issues:
+                lines.append(f"{heading}:")
+                lines.extend(f"• {issue.message}" for issue in issues)
+        if intrinsic_is_optional_absence:
+            lines.append("Intrinsic videos: none found.")
+        self._file_feedback_label.setText("\n".join(lines))
+
     def _update_intrinsic_row(self, status: WorkflowStatus) -> None:
         """Update the intrinsic calibration status row."""
         step_status = status.intrinsic_step_status
 
-        if step_status == StepStatus.COMPLETE:
+        present = [cam_id for cam_id in status.cam_ids if cam_id not in status.intrinsic_videos_missing]
+        calibrated = [cam_id for cam_id in status.cam_ids if cam_id not in status.cameras_needing_calibration]
+
+        if step_status == StepStatus.COMPLETE and not present:
+            # Pre-calibrated intrinsics (imported or from an earlier session) with no videos to redo them.
+            detail = (
+                f"Intrinsics loaded from camera_array.toml for cameras {_cam_labels(calibrated)}; "
+                "no intrinsic video files in workspace"
+            )
+        elif step_status == StepStatus.COMPLETE:
             detail = f"{status.camera_count}/{status.camera_count} cameras calibrated"
         elif step_status == StepStatus.AVAILABLE:
             detail = (
-                "Optional — the joint calibration recovers focal length and "
-                "distortion on its own. Run this for fisheye cameras or a dense lens model."
+                f"Video files in workspace for cameras {_cam_labels(present)}; "
+                f"{len(calibrated)}/{status.camera_count} calibrated"
             )
-        elif step_status == StepStatus.INCOMPLETE:
-            calibrated_count = status.camera_count - len(status.cameras_needing_calibration)
-            detail = f"{calibrated_count}/{status.camera_count} cameras calibrated"
-            if status.cameras_needing_calibration:
-                cam_labels = ", ".join(str(p) for p in status.cameras_needing_calibration[:3])
-                if len(status.cameras_needing_calibration) > 3:
-                    cam_labels += "..."
-                detail += f" (need: {cam_labels})"
+        elif status.camera_count > 0 and not present and calibrated:
+            detail = (
+                f"No intrinsic video files in workspace. Intrinsics loaded from camera_array.toml for cameras "
+                f"{_cam_labels(calibrated)}; extrinsic calibration must estimate the rest, "
+                "which is experimental and may give poor results."
+            )
+        elif status.camera_count > 0 and not present:
+            detail = (
+                "No intrinsic video files in workspace. Extrinsic calibration must estimate intrinsics, "
+                "which is experimental and may give poor results."
+            )
+        elif status.intrinsic_videos_missing:
+            detail = (
+                f"Video files in workspace for cameras {_cam_labels(present)}; "
+                f"missing cam {_cam_labels(status.intrinsic_videos_missing)}"
+            )
         else:
-            if status.camera_count > 0 and len(status.intrinsic_videos_missing) == status.camera_count:
-                # Extrinsic videos define the camera set but no intrinsic videos
-                # exist: the deliberate skip-intrinsics path, not a stalled step.
-                detail = (
-                    "No intrinsic videos — optional if you capture for it. "
-                    "Extrinsic calibration can recover intrinsics (fisheye cameras excepted); "
-                    f"see the {TabName.INTRINSICS} tab for prerequisites, "
-                    f"then continue on the {TabName.EXTRINSICS} tab."
-                )
-            elif status.intrinsic_videos_missing:
-                cam_labels = ", ".join(str(p) for p in status.intrinsic_videos_missing[:3])
-                if len(status.intrinsic_videos_missing) > 3:
-                    cam_labels += "..."
-                detail = f"Missing videos: cam {cam_labels}"
-            else:
-                detail = "Not started"
+            detail = "Not started"
 
         self._intrinsic_row.set_status(step_status, detail)
 

--- a/src/caliscope/gui/widgets/cameras_info_placeholder.py
+++ b/src/caliscope/gui/widgets/cameras_info_placeholder.py
@@ -1,53 +1,122 @@
 """Informational placeholder for the Cameras tab when intrinsic videos are absent.
 
-Shown in place of CamerasTabWidget so the tab stays clickable and can explain
-that skipping intrinsic calibration is a supported path with prerequisites,
-rather than presenting a greyed-out tab that reads as "stuck".
+Shown in place of CamerasTabWidget so the tab stays clickable and explains what
+the workspace holds: intrinsics already loaded from camera_array.toml, or none
+at all with the risks of estimating them during extrinsic calibration.
 """
 
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING
 
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QHBoxLayout, QLabel, QScrollArea, QVBoxLayout, QWidget
 
+from caliscope.gui.tab_names import TabName
+
+if TYPE_CHECKING:
+    from caliscope.cameras.camera_array import CameraArray, CameraData
+    from caliscope.workspace_coordinator import WorkspaceCoordinator
+
 logger = logging.getLogger(__name__)
 
-DOCS_URL = "https://mprib.github.io/caliscope/extrinsic_calibration/#skipping-intrinsic-calibration"
+DOCS_URL = "https://mprib.github.io/caliscope/extrinsic_calibration_reference/#skipping-intrinsic-calibration"
 
-_PLACEHOLDER_HTML = f"""
+_NO_INTRINSICS_HTML = f"""
 <h3>No intrinsic calibration videos</h3>
 
 <p>This tab calibrates each camera's lens (focal length, distortion) from videos in
-<code>calibration/intrinsic/</code>. This project has none — and that can be fine.
-Extrinsic calibration can recover lens parameters on its own if the capture supports it:</p>
+<code>calibration/intrinsic/</code>. This project has none.</p>
+
+<p>Without them, extrinsic calibration starts each camera from a rough guess (focal
+length from resolution, zero distortion) and refines focal length and the first two
+distortion terms during bundle adjustment. The principal point and remaining distortion
+terms stay at their assumed values. This path is experimental: it has not been validated
+on real-world data to the same degree as calibrating intrinsics first, and results may
+be poor even when the solver reports success.</p>
 
 <ul>
-<li>Move the target toward and away from the cameras, not just across the view.</li>
-<li>Measure marker sizes accurately — they set the world scale.</li>
-<li>No fisheye lenses. Those need intrinsic calibration first.</li>
+<li>Move the target toward and away from the cameras and out to the edges of each view,
+not just across the middle.</li>
+<li>Measure marker sizes accurately. They set the world scale.</li>
+<li>Fisheye lenses need intrinsic calibration first; this path cannot recover them.</li>
 </ul>
 
-<p>If that matches your capture, continue on the <b>Calibrate</b> tab. To calibrate
-intrinsics here instead, add <code>calibration/intrinsic/cam_N.mp4</code> videos and
-this tab will activate.</p>
+<p>Recording intrinsic videos is the reliable path. If you continue without them, judge
+the result by the quality report on the <b>{TabName.EXTRINSICS}</b> tab rather than
+assuming it worked.</p>
 
-<p><a href="{DOCS_URL}">Skipping intrinsic calibration — documentation</a></p>
+<p>To calibrate intrinsics here, add <code>calibration/intrinsic/cam_N.mp4</code> videos
+and this tab will activate.</p>
+
+<p><a href="{DOCS_URL}">Skipping intrinsic calibration: documentation</a></p>
 """
 
 
+def _camera_row(camera: CameraData) -> str:
+    assert camera.matrix is not None
+    fx, fy = camera.matrix[0, 0], camera.matrix[1, 1]
+    cx, cy = camera.matrix[0, 2], camera.matrix[1, 2]
+    error = f"{camera.error:.3f}" if camera.error is not None else "n/a"
+    model = "fisheye" if camera.fisheye else "standard"
+    return (
+        f"<tr><td>Cam {camera.cam_id}</td><td>{camera.size[0]}x{camera.size[1]}</td>"
+        f"<td>{fx:.1f}, {fy:.1f}</td><td>{cx:.1f}, {cy:.1f}</td><td>{error}</td><td>{model}</td></tr>"
+    )
+
+
+def _loaded_intrinsics_html(calibrated: list[CameraData], uncalibrated: list[CameraData]) -> str:
+    rows = "".join(_camera_row(camera) for camera in calibrated)
+    html = f"""
+<h3>Intrinsics loaded from camera_array.toml</h3>
+
+<p>There are no videos in <code>calibration/intrinsic/</code>, so these values cannot be
+reviewed or redone here. They came from an earlier calibration or an import.</p>
+
+<table cellpadding="4">
+<tr><th align="left">Camera</th><th align="left">Resolution</th><th align="left">Focal (px)</th>
+<th align="left">Principal point</th><th align="left">RMSE</th><th align="left">Model</th></tr>
+{rows}
+</table>
+
+<p>To recalibrate a camera, add <code>calibration/intrinsic/cam_N.mp4</code> for it and
+this tab will activate. The new result replaces the stored values for that camera.</p>
+"""
+    if uncalibrated:
+        ids = ", ".join(str(camera.cam_id) for camera in uncalibrated)
+        html += f"""
+<p><b>Cameras {ids} have no intrinsics.</b> Extrinsic calibration will have to estimate
+them. This path is experimental and can give poor results; see the
+<a href="{DOCS_URL}">documentation on skipping intrinsic calibration</a>.</p>
+"""
+    return html
+
+
+def placeholder_html(camera_array: CameraArray) -> str:
+    """Explain the intrinsic situation for the cameras in the workspace."""
+    cameras = [camera_array.cameras[cam_id] for cam_id in sorted(camera_array.cameras)]
+    calibrated = [camera for camera in cameras if camera.matrix is not None]
+    uncalibrated = [camera for camera in cameras if camera.matrix is None]
+    if calibrated:
+        return _loaded_intrinsics_html(calibrated, uncalibrated)
+    return _NO_INTRINSICS_HTML
+
+
 class CamerasInfoPlaceholder(QWidget):
-    """Static explanatory widget shown when the Cameras tab has no videos to work with."""
+    """Explanatory widget shown when the Cameras tab has no videos to work with."""
 
-    def __init__(self, parent: QWidget | None = None) -> None:
+    def __init__(self, coordinator: WorkspaceCoordinator, parent: QWidget | None = None) -> None:
         super().__init__(parent)
+        self._coordinator = coordinator
 
-        label = QLabel(_PLACEHOLDER_HTML)
-        label.setWordWrap(True)
-        label.setOpenExternalLinks(True)
-        label.setTextInteractionFlags(
+        self._label = QLabel()
+        self._label.setWordWrap(True)
+        self._label.setOpenExternalLinks(True)
+        self._label.setTextInteractionFlags(
             Qt.TextInteractionFlag.TextSelectableByMouse | Qt.TextInteractionFlag.LinksAccessibleByMouse
         )
-        label.setMaximumWidth(640)
+        self._label.setMaximumWidth(720)
 
         # Center the fixed-width column; row layout keeps heightForWidth intact
         # so the wrapped label gets its full height (alignment flags do not).
@@ -55,7 +124,7 @@ class CamerasInfoPlaceholder(QWidget):
         row = QHBoxLayout(content)
         row.setContentsMargins(24, 24, 24, 24)
         row.addStretch()
-        row.addWidget(label)
+        row.addWidget(self._label)
         row.addStretch()
 
         scroll = QScrollArea()
@@ -66,3 +135,10 @@ class CamerasInfoPlaceholder(QWidget):
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(scroll)
+
+        coordinator.status_changed.connect(self.refresh)
+        self.refresh()
+
+    def refresh(self) -> None:
+        """Re-read the camera array so the text follows the workspace."""
+        self._label.setText(placeholder_html(self._coordinator.camera_array))

--- a/src/caliscope/workspace_coordinator.py
+++ b/src/caliscope/workspace_coordinator.py
@@ -138,6 +138,11 @@ class WorkspaceCoordinator(QObject):
     def _on_directory_changed(self, path: str) -> None:
         """Handle filesystem change in watched directory."""
         logger.info(f"Directory changed: {path}")
+        if Path(path) in {
+            self.workspace_guide.intrinsic_dir,
+            self.workspace_guide.extrinsic_dir,
+        }:
+            self._discover_new_cameras()
         self.status_changed.emit()
 
     @property
@@ -149,6 +154,15 @@ class WorkspaceCoordinator(QObject):
     def cam_ids(self) -> list[int]:
         """Authoritative list of camera IDs from extrinsic directory."""
         return self.workspace_guide.get_cam_ids()
+
+    def _expected_cam_ids(self) -> set[int]:
+        """Cameras the workspace expects calibration videos for.
+
+        Extrinsic videos define the camera set. Loaded cameras keep that set
+        stable once a video disappears, so a deleted extrinsic file is reported
+        as missing instead of shrinking the set and blaming its intrinsic twin.
+        """
+        return set(self.camera_array.cameras) | set(self.workspace_guide.get_cam_ids())
 
     @property
     def extrinsic_image_points_path(self) -> Path:
@@ -305,16 +319,10 @@ class WorkspaceCoordinator(QObject):
         This method queries the filesystem and domain objects to build
         a status snapshot. Called by the Project tab whenever it refreshes.
         """
-        camera_count = self.camera_count  # Now a property
-        expected_cam_ids = set(self.cam_ids) if self.cam_ids else set()
-
-        # Intrinsic video availability
-        intrinsic_cam_ids = self.workspace_guide.get_cam_ids_in_dir(self.workspace_guide.intrinsic_dir)
-        intrinsic_missing = sorted(expected_cam_ids - set(intrinsic_cam_ids))
-
-        # Extrinsic video availability
-        extrinsic_cam_ids = self.workspace_guide.get_cam_ids_in_dir(self.workspace_guide.extrinsic_dir)
-        extrinsic_missing = sorted(expected_cam_ids - set(extrinsic_cam_ids))
+        expected_cam_ids = self._expected_cam_ids()
+        extrinsic_assessment = self.workspace_guide.assess_extrinsic_videos(expected_cam_ids)
+        intrinsic_assessment = self.workspace_guide.assess_intrinsic_videos(expected_cam_ids)
+        camera_count = len(expected_cam_ids)
 
         # Cameras needing intrinsic calibration
         cameras_needing = [cam_id for cam_id, cam in self.camera_array.cameras.items() if cam.matrix is None]
@@ -324,19 +332,40 @@ class WorkspaceCoordinator(QObject):
 
         return WorkflowStatus(
             camera_count=camera_count,
+            cam_ids=sorted(expected_cam_ids),
             charuco_configured=True,
-            intrinsic_videos_available=len(intrinsic_missing) == 0,
-            intrinsic_videos_missing=intrinsic_missing,
+            intrinsic_videos_available=(bool(expected_cam_ids) and not intrinsic_assessment.missing_camera_ids),
+            intrinsic_videos_missing=list(intrinsic_assessment.missing_camera_ids),
+            intrinsic_video_issues=intrinsic_assessment.issues,
             intrinsic_calibration_complete=self.camera_array.all_intrinsics_calibrated(),
             cameras_needing_calibration=cameras_needing,
             cameras_have_resolution=self.camera_array.all_cameras_have_resolution(),
-            extrinsic_videos_available=len(extrinsic_missing) == 0,
-            extrinsic_videos_missing=extrinsic_missing,
+            extrinsic_videos_available=(bool(expected_cam_ids) and not extrinsic_assessment.missing_camera_ids),
+            extrinsic_videos_missing=list(extrinsic_assessment.missing_camera_ids),
+            extrinsic_video_issues=extrinsic_assessment.issues,
             extrinsic_2d_extraction_complete=extraction_complete,
             extrinsic_calibration_complete=self.all_extrinsics_estimated(),
             recordings_available=self.recordings_available(),
             recording_names=self.workspace_guide.valid_recording_dirs(),
+            recording_layout_issues=self.workspace_guide.recording_layout_issues(),
         )
+
+    def _discover_new_cameras(self) -> None:
+        """Add canonical camera files that appeared after workspace loading."""
+        # An empty in-memory array has nothing unsaved to lose (bundle overlays
+        # only exist once cameras are loaded), so start from the persisted file
+        # rather than overwriting it with a freshly discovered subset.
+        if not self.camera_array.cameras:
+            self.camera_array = self.camera_repository.load()
+        intrinsic_ids = set(self.workspace_guide.get_cam_ids_in_dir(self.workspace_guide.intrinsic_dir))
+        extrinsic_ids = set(self.workspace_guide.get_cam_ids_in_dir(self.workspace_guide.extrinsic_dir))
+        for cam_id in sorted(intrinsic_ids | extrinsic_ids):
+            if cam_id in self.camera_array.cameras:
+                continue
+            try:
+                self._add_camera_from_source(cam_id)
+            except Exception as error:
+                logger.warning("Could not add camera %s from new video files: %s", cam_id, error)
 
     def update_intrinsic_target_type(self, target_type: IntrinsicTargetType) -> None:
         """Update which target type is used for intrinsic calibration."""

--- a/src/caliscope/workspace_guide.py
+++ b/src/caliscope/workspace_guide.py
@@ -1,9 +1,25 @@
 import logging
+import re
+from collections.abc import Collection
+from dataclasses import dataclass
 from pathlib import Path
 
 from caliscope.cameras.camera_array import CameraArray
+from caliscope.core.workflow_status import WorkspaceIssue
 
 logger = logging.getLogger(__name__)
+
+_CAMERA_VIDEO_PATTERN = re.compile(r"^cam_(0|[1-9][0-9]*)\.mp4$")
+_CAMERA_DIRECTORY_PATTERN = re.compile(r"^cam_(0|[1-9][0-9]*)$")
+
+
+@dataclass(frozen=True)
+class CameraVideoAssessment:
+    """Snapshot of direct-child camera videos in one directory."""
+
+    camera_ids: tuple[int, ...]
+    missing_camera_ids: tuple[int, ...]
+    issues: tuple[WorkspaceIssue, ...]
 
 
 class WorkspaceGuide:
@@ -34,19 +50,144 @@ class WorkspaceGuide:
         Returns:
             Sorted list of integer camera IDs found
         """
-        if not directory.exists():
-            return []
+        return list(self._assess_camera_videos(directory, ()).camera_ids)
 
-        all_cam_ids = []
-        for file in directory.iterdir():
-            if file.stem.startswith("cam_") and file.suffix == ".mp4":
-                try:
-                    cam_id = int(file.stem.split("_")[1])
-                    all_cam_ids.append(cam_id)
-                except (ValueError, IndexError):
-                    logger.warning(f"Skipping malformed filename: {file.name}")
+    def assess_intrinsic_videos(self, expected_cam_ids: Collection[int]) -> CameraVideoAssessment:
+        """Assess intrinsic videos against the workspace camera set."""
+        return self._assess_camera_videos(self.intrinsic_dir, expected_cam_ids)
 
-        return sorted(all_cam_ids)
+    def assess_extrinsic_videos(self, expected_cam_ids: Collection[int]) -> CameraVideoAssessment:
+        """Assess extrinsic videos against the workspace camera set.
+
+        Per-camera missing issues cover any expected camera. The generic
+        "no videos" issue only applies when there is nothing more specific to say.
+        """
+        assessment = self._assess_camera_videos(self.extrinsic_dir, expected_cam_ids)
+        if assessment.camera_ids or assessment.missing_camera_ids:
+            return assessment
+
+        issue = WorkspaceIssue(
+            code="missing_camera_video",
+            message="No extrinsic camera videos found. Add cam_N.mp4 files directly to calibration/extrinsic/.",
+            relative_path="calibration/extrinsic",
+        )
+        return CameraVideoAssessment(
+            camera_ids=assessment.camera_ids,
+            missing_camera_ids=assessment.missing_camera_ids,
+            issues=(issue, *assessment.issues),
+        )
+
+    def _assess_camera_videos(
+        self,
+        directory: Path,
+        expected_cam_ids: Collection[int],
+    ) -> CameraVideoAssessment:
+        camera_ids: list[int] = []
+        file_issues: list[WorkspaceIssue] = []
+
+        if directory.exists():
+            for path in sorted(directory.iterdir(), key=lambda item: item.name.casefold()):
+                if not path.is_file():
+                    continue
+
+                match = _CAMERA_VIDEO_PATTERN.fullmatch(path.name)
+                if match is not None:
+                    camera_ids.append(int(match.group(1)))
+                    continue
+
+                if path.suffix.casefold() != ".mp4":
+                    continue
+
+                relative_path = self._relative_path(path)
+                if path.name.casefold().startswith("cam"):
+                    file_issues.append(
+                        WorkspaceIssue(
+                            code="malformed_camera_filename",
+                            message=f"{relative_path} looks like a camera video but must be named cam_N.mp4.",
+                            relative_path=relative_path,
+                        )
+                    )
+                else:
+                    file_issues.append(
+                        WorkspaceIssue(
+                            code="unexpected_mp4",
+                            message=f"{relative_path} is an unexpected MP4. Only cam_N.mp4 files belong here.",
+                            relative_path=relative_path,
+                        )
+                    )
+
+        actual_ids = set(camera_ids)
+        expected_ids = set(expected_cam_ids)
+        missing_ids = tuple(sorted(expected_ids - actual_ids))
+        missing_issues = tuple(
+            WorkspaceIssue(
+                code="missing_camera_video",
+                message=f"Missing {self._relative_path(directory / f'cam_{cam_id}.mp4')}.",
+                relative_path=self._relative_path(directory / f"cam_{cam_id}.mp4"),
+            )
+            for cam_id in missing_ids
+        )
+
+        unexpected_issues: list[WorkspaceIssue] = []
+        if expected_ids:
+            for cam_id in sorted(actual_ids - expected_ids):
+                relative_path = self._relative_path(directory / f"cam_{cam_id}.mp4")
+                unexpected_issues.append(
+                    WorkspaceIssue(
+                        code="unexpected_mp4",
+                        message=f"{relative_path} does not match the workspace camera set.",
+                        relative_path=relative_path,
+                    )
+                )
+
+        return CameraVideoAssessment(
+            camera_ids=tuple(sorted(actual_ids)),
+            missing_camera_ids=missing_ids,
+            issues=(*missing_issues, *unexpected_issues, *file_issues),
+        )
+
+    def recording_layout_issues(self) -> tuple[WorkspaceIssue, ...]:
+        """Report recognizable recording layouts that Caliscope cannot use."""
+        if not self.recording_dir.exists():
+            return ()
+
+        children = tuple(self.recording_dir.iterdir())
+        root_mp4s = sorted(path.name for path in children if path.is_file() and path.suffix.casefold() == ".mp4")
+        camera_directories = sorted(
+            path.name
+            for path in children
+            if path.is_dir()
+            and _CAMERA_DIRECTORY_PATTERN.fullmatch(path.name)
+            and any(child.is_file() and child.suffix.casefold() == ".mp4" for child in path.iterdir())
+        )
+
+        issues: list[WorkspaceIssue] = []
+        if root_mp4s:
+            issues.append(
+                WorkspaceIssue(
+                    code="recordings_need_session_folder",
+                    message=(
+                        "Recording videos are directly inside recordings/. "
+                        "Create a named session folder and place its cam_N.mp4 files there."
+                    ),
+                    relative_path="recordings",
+                )
+            )
+        if len(camera_directories) >= 2:
+            issues.append(
+                WorkspaceIssue(
+                    code="recording_split_by_camera",
+                    message=(
+                        "The recordings/cam_N folders split a recording by camera. "
+                        "Create one named session folder containing every cam_N.mp4 file instead."
+                    ),
+                    relative_path="recordings",
+                )
+            )
+        return tuple(issues)
+
+    def _relative_path(self, path: Path) -> str:
+        return path.relative_to(self.workspace_dir).as_posix()
 
     def get_cam_ids(self) -> list[int]:
         """Return the authoritative list of camera IDs from extrinsic directory.

--- a/tests/gui/test_workspace_feedback.py
+++ b/tests/gui/test_workspace_feedback.py
@@ -1,46 +1,28 @@
-"""Focused Project view tests for workspace file feedback."""
+"""Workspace file feedback reaching already-built views."""
 
+from collections.abc import Iterator
 from pathlib import Path
-from types import SimpleNamespace
 
-import numpy as np
-from PySide6.QtCore import QObject, Signal
+import pytest
 
-from caliscope.cameras.camera_array import CameraArray, CameraData
-from caliscope.core.workflow_status import WorkspaceIssue
-from caliscope.gui.cameras_tab_widget import CamerasTabWidget
 from caliscope.gui.multi_camera_processing_tab import MultiCameraProcessingTab
 from caliscope.gui.presenters.multi_camera_processing_presenter import MultiCameraProcessingState
 from caliscope.gui.views.project_setup_view import ProjectSetupView
-from caliscope.gui.widgets.cameras_info_placeholder import CamerasInfoPlaceholder
 from caliscope.workspace_coordinator import WorkspaceCoordinator
 
 
-class _CameraTabCoordinator(QObject):
-    status_changed = Signal()
-    intrinsic_target_changed = Signal()
-
-    def __init__(self, camera_array: CameraArray) -> None:
-        super().__init__()
-        self.camera_array = camera_array
-        self.intrinsic_frame_skip = 5
-        self.intrinsic_cam_ids = set(camera_array.cameras)
-        self.intrinsic_video_issues: tuple[WorkspaceIssue, ...] = ()
-        self.workspace_guide = SimpleNamespace(
-            intrinsic_dir=Path("calibration/intrinsic"),
-            get_cam_ids_in_dir=lambda _directory: sorted(self.intrinsic_cam_ids),
-        )
-
-    def get_workflow_status(self):
-        return SimpleNamespace(intrinsic_video_issues=self.intrinsic_video_issues)
-
-
-def test_project_feedback_follows_directory_change(tmp_path: Path, qapp, monkeypatch) -> None:
+@pytest.fixture
+def coordinator(tmp_path: Path, qapp, monkeypatch: pytest.MonkeyPatch) -> Iterator[WorkspaceCoordinator]:
     monkeypatch.setattr(
         "caliscope.workspace_coordinator.read_video_properties",
         lambda _path: {"size": (640, 480)},
     )
     coordinator = WorkspaceCoordinator(tmp_path)
+    yield coordinator
+    coordinator.cleanup()
+
+
+def test_project_feedback_follows_directory_change(coordinator: WorkspaceCoordinator) -> None:
     extrinsic = coordinator.workspace_guide.extrinsic_dir
     view = ProjectSetupView(coordinator)
 
@@ -49,172 +31,35 @@ def test_project_feedback_follows_directory_change(tmp_path: Path, qapp, monkeyp
     (extrinsic / "cam_0.mp4").touch()
     coordinator._on_directory_changed(str(extrinsic))
 
-    assert view._file_feedback_label.text() == (
-        "Calibration video file names and locations look correct.\nIntrinsic videos: none found."
-    )
+    assert "No extrinsic camera videos found" not in view._file_feedback_label.text()
     assert tuple(coordinator.camera_array.cameras) == (0,)
-    assert view._intrinsic_row._status_label.text().startswith("No intrinsic video files in workspace.")
-
-    (coordinator.workspace_guide.intrinsic_dir / "cam_0.mp4").touch()
-    coordinator._on_directory_changed(str(coordinator.workspace_guide.intrinsic_dir))
-
-    assert view._intrinsic_row._status_label.text() == "Video files in workspace for cameras 0; 0/1 calibrated"
-    coordinator.cleanup()
 
 
-def test_project_names_precalibrated_intrinsics_without_videos(tmp_path: Path, qapp, monkeypatch) -> None:
-    monkeypatch.setattr(
-        "caliscope.workspace_coordinator.read_video_properties",
-        lambda _path: {"size": (640, 480)},
-    )
-    coordinator = WorkspaceCoordinator(tmp_path)
-    extrinsic = coordinator.workspace_guide.extrinsic_dir
-    cameras = {
-        cam_id: CameraData(cam_id=cam_id, size=(640, 480), matrix=np.eye(3), distortions=np.zeros(5))
-        for cam_id in (0, 1)
-    }
-    coordinator.camera_repository.save(CameraArray(cameras))
-    for cam_id in (0, 1):
-        (extrinsic / f"cam_{cam_id}.mp4").touch()
-    coordinator.load_camera_array()
-    view = ProjectSetupView(coordinator)
-
-    assert view._intrinsic_row._status_label.text() == (
-        "Intrinsics loaded from camera_array.toml for cameras 0, 1; no intrinsic video files in workspace"
-    )
-
-    placeholder = CamerasInfoPlaceholder(coordinator)
-    text = placeholder._label.text()
-    assert "Intrinsics loaded from camera_array.toml" in text
-    assert "Cam 0" in text and "Cam 1" in text
-    assert "experimental" not in text
-
-    coordinator.camera_array.cameras[1].matrix = None
-    coordinator.status_changed.emit()
-    text = placeholder._label.text()
-    assert "Cameras 1 have no intrinsics" in text
-    assert "experimental" in text
-    coordinator.cleanup()
-
-
-def test_placeholder_without_intrinsics_states_the_risk(tmp_path: Path, qapp, monkeypatch) -> None:
-    monkeypatch.setattr(
-        "caliscope.workspace_coordinator.read_video_properties",
-        lambda _path: {"size": (640, 480)},
-    )
-    coordinator = WorkspaceCoordinator(tmp_path)
-    (coordinator.workspace_guide.extrinsic_dir / "cam_0.mp4").touch()
-    coordinator.load_camera_array()
-
-    placeholder = CamerasInfoPlaceholder(coordinator)
-    text = placeholder._label.text()
-
-    assert "No intrinsic calibration videos" in text
-    assert "experimental" in text
-    assert "camera_array.toml" not in text
-    coordinator.cleanup()
-
-
-def test_open_extract_tab_warns_when_extrinsic_video_disappears(tmp_path: Path, qapp, monkeypatch) -> None:
-    monkeypatch.setattr(
-        "caliscope.workspace_coordinator.read_video_properties",
-        lambda _path: {"size": (640, 480)},
-    )
-    coordinator = WorkspaceCoordinator(tmp_path)
+def test_open_extract_tab_follows_extrinsic_videos(coordinator: WorkspaceCoordinator) -> None:
     extrinsic = coordinator.workspace_guide.extrinsic_dir
     for cam_id in (0, 1):
         (extrinsic / f"cam_{cam_id}.mp4").touch()
     coordinator.load_camera_array()
     tab = MultiCameraProcessingTab(coordinator)
-
+    assert tab._presenter is not None and tab._widget is not None
     assert tab._file_warning_label.isHidden()
+    assert sorted(tab._widget._camera_cards) == [0, 1]
 
     (extrinsic / "cam_1.mp4").unlink()
-    coordinator._on_directory_changed(str(coordinator.workspace_guide.extrinsic_dir))
+    coordinator._on_directory_changed(str(extrinsic))
 
-    assert not tab._file_warning_label.isHidden()
     assert "Missing calibration/extrinsic/cam_1.mp4" in tab._file_warning_label.text()
     assert tuple(coordinator.camera_array.cameras) == (0, 1)
-    assert tab._presenter is not None and tab._widget is not None
     assert tab._presenter.state == MultiCameraProcessingState.UNCONFIGURED
     assert tab._widget._camera_cards[1]._thumbnail_label.text() == "No video file for cam_1"
     assert not tab._widget._action_btn.isEnabled()
 
     (extrinsic / "cam_1.mp4").touch()
-    coordinator._on_directory_changed(str(coordinator.workspace_guide.extrinsic_dir))
+    (extrinsic / "cam_2.mp4").touch()
+    coordinator._on_directory_changed(str(extrinsic))
 
     assert tab._file_warning_label.isHidden()
     assert tab._presenter.state == MultiCameraProcessingState.READY
     assert tab._widget._action_btn.isEnabled()
+    assert sorted(tab._widget._camera_cards) == [0, 1, 2]
     tab.cleanup()
-    coordinator.cleanup()
-
-
-def test_open_extract_tab_adds_card_when_camera_appears(tmp_path: Path, qapp, monkeypatch) -> None:
-    monkeypatch.setattr(
-        "caliscope.workspace_coordinator.read_video_properties",
-        lambda _path: {"size": (640, 480)},
-    )
-    coordinator = WorkspaceCoordinator(tmp_path)
-    extrinsic = coordinator.workspace_guide.extrinsic_dir
-    (extrinsic / "cam_0.mp4").touch()
-    coordinator.load_camera_array()
-    tab = MultiCameraProcessingTab(coordinator)
-    assert tab._widget is not None
-    assert sorted(tab._widget._camera_cards) == [0]
-
-    (extrinsic / "cam_2.mp4").touch()
-    coordinator._on_directory_changed(str(extrinsic))
-
-    assert sorted(tab._widget._camera_cards) == [0, 2]
-    tab.cleanup()
-    coordinator.cleanup()
-
-
-def test_open_intrinsics_tab_refreshes_when_camera_is_added(qapp, monkeypatch) -> None:
-    coordinator = _CameraTabCoordinator(CameraArray({0: CameraData(cam_id=0, size=(640, 480))}))
-    monkeypatch.setattr(CamerasTabWidget, "_update_pattern_preview", lambda _self: None)
-    monkeypatch.setattr(CamerasTabWidget, "_on_camera_selected", lambda _self, _cam_id: None)
-    tab = CamerasTabWidget(coordinator)  # type: ignore[arg-type]
-
-    assert tab.camera_list.count() == 1
-
-    coordinator.camera_array.cameras[2] = CameraData(cam_id=2, size=(640, 480))
-    coordinator.intrinsic_cam_ids.add(2)
-    coordinator.status_changed.emit()
-
-    assert tab.camera_list.count() == 2
-    assert tab.camera_list.item(1).text() == "○ Cam 2"
-    tab.close()
-
-
-def test_open_intrinsics_tab_removes_camera_when_video_disappears(qapp, monkeypatch) -> None:
-    coordinator = _CameraTabCoordinator(
-        CameraArray(
-            {
-                0: CameraData(cam_id=0, size=(640, 480)),
-                2: CameraData(cam_id=2, size=(640, 480)),
-            }
-        )
-    )
-    monkeypatch.setattr(CamerasTabWidget, "_update_pattern_preview", lambda _self: None)
-    monkeypatch.setattr(CamerasTabWidget, "_on_camera_selected", lambda _self, _cam_id: None)
-    tab = CamerasTabWidget(coordinator)  # type: ignore[arg-type]
-
-    assert tab.camera_list.count() == 2
-
-    coordinator.intrinsic_cam_ids.remove(2)
-    coordinator.intrinsic_video_issues = (
-        WorkspaceIssue(
-            code="missing_camera_video",
-            message="Missing calibration/intrinsic/cam_2.mp4.",
-            relative_path="calibration/intrinsic/cam_2.mp4",
-        ),
-    )
-    coordinator.status_changed.emit()
-
-    assert tab.camera_list.count() == 1
-    assert tab.camera_list.item(0).text() == "○ Cam 0"
-    assert "Missing calibration/intrinsic/cam_2.mp4" in tab._file_warning_label.text()
-    assert not tab._file_warning_label.isHidden()
-    tab.close()

--- a/tests/gui/test_workspace_feedback.py
+++ b/tests/gui/test_workspace_feedback.py
@@ -1,0 +1,220 @@
+"""Focused Project view tests for workspace file feedback."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+from PySide6.QtCore import QObject, Signal
+
+from caliscope.cameras.camera_array import CameraArray, CameraData
+from caliscope.core.workflow_status import WorkspaceIssue
+from caliscope.gui.cameras_tab_widget import CamerasTabWidget
+from caliscope.gui.multi_camera_processing_tab import MultiCameraProcessingTab
+from caliscope.gui.presenters.multi_camera_processing_presenter import MultiCameraProcessingState
+from caliscope.gui.views.project_setup_view import ProjectSetupView
+from caliscope.gui.widgets.cameras_info_placeholder import CamerasInfoPlaceholder
+from caliscope.workspace_coordinator import WorkspaceCoordinator
+
+
+class _CameraTabCoordinator(QObject):
+    status_changed = Signal()
+    intrinsic_target_changed = Signal()
+
+    def __init__(self, camera_array: CameraArray) -> None:
+        super().__init__()
+        self.camera_array = camera_array
+        self.intrinsic_frame_skip = 5
+        self.intrinsic_cam_ids = set(camera_array.cameras)
+        self.intrinsic_video_issues: tuple[WorkspaceIssue, ...] = ()
+        self.workspace_guide = SimpleNamespace(
+            intrinsic_dir=Path("calibration/intrinsic"),
+            get_cam_ids_in_dir=lambda _directory: sorted(self.intrinsic_cam_ids),
+        )
+
+    def get_workflow_status(self):
+        return SimpleNamespace(intrinsic_video_issues=self.intrinsic_video_issues)
+
+
+def test_project_feedback_follows_directory_change(tmp_path: Path, qapp, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "caliscope.workspace_coordinator.read_video_properties",
+        lambda _path: {"size": (640, 480)},
+    )
+    coordinator = WorkspaceCoordinator(tmp_path)
+    extrinsic = coordinator.workspace_guide.extrinsic_dir
+    view = ProjectSetupView(coordinator)
+
+    assert "No extrinsic camera videos found" in view._file_feedback_label.text()
+
+    (extrinsic / "cam_0.mp4").touch()
+    coordinator._on_directory_changed(str(extrinsic))
+
+    assert view._file_feedback_label.text() == (
+        "Calibration video file names and locations look correct.\nIntrinsic videos: none found."
+    )
+    assert tuple(coordinator.camera_array.cameras) == (0,)
+    assert view._intrinsic_row._status_label.text().startswith("No intrinsic video files in workspace.")
+
+    (coordinator.workspace_guide.intrinsic_dir / "cam_0.mp4").touch()
+    coordinator._on_directory_changed(str(coordinator.workspace_guide.intrinsic_dir))
+
+    assert view._intrinsic_row._status_label.text() == "Video files in workspace for cameras 0; 0/1 calibrated"
+    coordinator.cleanup()
+
+
+def test_project_names_precalibrated_intrinsics_without_videos(tmp_path: Path, qapp, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "caliscope.workspace_coordinator.read_video_properties",
+        lambda _path: {"size": (640, 480)},
+    )
+    coordinator = WorkspaceCoordinator(tmp_path)
+    extrinsic = coordinator.workspace_guide.extrinsic_dir
+    cameras = {
+        cam_id: CameraData(cam_id=cam_id, size=(640, 480), matrix=np.eye(3), distortions=np.zeros(5))
+        for cam_id in (0, 1)
+    }
+    coordinator.camera_repository.save(CameraArray(cameras))
+    for cam_id in (0, 1):
+        (extrinsic / f"cam_{cam_id}.mp4").touch()
+    coordinator.load_camera_array()
+    view = ProjectSetupView(coordinator)
+
+    assert view._intrinsic_row._status_label.text() == (
+        "Intrinsics loaded from camera_array.toml for cameras 0, 1; no intrinsic video files in workspace"
+    )
+
+    placeholder = CamerasInfoPlaceholder(coordinator)
+    text = placeholder._label.text()
+    assert "Intrinsics loaded from camera_array.toml" in text
+    assert "Cam 0" in text and "Cam 1" in text
+    assert "experimental" not in text
+
+    coordinator.camera_array.cameras[1].matrix = None
+    coordinator.status_changed.emit()
+    text = placeholder._label.text()
+    assert "Cameras 1 have no intrinsics" in text
+    assert "experimental" in text
+    coordinator.cleanup()
+
+
+def test_placeholder_without_intrinsics_states_the_risk(tmp_path: Path, qapp, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "caliscope.workspace_coordinator.read_video_properties",
+        lambda _path: {"size": (640, 480)},
+    )
+    coordinator = WorkspaceCoordinator(tmp_path)
+    (coordinator.workspace_guide.extrinsic_dir / "cam_0.mp4").touch()
+    coordinator.load_camera_array()
+
+    placeholder = CamerasInfoPlaceholder(coordinator)
+    text = placeholder._label.text()
+
+    assert "No intrinsic calibration videos" in text
+    assert "experimental" in text
+    assert "camera_array.toml" not in text
+    coordinator.cleanup()
+
+
+def test_open_extract_tab_warns_when_extrinsic_video_disappears(tmp_path: Path, qapp, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "caliscope.workspace_coordinator.read_video_properties",
+        lambda _path: {"size": (640, 480)},
+    )
+    coordinator = WorkspaceCoordinator(tmp_path)
+    extrinsic = coordinator.workspace_guide.extrinsic_dir
+    for cam_id in (0, 1):
+        (extrinsic / f"cam_{cam_id}.mp4").touch()
+    coordinator.load_camera_array()
+    tab = MultiCameraProcessingTab(coordinator)
+
+    assert tab._file_warning_label.isHidden()
+
+    (extrinsic / "cam_1.mp4").unlink()
+    coordinator._on_directory_changed(str(coordinator.workspace_guide.extrinsic_dir))
+
+    assert not tab._file_warning_label.isHidden()
+    assert "Missing calibration/extrinsic/cam_1.mp4" in tab._file_warning_label.text()
+    assert tuple(coordinator.camera_array.cameras) == (0, 1)
+    assert tab._presenter is not None and tab._widget is not None
+    assert tab._presenter.state == MultiCameraProcessingState.UNCONFIGURED
+    assert tab._widget._camera_cards[1]._thumbnail_label.text() == "No video file for cam_1"
+    assert not tab._widget._action_btn.isEnabled()
+
+    (extrinsic / "cam_1.mp4").touch()
+    coordinator._on_directory_changed(str(coordinator.workspace_guide.extrinsic_dir))
+
+    assert tab._file_warning_label.isHidden()
+    assert tab._presenter.state == MultiCameraProcessingState.READY
+    assert tab._widget._action_btn.isEnabled()
+    tab.cleanup()
+    coordinator.cleanup()
+
+
+def test_open_extract_tab_adds_card_when_camera_appears(tmp_path: Path, qapp, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "caliscope.workspace_coordinator.read_video_properties",
+        lambda _path: {"size": (640, 480)},
+    )
+    coordinator = WorkspaceCoordinator(tmp_path)
+    extrinsic = coordinator.workspace_guide.extrinsic_dir
+    (extrinsic / "cam_0.mp4").touch()
+    coordinator.load_camera_array()
+    tab = MultiCameraProcessingTab(coordinator)
+    assert tab._widget is not None
+    assert sorted(tab._widget._camera_cards) == [0]
+
+    (extrinsic / "cam_2.mp4").touch()
+    coordinator._on_directory_changed(str(extrinsic))
+
+    assert sorted(tab._widget._camera_cards) == [0, 2]
+    tab.cleanup()
+    coordinator.cleanup()
+
+
+def test_open_intrinsics_tab_refreshes_when_camera_is_added(qapp, monkeypatch) -> None:
+    coordinator = _CameraTabCoordinator(CameraArray({0: CameraData(cam_id=0, size=(640, 480))}))
+    monkeypatch.setattr(CamerasTabWidget, "_update_pattern_preview", lambda _self: None)
+    monkeypatch.setattr(CamerasTabWidget, "_on_camera_selected", lambda _self, _cam_id: None)
+    tab = CamerasTabWidget(coordinator)  # type: ignore[arg-type]
+
+    assert tab.camera_list.count() == 1
+
+    coordinator.camera_array.cameras[2] = CameraData(cam_id=2, size=(640, 480))
+    coordinator.intrinsic_cam_ids.add(2)
+    coordinator.status_changed.emit()
+
+    assert tab.camera_list.count() == 2
+    assert tab.camera_list.item(1).text() == "○ Cam 2"
+    tab.close()
+
+
+def test_open_intrinsics_tab_removes_camera_when_video_disappears(qapp, monkeypatch) -> None:
+    coordinator = _CameraTabCoordinator(
+        CameraArray(
+            {
+                0: CameraData(cam_id=0, size=(640, 480)),
+                2: CameraData(cam_id=2, size=(640, 480)),
+            }
+        )
+    )
+    monkeypatch.setattr(CamerasTabWidget, "_update_pattern_preview", lambda _self: None)
+    monkeypatch.setattr(CamerasTabWidget, "_on_camera_selected", lambda _self, _cam_id: None)
+    tab = CamerasTabWidget(coordinator)  # type: ignore[arg-type]
+
+    assert tab.camera_list.count() == 2
+
+    coordinator.intrinsic_cam_ids.remove(2)
+    coordinator.intrinsic_video_issues = (
+        WorkspaceIssue(
+            code="missing_camera_video",
+            message="Missing calibration/intrinsic/cam_2.mp4.",
+            relative_path="calibration/intrinsic/cam_2.mp4",
+        ),
+    )
+    coordinator.status_changed.emit()
+
+    assert tab.camera_list.count() == 1
+    assert tab.camera_list.item(0).text() == "○ Cam 0"
+    assert "Missing calibration/intrinsic/cam_2.mp4" in tab._file_warning_label.text()
+    assert not tab._file_warning_label.isHidden()
+    tab.close()

--- a/tests/synthetic/primitives/test_coverage.py
+++ b/tests/synthetic/primitives/test_coverage.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from caliscope.core.point_data import ImagePoints
+from caliscope.core.point_data import IMAGE_POINT_COLUMNS, ImagePoints
 from caliscope.core.coverage_analysis import (
     analyze_multi_camera_coverage,
     classify_link_quality,
@@ -411,6 +411,26 @@ class TestStructuralWarnings:
         # so there should be no critical or warning messages
         critical = [w for w in warnings if w.severity == WarningSeverity.CRITICAL]
         assert len(critical) == 0
+
+    def test_no_detections_is_a_single_critical_warning(self):
+        """Configured cameras with no detections at all are not a clean network."""
+        empty = ImagePoints(pd.DataFrame(columns=list(IMAGE_POINT_COLUMNS.keys())))
+        report = analyze_multi_camera_coverage(empty, cam_ids=[0, 1])
+
+        assert report.isolated_cameras == [0, 1]
+        assert report.has_critical_issues
+
+        warnings = detect_structural_warnings(report, n_cameras=2)
+
+        assert [w.severity for w in warnings] == [WarningSeverity.CRITICAL]
+        assert "No calibration target detected" in warnings[0].message
+
+    def test_camera_without_detections_is_isolated(self):
+        """A configured camera absent from the data is isolated, not omitted."""
+        report = analyze_multi_camera_coverage(make_simple_image_points(), cam_ids=[0, 1, 2, 3])
+
+        assert report.n_cameras == 4
+        assert report.isolated_cameras == [3]
 
     def test_isolated_camera_critical_warning(self):
         """Isolated camera produces a CRITICAL warning."""

--- a/tests/test_workspace_coordinator.py
+++ b/tests/test_workspace_coordinator.py
@@ -66,25 +66,6 @@ def test_empty_workspace_video_status_is_not_ready(coordinator: WorkspaceCoordin
     assert status.extrinsic_video_issues[0].code == "missing_camera_video"
 
 
-def test_workflow_status_reports_video_filename_issues(coordinator: WorkspaceCoordinator):
-    extrinsic = coordinator.workspace_guide.extrinsic_dir
-    intrinsic = coordinator.workspace_guide.intrinsic_dir
-    (extrinsic / "cam_2.mp4").touch()
-    (extrinsic / "notes.mp4").touch()
-    (intrinsic / "cam_02.mp4").touch()
-
-    status = coordinator.get_workflow_status()
-
-    assert status.camera_count == 1
-    assert status.intrinsic_videos_missing == [2]
-    assert {issue.code for issue in status.intrinsic_video_issues} == {
-        "missing_camera_video",
-        "malformed_camera_filename",
-    }
-    assert [issue.code for issue in status.extrinsic_video_issues] == ["unexpected_mp4"]
-    assert status.extrinsic_videos_available is True
-
-
 def test_deleted_extrinsic_video_is_reported_as_missing(
     coordinator: WorkspaceCoordinator,
     monkeypatch: pytest.MonkeyPatch,
@@ -111,7 +92,7 @@ def test_deleted_extrinsic_video_is_reported_as_missing(
     assert status.intrinsic_video_issues == ()
 
 
-def test_discovering_cameras_keeps_persisted_calibration(
+def test_directory_change_discovers_cameras_and_keeps_persisted_calibration(
     coordinator: WorkspaceCoordinator,
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -121,41 +102,19 @@ def test_discovering_cameras_keeps_persisted_calibration(
     )
     calibrated = CameraData(cam_id=0, size=(640, 480), matrix=np.eye(3), distortions=np.zeros(5))
     coordinator.camera_repository.save(CameraArray({0: calibrated}))
-    (coordinator.workspace_guide.extrinsic_dir / "cam_0.mp4").touch()
-    (coordinator.workspace_guide.extrinsic_dir / "cam_1.mp4").touch()
-
-    coordinator._on_directory_changed(str(coordinator.workspace_guide.extrinsic_dir))
-
-    assert tuple(coordinator.camera_array.cameras) == (0, 1)
-    assert coordinator.camera_array.cameras[0].matrix is not None
-    assert coordinator.camera_repository.load().cameras[0].matrix is not None
-
-
-def test_directory_change_emits_status_changed(coordinator: WorkspaceCoordinator):
-    emissions: list[None] = []
-    coordinator.status_changed.connect(lambda: emissions.append(None))
-
-    coordinator._on_directory_changed(str(coordinator.workspace_guide.extrinsic_dir))
-
-    assert emissions == [None]
-
-
-def test_directory_change_discovers_new_cameras(
-    coordinator: WorkspaceCoordinator,
-    monkeypatch: pytest.MonkeyPatch,
-):
-    monkeypatch.setattr(
-        "caliscope.workspace_coordinator.read_video_properties",
-        lambda _path: {"size": (640, 480)},
-    )
-    (coordinator.workspace_guide.extrinsic_dir / "cam_0.mp4").touch()
-    (coordinator.workspace_guide.intrinsic_dir / "cam_0.mp4").touch()
+    extrinsic = coordinator.workspace_guide.extrinsic_dir
+    intrinsic = coordinator.workspace_guide.intrinsic_dir
+    for cam_id in (0, 1):
+        (extrinsic / f"cam_{cam_id}.mp4").touch()
+        (intrinsic / f"cam_{cam_id}.mp4").touch()
 
     assert coordinator.camera_array.cameras == {}
     assert coordinator.multi_camera_tab_enabled is False
 
-    coordinator._on_directory_changed(str(coordinator.workspace_guide.extrinsic_dir))
+    coordinator._on_directory_changed(str(extrinsic))
 
-    assert tuple(coordinator.camera_array.cameras) == (0,)
+    assert tuple(coordinator.camera_array.cameras) == (0, 1)
+    assert coordinator.camera_array.cameras[0].matrix is not None
+    assert coordinator.camera_repository.load().cameras[0].matrix is not None
     assert coordinator.cameras_tab_enabled is True
     assert coordinator.multi_camera_tab_enabled is True

--- a/tests/test_workspace_coordinator.py
+++ b/tests/test_workspace_coordinator.py
@@ -9,8 +9,10 @@ target, and still wires the ArUco marker-set factory for the ArUco target.
 
 from pathlib import Path
 
+import numpy as np
 import pytest
 
+from caliscope.cameras.camera_array import CameraArray, CameraData
 from caliscope.workspace_coordinator import WorkspaceCoordinator
 
 
@@ -54,3 +56,106 @@ def test_aruco_extrinsic_presenter_gets_marker_set_constraints(coordinator: Work
     assert constraints is not None
     assert len(constraints.distances) > 0
     assert presenter._extrinsic_target_type == "aruco"
+
+
+def test_empty_workspace_video_status_is_not_ready(coordinator: WorkspaceCoordinator):
+    status = coordinator.get_workflow_status()
+
+    assert status.intrinsic_videos_available is False
+    assert status.extrinsic_videos_available is False
+    assert status.extrinsic_video_issues[0].code == "missing_camera_video"
+
+
+def test_workflow_status_reports_video_filename_issues(coordinator: WorkspaceCoordinator):
+    extrinsic = coordinator.workspace_guide.extrinsic_dir
+    intrinsic = coordinator.workspace_guide.intrinsic_dir
+    (extrinsic / "cam_2.mp4").touch()
+    (extrinsic / "notes.mp4").touch()
+    (intrinsic / "cam_02.mp4").touch()
+
+    status = coordinator.get_workflow_status()
+
+    assert status.camera_count == 1
+    assert status.intrinsic_videos_missing == [2]
+    assert {issue.code for issue in status.intrinsic_video_issues} == {
+        "missing_camera_video",
+        "malformed_camera_filename",
+    }
+    assert [issue.code for issue in status.extrinsic_video_issues] == ["unexpected_mp4"]
+    assert status.extrinsic_videos_available is True
+
+
+def test_deleted_extrinsic_video_is_reported_as_missing(
+    coordinator: WorkspaceCoordinator,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        "caliscope.workspace_coordinator.read_video_properties",
+        lambda _path: {"size": (640, 480)},
+    )
+    extrinsic = coordinator.workspace_guide.extrinsic_dir
+    intrinsic = coordinator.workspace_guide.intrinsic_dir
+    for cam_id in (0, 1):
+        (extrinsic / f"cam_{cam_id}.mp4").touch()
+        (intrinsic / f"cam_{cam_id}.mp4").touch()
+    coordinator.load_camera_array()
+
+    (extrinsic / "cam_1.mp4").unlink()
+    status = coordinator.get_workflow_status()
+
+    assert status.camera_count == 2
+    assert status.extrinsic_videos_available is False
+    assert status.extrinsic_videos_missing == [1]
+    assert [issue.relative_path for issue in status.extrinsic_video_issues] == ["calibration/extrinsic/cam_1.mp4"]
+    assert status.intrinsic_videos_missing == []
+    assert status.intrinsic_video_issues == ()
+
+
+def test_discovering_cameras_keeps_persisted_calibration(
+    coordinator: WorkspaceCoordinator,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        "caliscope.workspace_coordinator.read_video_properties",
+        lambda _path: {"size": (640, 480)},
+    )
+    calibrated = CameraData(cam_id=0, size=(640, 480), matrix=np.eye(3), distortions=np.zeros(5))
+    coordinator.camera_repository.save(CameraArray({0: calibrated}))
+    (coordinator.workspace_guide.extrinsic_dir / "cam_0.mp4").touch()
+    (coordinator.workspace_guide.extrinsic_dir / "cam_1.mp4").touch()
+
+    coordinator._on_directory_changed(str(coordinator.workspace_guide.extrinsic_dir))
+
+    assert tuple(coordinator.camera_array.cameras) == (0, 1)
+    assert coordinator.camera_array.cameras[0].matrix is not None
+    assert coordinator.camera_repository.load().cameras[0].matrix is not None
+
+
+def test_directory_change_emits_status_changed(coordinator: WorkspaceCoordinator):
+    emissions: list[None] = []
+    coordinator.status_changed.connect(lambda: emissions.append(None))
+
+    coordinator._on_directory_changed(str(coordinator.workspace_guide.extrinsic_dir))
+
+    assert emissions == [None]
+
+
+def test_directory_change_discovers_new_cameras(
+    coordinator: WorkspaceCoordinator,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        "caliscope.workspace_coordinator.read_video_properties",
+        lambda _path: {"size": (640, 480)},
+    )
+    (coordinator.workspace_guide.extrinsic_dir / "cam_0.mp4").touch()
+    (coordinator.workspace_guide.intrinsic_dir / "cam_0.mp4").touch()
+
+    assert coordinator.camera_array.cameras == {}
+    assert coordinator.multi_camera_tab_enabled is False
+
+    coordinator._on_directory_changed(str(coordinator.workspace_guide.extrinsic_dir))
+
+    assert tuple(coordinator.camera_array.cameras) == (0,)
+    assert coordinator.cameras_tab_enabled is True
+    assert coordinator.multi_camera_tab_enabled is True

--- a/tests/test_workspace_guide.py
+++ b/tests/test_workspace_guide.py
@@ -68,98 +68,37 @@ class TestMissingFilesInDir:
 
 
 class TestCameraVideoAssessment:
-    def test_canonical_noncontiguous_camera_ids_are_accepted(self, workspace: Path) -> None:
-        _touch_cam_ids(workspace / "calibration" / "extrinsic", [0, 3, 12])
-
-        assessment = WorkspaceGuide(workspace).assess_extrinsic_videos(())
-
-        assert assessment.camera_ids == (0, 3, 12)
-        assert assessment.issues == ()
-
-    @pytest.mark.parametrize(
-        "filename",
-        ["cam_01.mp4", "cam_-1.mp4", "cam_1_extra.mp4", "cam1.mp4", "cam_1.MP4"],
-    )
-    def test_near_match_is_reported_as_malformed(self, workspace: Path, filename: str) -> None:
+    def test_each_issue_kind_is_reported_with_a_relative_path(self, workspace: Path) -> None:
         extrinsic = workspace / "calibration" / "extrinsic"
-        (extrinsic / "cam_0.mp4").touch()
-        (extrinsic / filename).touch()
-
-        assessment = WorkspaceGuide(workspace).assess_extrinsic_videos(())
-
-        assert assessment.camera_ids == (0,)
-        issue = next(issue for issue in assessment.issues if issue.code == "malformed_camera_filename")
-        assert issue.relative_path == f"calibration/extrinsic/{filename}"
-        assert "must be named cam_N.mp4" in issue.message
-
-    def test_unexpected_mp4_is_reported(self, workspace: Path) -> None:
-        extrinsic = workspace / "calibration" / "extrinsic"
-        (extrinsic / "cam_0.mp4").touch()
+        _touch_cam_ids(extrinsic, [0, 3])
+        (extrinsic / "cam_1.MP4").touch()
         (extrinsic / "calibration_take.mp4").touch()
         (extrinsic / "timestamps.csv").touch()
 
-        assessment = WorkspaceGuide(workspace).assess_extrinsic_videos(())
+        assessment = WorkspaceGuide(workspace).assess_extrinsic_videos([0, 5])
 
-        assert [issue.code for issue in assessment.issues] == ["unexpected_mp4"]
-        assert assessment.issues[0].relative_path == "calibration/extrinsic/calibration_take.mp4"
-
-    def test_missing_intrinsic_video_uses_relative_path(self, workspace: Path) -> None:
-        _touch_cam_ids(workspace / "calibration" / "extrinsic", [0, 5])
-        _touch_cam_ids(workspace / "calibration" / "intrinsic", [0])
-        guide = WorkspaceGuide(workspace)
-
-        assessment = guide.assess_intrinsic_videos(guide.get_cam_ids())
-
+        assert assessment.camera_ids == (0, 3)
         assert assessment.missing_camera_ids == (5,)
-        assert assessment.issues[0].code == "missing_camera_video"
-        assert assessment.issues[0].relative_path == "calibration/intrinsic/cam_5.mp4"
-
-    def test_missing_extrinsic_video_is_reported_against_expected_set(self, workspace: Path) -> None:
-        _touch_cam_ids(workspace / "calibration" / "extrinsic", [0])
-
-        assessment = WorkspaceGuide(workspace).assess_extrinsic_videos([0, 1])
-
-        assert assessment.camera_ids == (0,)
-        assert assessment.missing_camera_ids == (1,)
-        assert [issue.code for issue in assessment.issues] == ["missing_camera_video"]
-        assert assessment.issues[0].relative_path == "calibration/extrinsic/cam_1.mp4"
-
-    def test_empty_extrinsic_directory_is_not_ready(self, workspace: Path) -> None:
-        assessment = WorkspaceGuide(workspace).assess_extrinsic_videos(())
-
-        assert assessment.camera_ids == ()
-        assert assessment.issues[0].code == "missing_camera_video"
-        assert assessment.issues[0].relative_path == "calibration/extrinsic"
-
-    def test_canonical_name_must_be_a_direct_child_file(self, workspace: Path) -> None:
-        nested = workspace / "calibration" / "extrinsic" / "cam_0.mp4"
-        nested.mkdir()
-
-        assessment = WorkspaceGuide(workspace).assess_extrinsic_videos(())
-
-        assert assessment.camera_ids == ()
+        assert [(issue.code, issue.relative_path) for issue in assessment.issues] == [
+            ("missing_camera_video", "calibration/extrinsic/cam_5.mp4"),
+            ("unexpected_mp4", "calibration/extrinsic/cam_3.mp4"),
+            ("unexpected_mp4", "calibration/extrinsic/calibration_take.mp4"),
+            ("malformed_camera_filename", "calibration/extrinsic/cam_1.MP4"),
+        ]
 
 
 class TestRecordingLayoutIssues:
-    def test_root_level_recording_videos_get_session_folder_hint(self, workspace: Path) -> None:
-        recordings = workspace / "recordings"
-        recordings.mkdir()
-        (recordings / "cam_0.mp4").touch()
-
-        issues = WorkspaceGuide(workspace).recording_layout_issues()
-
-        assert [issue.code for issue in issues] == ["recordings_need_session_folder"]
-
-    def test_camera_folders_get_combined_session_hint(self, workspace: Path) -> None:
+    def test_misplaced_layouts_get_hints(self, workspace: Path) -> None:
         recordings = workspace / "recordings"
         for cam_id in (0, 1):
             camera_dir = recordings / f"cam_{cam_id}"
             camera_dir.mkdir(parents=True)
             (camera_dir / "take.mp4").touch()
+        (recordings / "cam_0.mp4").touch()
 
         issues = WorkspaceGuide(workspace).recording_layout_issues()
 
-        assert [issue.code for issue in issues] == ["recording_split_by_camera"]
+        assert [issue.code for issue in issues] == ["recordings_need_session_folder", "recording_split_by_camera"]
 
 
 if __name__ == "__main__":

--- a/tests/test_workspace_guide.py
+++ b/tests/test_workspace_guide.py
@@ -67,5 +67,100 @@ class TestMissingFilesInDir:
         assert guide.all_instrinsic_mp4s_available() is False
 
 
+class TestCameraVideoAssessment:
+    def test_canonical_noncontiguous_camera_ids_are_accepted(self, workspace: Path) -> None:
+        _touch_cam_ids(workspace / "calibration" / "extrinsic", [0, 3, 12])
+
+        assessment = WorkspaceGuide(workspace).assess_extrinsic_videos(())
+
+        assert assessment.camera_ids == (0, 3, 12)
+        assert assessment.issues == ()
+
+    @pytest.mark.parametrize(
+        "filename",
+        ["cam_01.mp4", "cam_-1.mp4", "cam_1_extra.mp4", "cam1.mp4", "cam_1.MP4"],
+    )
+    def test_near_match_is_reported_as_malformed(self, workspace: Path, filename: str) -> None:
+        extrinsic = workspace / "calibration" / "extrinsic"
+        (extrinsic / "cam_0.mp4").touch()
+        (extrinsic / filename).touch()
+
+        assessment = WorkspaceGuide(workspace).assess_extrinsic_videos(())
+
+        assert assessment.camera_ids == (0,)
+        issue = next(issue for issue in assessment.issues if issue.code == "malformed_camera_filename")
+        assert issue.relative_path == f"calibration/extrinsic/{filename}"
+        assert "must be named cam_N.mp4" in issue.message
+
+    def test_unexpected_mp4_is_reported(self, workspace: Path) -> None:
+        extrinsic = workspace / "calibration" / "extrinsic"
+        (extrinsic / "cam_0.mp4").touch()
+        (extrinsic / "calibration_take.mp4").touch()
+        (extrinsic / "timestamps.csv").touch()
+
+        assessment = WorkspaceGuide(workspace).assess_extrinsic_videos(())
+
+        assert [issue.code for issue in assessment.issues] == ["unexpected_mp4"]
+        assert assessment.issues[0].relative_path == "calibration/extrinsic/calibration_take.mp4"
+
+    def test_missing_intrinsic_video_uses_relative_path(self, workspace: Path) -> None:
+        _touch_cam_ids(workspace / "calibration" / "extrinsic", [0, 5])
+        _touch_cam_ids(workspace / "calibration" / "intrinsic", [0])
+        guide = WorkspaceGuide(workspace)
+
+        assessment = guide.assess_intrinsic_videos(guide.get_cam_ids())
+
+        assert assessment.missing_camera_ids == (5,)
+        assert assessment.issues[0].code == "missing_camera_video"
+        assert assessment.issues[0].relative_path == "calibration/intrinsic/cam_5.mp4"
+
+    def test_missing_extrinsic_video_is_reported_against_expected_set(self, workspace: Path) -> None:
+        _touch_cam_ids(workspace / "calibration" / "extrinsic", [0])
+
+        assessment = WorkspaceGuide(workspace).assess_extrinsic_videos([0, 1])
+
+        assert assessment.camera_ids == (0,)
+        assert assessment.missing_camera_ids == (1,)
+        assert [issue.code for issue in assessment.issues] == ["missing_camera_video"]
+        assert assessment.issues[0].relative_path == "calibration/extrinsic/cam_1.mp4"
+
+    def test_empty_extrinsic_directory_is_not_ready(self, workspace: Path) -> None:
+        assessment = WorkspaceGuide(workspace).assess_extrinsic_videos(())
+
+        assert assessment.camera_ids == ()
+        assert assessment.issues[0].code == "missing_camera_video"
+        assert assessment.issues[0].relative_path == "calibration/extrinsic"
+
+    def test_canonical_name_must_be_a_direct_child_file(self, workspace: Path) -> None:
+        nested = workspace / "calibration" / "extrinsic" / "cam_0.mp4"
+        nested.mkdir()
+
+        assessment = WorkspaceGuide(workspace).assess_extrinsic_videos(())
+
+        assert assessment.camera_ids == ()
+
+
+class TestRecordingLayoutIssues:
+    def test_root_level_recording_videos_get_session_folder_hint(self, workspace: Path) -> None:
+        recordings = workspace / "recordings"
+        recordings.mkdir()
+        (recordings / "cam_0.mp4").touch()
+
+        issues = WorkspaceGuide(workspace).recording_layout_issues()
+
+        assert [issue.code for issue in issues] == ["recordings_need_session_folder"]
+
+    def test_camera_folders_get_combined_session_hint(self, workspace: Path) -> None:
+        recordings = workspace / "recordings"
+        for cam_id in (0, 1):
+            camera_dir = recordings / f"cam_{cam_id}"
+            camera_dir.mkdir(parents=True)
+            (camera_dir / "take.mp4").touch()
+
+        issues = WorkspaceGuide(workspace).recording_layout_issues()
+
+        assert [issue.code for issue in issues] == ["recording_split_by_camera"]
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Report missing, malformed, and unexpected calibration videos in the Project view. Also flag recordings placed directly under `recordings/` or split across `recordings/cam_N/` directories.
- Keep open Intrinsics and Extract tabs synchronized with changes in the calibration folders. Adding or removing a video now updates camera rows, cards, warnings, and processing availability without reopening the project.
- Build the expected camera set from the loaded `CameraArray` and the current extrinsic videos. A deleted extrinsic video remains visible as missing, and newly added cameras are discovered without overwriting stored intrinsic calibration.
- Treat an extraction with no detections as a critical coverage warning. Remove the redundant `Check files now` button because the directory watcher already refreshes the workspace status.

## Test plan

- [x] CI passes on Linux, macOS, and Windows. The documentation build also passes.
- [x] Manually tested a pre-calibrated four-camera workspace with no intrinsic videos.
- [x] Manually tested missing, misnamed, and misplaced video files.
- [x] Manually exercised `QFileSystemWatcher` with absolute and relative workspace paths. Adding a camera updated the open tabs. Deleting `calibration/extrinsic/cam_1.mp4` reported that file as missing, kept both cameras loaded, and did not create an intrinsic-file warning.

The automated tests call `_on_directory_changed()` directly. Delivery through `QFileSystemWatcher` is covered by the manual checks above.

## Known limitations

- If discovery runs before a video finishes copying, metadata loading can fail. Caliscope logs a warning and tries again after a later directory change.
- When neither intrinsic nor extrinsic videos exist, `load_workspace()` does not load the saved camera array.
- A camera that remains in `camera_array.toml` after removal from the rig is reported as missing. The app does not currently provide a way to remove it.
