### PR TITLE
feat(gui): surface recording file issues

### DIFF
--- a/src/caliscope/core/workflow_status.py
+++ b/src/caliscope/core/workflow_status.py
@@ -65,9 +65,14 @@ class WorkflowStatus:
     extrinsic_calibration_complete: bool
 
     # Step 5: Reconstruction (optional)
-    recordings_available: bool
     recording_names: list[str]
-    recording_layout_issues: tuple[WorkspaceIssue, ...]
+    ready_recording_names: list[str]
+    recording_issues: tuple[WorkspaceIssue, ...]
+
+    @property
+    def recordings_available(self) -> bool:
+        """Whether at least one recording session is ready to process."""
+        return bool(self.ready_recording_names)
 
     @property
     def intrinsic_step_status(self) -> StepStatus:

--- a/src/caliscope/gui/cameras_tab_widget.py
+++ b/src/caliscope/gui/cameras_tab_widget.py
@@ -28,6 +28,7 @@ from caliscope.gui.utils.charuco_preview import render_charuco_pixmap
 from caliscope.gui.utils.spinbox_utils import setup_spinbox_sizing
 from caliscope.gui.camera_list_widget import CameraListWidget
 from caliscope.gui.views.intrinsic_calibration_widget import IntrinsicCalibrationWidget
+from caliscope.gui.widgets.workspace_issue_label import WorkspaceIssueLabel
 
 if TYPE_CHECKING:
     from caliscope.gui.presenters.intrinsic_calibration_presenter import (
@@ -68,7 +69,7 @@ class CamerasTabWidget(QWidget):
 
         self._setup_ui()
         self._connect_signals()
-        self._refresh_camera_list()
+        self._refresh_from_workspace()
         self._update_pattern_preview()
 
         # Auto-select first camera if available
@@ -89,14 +90,11 @@ class CamerasTabWidget(QWidget):
         left_layout.setContentsMargins(0, 0, 0, 0)
         left_layout.setSpacing(8)
 
-        self._file_warning_label = QLabel()
-        self._file_warning_label.setTextFormat(Qt.TextFormat.PlainText)
-        self._file_warning_label.setWordWrap(True)
-        self._file_warning_label.setStyleSheet(f"color: {Colors.WARNING};")
-        self._file_warning_label.hide()
-        left_layout.addWidget(self._file_warning_label)
+        self._issue_label = WorkspaceIssueLabel()
+        left_layout.addWidget(self._issue_label)
 
-        self.camera_list = CameraListWidget(self.coordinator.camera_array, self._intrinsic_video_cam_ids())
+        assessment = self.coordinator.workspace_guide.assess_intrinsic_videos(self.coordinator.expected_cam_ids)
+        self.camera_list = CameraListWidget(self.coordinator.camera_array, set(assessment.camera_ids))
         self.camera_list.setMinimumWidth(150)
         left_layout.addWidget(self.camera_list, stretch=1)
 
@@ -153,33 +151,21 @@ class CamerasTabWidget(QWidget):
     def _connect_signals(self) -> None:
         """Connect internal signals."""
         self.camera_list.camera_selected.connect(self._on_camera_selected)
-        self.coordinator.status_changed.connect(self._refresh_camera_list)
+        self.coordinator.status_changed.connect(self._refresh_from_workspace)
         self.coordinator.intrinsic_target_changed.connect(self._on_intrinsic_target_changed)
         self._frame_skip_spin.valueChanged.connect(self._on_frame_skip_changed)
 
-    def _refresh_camera_list(self) -> None:
+    def _refresh_from_workspace(self) -> None:
         """Refresh cameras and feedback from the current intrinsic files."""
-        available_cam_ids = self._intrinsic_video_cam_ids()
+        assessment = self.coordinator.workspace_guide.assess_intrinsic_videos(self.coordinator.expected_cam_ids)
+        available_cam_ids = set(assessment.camera_ids)
         self.camera_list.refresh(self.coordinator.camera_array, available_cam_ids)
-
-        issues = self.coordinator.get_workflow_status().intrinsic_video_issues
-        if issues:
-            self._file_warning_label.setText(
-                "Intrinsic videos need attention:\n" + "\n".join(i.message for i in issues)
-            )
-            self._file_warning_label.show()
-        else:
-            self._file_warning_label.clear()
-            self._file_warning_label.hide()
+        self._issue_label.set_issues(assessment.issues)
 
         if self._current_cam_id is not None and self._current_cam_id not in available_cam_ids:
             missing_cam_id = self._current_cam_id
             self._show_message(f"Intrinsic video for camera {missing_cam_id} is missing. Review the Project tab.")
             self._current_cam_id = None
-
-    def _intrinsic_video_cam_ids(self) -> set[int]:
-        guide = self.coordinator.workspace_guide
-        return set(guide.get_cam_ids_in_dir(guide.intrinsic_dir))
 
     def _on_intrinsic_target_changed(self) -> None:
         """Update tracker in all pooled presenters and refresh preview."""
@@ -241,7 +227,7 @@ class CamerasTabWidget(QWidget):
         self.coordinator.persist_intrinsic_calibration(output, collected_points)
 
         # Refresh camera list to show updated status
-        self._refresh_camera_list()
+        self._refresh_from_workspace()
 
     def _show_message(self, text: str) -> None:
         """Show a message in the content area."""
@@ -291,6 +277,17 @@ class CamerasTabWidget(QWidget):
         removeTab() + deleteLater() doesn't trigger closeEvent.
         The parent (MainWidget) must call this during reload_workspace.
         """
+        # The coordinator outlives this tab; drop its connections so they never
+        # fire into discarded widgets or presenters.
+        try:
+            self.coordinator.status_changed.disconnect(self._refresh_from_workspace)
+        except (RuntimeError, TypeError):
+            pass
+        try:
+            self.coordinator.intrinsic_target_changed.disconnect(self._on_intrinsic_target_changed)
+        except (RuntimeError, TypeError):
+            pass
+
         for cam_id, presenter in self._presenters.items():
             logger.info(f"Cleaning up presenter for cam {cam_id}")
             presenter.cleanup()

--- a/src/caliscope/gui/extrinsic_calibration_tab.py
+++ b/src/caliscope/gui/extrinsic_calibration_tab.py
@@ -72,7 +72,12 @@ class ExtrinsicCalibrationTab(QWidget):
         # built. status_changed fires after image_points.csv is written (and on
         # watched filesystem changes); the presenter re-checks for extraction
         # output so the workflow strip and Calibrate button catch up.
-        self._coordinator.status_changed.connect(self._presenter.refresh_extraction_status)
+        self._coordinator.status_changed.connect(self._refresh_from_workspace)
+
+    def _refresh_from_workspace(self) -> None:
+        """Follow the workspace: extraction output that landed after tab build."""
+        if self._presenter is not None:
+            self._presenter.refresh_from_workspace()
 
     # -------------------------------------------------------------------------
     # Rendering Lifecycle
@@ -98,17 +103,18 @@ class ExtrinsicCalibrationTab(QWidget):
         Must be called before tab is destroyed. The parent (MainWidget) is
         responsible for calling this during reload_workspace or closeEvent.
         """
+        # The coordinator outlives this tab, so drop the status_changed
+        # connection before discarding the presenter to avoid firing into it.
+        try:
+            self._coordinator.status_changed.disconnect(self._refresh_from_workspace)
+        except (RuntimeError, TypeError):
+            pass
+
         if self._view is not None:
             self._view.cleanup()
             self._view = None
 
         if self._presenter is not None:
-            # The coordinator outlives this tab, so drop the status_changed
-            # connection before discarding the presenter to avoid firing into it.
-            try:
-                self._coordinator.status_changed.disconnect(self._presenter.refresh_extraction_status)
-            except (RuntimeError, TypeError):
-                pass
             logger.info("Cleaning up extrinsic calibration presenter")
             self._presenter.cleanup()
             self._presenter = None

--- a/src/caliscope/gui/main_widget.py
+++ b/src/caliscope/gui/main_widget.py
@@ -253,7 +253,7 @@ class MainWindow(QMainWindow):
         if enabled:
             logger.info("Creating reconstruction tab")
             presenter = self.coordinator.create_reconstruction_presenter()
-            self.reconstruction_tab: QWidget = ReconstructionTab(presenter)
+            self.reconstruction_tab: QWidget = ReconstructionTab(presenter, self.coordinator)
             self.coordinator.capture_volume_updated.connect(
                 lambda: presenter.refresh_camera_array(self.coordinator.camera_array)
             )

--- a/src/caliscope/gui/main_widget.py
+++ b/src/caliscope/gui/main_widget.py
@@ -252,11 +252,7 @@ class MainWindow(QMainWindow):
         enabled = self.coordinator.reconstruction_tab_enabled
         if enabled:
             logger.info("Creating reconstruction tab")
-            presenter = self.coordinator.create_reconstruction_presenter()
-            self.reconstruction_tab: QWidget = ReconstructionTab(presenter, self.coordinator)
-            self.coordinator.capture_volume_updated.connect(
-                lambda: presenter.refresh_camera_array(self.coordinator.camera_array)
-            )
+            self.reconstruction_tab: QWidget = ReconstructionTab(self.coordinator)
         else:
             self.reconstruction_tab = QWidget()
         return self.reconstruction_tab, enabled

--- a/src/caliscope/gui/multi_camera_processing_tab.py
+++ b/src/caliscope/gui/multi_camera_processing_tab.py
@@ -9,13 +9,11 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from PySide6.QtCore import Qt
-from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
+from PySide6.QtWidgets import QVBoxLayout, QWidget
 
 from caliscope.gui.presenters.multi_camera_processing_presenter import (
     MultiCameraProcessingPresenter,
 )
-from caliscope.gui.theme import Colors
 from caliscope.gui.views.multi_camera_processing_widget import MultiCameraProcessingWidget
 
 if TYPE_CHECKING:
@@ -51,14 +49,6 @@ class MultiCameraProcessingTab(QWidget):
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
 
-        self._file_warning_label = QLabel()
-        self._file_warning_label.setTextFormat(Qt.TextFormat.PlainText)
-        self._file_warning_label.setWordWrap(True)
-        self._file_warning_label.setStyleSheet(f"color: {Colors.WARNING};")
-        self._file_warning_label.setContentsMargins(8, 8, 8, 0)
-        self._file_warning_label.hide()
-        layout.addWidget(self._file_warning_label)
-
         # Create presenter via coordinator factory
         self._presenter = self.coordinator.create_multi_camera_presenter()
 
@@ -89,23 +79,15 @@ class MultiCameraProcessingTab(QWidget):
         self.coordinator.status_changed.connect(self._refresh_from_workspace)
 
     def _refresh_from_workspace(self) -> None:
-        """Follow the workspace: camera set, video files, and file feedback."""
-        if self._presenter is not None:
-            cameras = self.coordinator.camera_array.cameras
-            if set(cameras) != set(self._presenter.cameras):
-                self._presenter.set_cameras(cameras)
-            else:
-                self._presenter.refresh_videos()
+        """Follow the workspace: push the current camera set, then re-read files."""
+        if self._presenter is None:
+            return
 
-        issues = self.coordinator.get_workflow_status().extrinsic_video_issues
-        if issues:
-            self._file_warning_label.setText(
-                "Extrinsic videos need attention:\n" + "\n".join(issue.message for issue in issues)
-            )
-            self._file_warning_label.show()
+        cameras = self.coordinator.camera_array.cameras
+        if set(cameras) != set(self._presenter.cameras):
+            self._presenter.set_cameras(cameras)
         else:
-            self._file_warning_label.clear()
-            self._file_warning_label.hide()
+            self._presenter.refresh_from_workspace()
 
     def _on_extrinsic_target_changed(self) -> None:
         """Update tracker when extrinsic target config changes.
@@ -127,10 +109,14 @@ class MultiCameraProcessingTab(QWidget):
         responsible for calling this during reload_workspace or closeEvent.
         """
         if self._presenter is not None:
-            # The coordinator outlives this tab; drop the status_changed
-            # connection so it never fires into a deleted label.
+            # The coordinator outlives this tab; drop its connections so they
+            # never fire into a discarded presenter.
             try:
                 self.coordinator.status_changed.disconnect(self._refresh_from_workspace)
+            except (RuntimeError, TypeError):
+                pass
+            try:
+                self.coordinator.extrinsic_target_changed.disconnect(self._on_extrinsic_target_changed)
             except (RuntimeError, TypeError):
                 pass
             logger.info("Cleaning up multi-camera processing presenter")

--- a/src/caliscope/gui/presenters/extrinsic_calibration_presenter.py
+++ b/src/caliscope/gui/presenters/extrinsic_calibration_presenter.py
@@ -998,7 +998,7 @@ class ExtrinsicCalibrationPresenter(QObject):
             logger.warning(f"Could not load initial image points: {e}")
             self._initial_image_points = None
 
-    def refresh_extraction_status(self) -> None:
+    def refresh_from_workspace(self) -> None:
         """Pick up extraction output that appeared after the tab was built.
 
         Wired to the coordinator's status_changed signal. Extraction runs on the

--- a/src/caliscope/gui/presenters/multi_camera_processing_presenter.py
+++ b/src/caliscope/gui/presenters/multi_camera_processing_presenter.py
@@ -22,6 +22,7 @@ from caliscope.core.coverage_analysis import (
     analyze_multi_camera_coverage,
 )
 from caliscope.core.point_data import ImagePoints
+from caliscope.core.workflow_status import WorkspaceIssue
 from caliscope.core.process_synchronized_recording import (
     FrameData,
     get_initial_thumbnails,
@@ -33,6 +34,7 @@ from caliscope.task_manager.task_handle import TaskHandle
 from caliscope.task_manager.task_manager import TaskManager
 from caliscope.task_manager.task_state import TaskState
 from caliscope.tracker import Tracker
+from caliscope.workspace_guide import WorkspaceGuide
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +68,7 @@ class MultiCameraProcessingPresenter(QObject):
         processing_failed: Emitted when processing fails. Contains error message.
 
     Usage:
-        presenter = MultiCameraProcessingPresenter(task_manager, tracker)
+        presenter = MultiCameraProcessingPresenter(task_manager, tracker, workspace_guide)
         presenter.set_recording_dir(path)
         presenter.set_cameras(cameras)
         presenter.start_processing()  # Emits progress_updated during work
@@ -100,6 +102,7 @@ class MultiCameraProcessingPresenter(QObject):
         self,
         task_manager: TaskManager,
         tracker: Tracker,
+        workspace_guide: WorkspaceGuide,
         parent: QObject | None = None,
     ) -> None:
         """Initialize the presenter.
@@ -107,12 +110,14 @@ class MultiCameraProcessingPresenter(QObject):
         Args:
             task_manager: TaskManager for background processing
             tracker: Tracker for 2D point extraction
+            workspace_guide: Shared filesystem assessment gateway
             parent: Optional Qt parent
         """
         super().__init__(parent)
 
         self._task_manager = task_manager
         self._tracker = tracker
+        self._workspace_guide = workspace_guide
 
         # Configuration state (set externally)
         self._recording_dir: Path | None = None
@@ -173,8 +178,14 @@ class MultiCameraProcessingPresenter(QObject):
         """Configured cameras whose cam_N.mp4 is absent from the recording directory."""
         if self._recording_dir is None:
             return []
-        recording_dir = self._recording_dir
-        return sorted(cam_id for cam_id in self._cameras if not (recording_dir / f"cam_{cam_id}.mp4").exists())
+        return list(self._workspace_guide.assess_camera_videos(self._recording_dir, self._cameras).missing_camera_ids)
+
+    @property
+    def workspace_issues(self) -> tuple[WorkspaceIssue, ...]:
+        """Everything the video feedback label should say about the recording dir."""
+        if self._recording_dir is None:
+            return ()
+        return self._workspace_guide.assess_camera_videos(self._recording_dir, self._cameras).issues
 
     @property
     def recording_dir(self) -> Path | None:
@@ -243,7 +254,7 @@ class MultiCameraProcessingPresenter(QObject):
         self.cameras_changed.emit()
         self._emit_state_changed()
 
-    def refresh_videos(self) -> None:
+    def refresh_from_workspace(self) -> None:
         """Re-read which camera videos exist after the workspace changed.
 
         Drops thumbnails for videos that disappeared, loads thumbnails for

--- a/src/caliscope/gui/presenters/reconstruction_presenter.py
+++ b/src/caliscope/gui/presenters/reconstruction_presenter.py
@@ -18,6 +18,7 @@ from PySide6.QtCore import QObject, Qt, Signal
 
 from caliscope.cameras.camera_array import CameraArray
 from caliscope.core.process_synchronized_recording import process_synchronized_recording
+from caliscope.core.workflow_status import WorkspaceIssue
 from caliscope.gui.geometry.wireframe import WireframeSegment, wireframe_segments_from_view
 from caliscope.reconstruction.reconstruct_xyz import reconstruct_xyz
 from caliscope.recording.overlay_video_writer import OverlayVideoWriter
@@ -27,6 +28,7 @@ from caliscope.task_manager.task_handle import TaskHandle
 from caliscope.task_manager.task_manager import TaskManager
 from caliscope.task_manager.task_state import TaskState
 from caliscope.trackers import tracker_registry
+from caliscope.workspace_guide import CameraVideoAssessment, WorkspaceGuide
 
 logger = logging.getLogger(__name__)
 
@@ -69,10 +71,12 @@ class ReconstructionPresenter(QObject):
     progress_updated = Signal(int, str)  # percent (0-100), message
     model_download_needed = Signal(object)  # ModelCard when weights missing
     camera_array_changed = Signal()  # camera positions changed, rebuild viz
+    recordings_changed = Signal()  # recording folders or their assessments changed
 
     def __init__(
         self,
         workspace_dir: Path,
+        workspace_guide: WorkspaceGuide,
         camera_array: CameraArray,
         task_manager: TaskManager,
         project_settings: ProjectSettingsRepository | None = None,
@@ -82,6 +86,7 @@ class ReconstructionPresenter(QObject):
 
         Args:
             workspace_dir: Root workspace directory
+            workspace_guide: Shared filesystem assessment gateway
             camera_array: Calibrated camera array for triangulation
             task_manager: TaskManager for background processing
             project_settings: Repository for persisting 3D view appearance settings.
@@ -90,6 +95,7 @@ class ReconstructionPresenter(QObject):
         super().__init__(parent)
 
         self._workspace_dir = workspace_dir
+        self._workspace_guide = workspace_guide
         self._camera_array = camera_array
         self._task_manager = task_manager
         self._project_settings = project_settings
@@ -107,16 +113,17 @@ class ReconstructionPresenter(QObject):
         """Compute current state from internal reality - never stale.
 
         Priority order (task state takes precedence to avoid race conditions):
-        1. Task RUNNING -> RECONSTRUCTING
+        1. Task PENDING or RUNNING -> RECONSTRUCTING
         2. Task FAILED or _last_error set -> ERROR
         3. Task CANCELLED -> IDLE (cancellation returns to idle)
         4. xyz output exists -> COMPLETE
         5. Otherwise -> IDLE
         """
+        if self.has_active_task:
+            return ReconstructionState.RECONSTRUCTING
+
         if self._processing_task is not None:
             task_state = self._processing_task.state
-            if task_state == TaskState.RUNNING:
-                return ReconstructionState.RECONSTRUCTING
             if task_state == TaskState.FAILED:
                 return ReconstructionState.ERROR
             # CANCELLED or COMPLETED fall through to file check
@@ -133,39 +140,61 @@ class ReconstructionPresenter(QObject):
 
     @property
     def available_recordings(self) -> list[str]:
-        """List of valid recording directory names.
+        """List every immediate recording session directory, valid or not."""
+        return list(self.recording_assessments)
 
-        A recording directory is valid if:
-        1. It contains a cam_N.mp4 file for every camera in the camera array
-        2. There are no unexpected .mp4 files (catches misnamed files)
-        """
-        recordings_dir = self._workspace_dir / "recordings"
-        if not recordings_dir.exists():
-            return []
+    @property
+    def recording_assessments(self) -> dict[str, CameraVideoAssessment]:
+        """Current filesystem assessment for every recording session."""
+        return self._workspace_guide.assess_recordings(self._camera_array.cameras)
 
-        expected_cam_ids = set(self._camera_array.cameras.keys())
-        if not expected_cam_ids:
-            return []
+    @property
+    def recording_layout_issues(self) -> tuple[WorkspaceIssue, ...]:
+        """Current issues with files and camera-split folders at recordings/."""
+        return self._workspace_guide.recording_layout_issues()
 
-        valid = []
-        for item in recordings_dir.iterdir():
-            if item.is_dir():
-                # Get all mp4 files in the directory
-                all_mp4s = list(item.glob("*.mp4"))
+    @property
+    def selected_recording_assessment(self) -> CameraVideoAssessment | None:
+        """Current structural assessment for the selected recording."""
+        if self._selected_recording is None:
+            return None
+        return self.recording_assessments.get(self._selected_recording)
 
-                # Parse camera IDs from properly named files
-                available_cam_ids: set[int] = set()
-                for mp4 in all_mp4s:
-                    parts = mp4.stem.split("_")
-                    if len(parts) == 2 and parts[0] == "cam" and parts[1].isdigit():
-                        available_cam_ids.add(int(parts[1]))
+    @property
+    def selected_recording_issues(self) -> tuple[WorkspaceIssue, ...]:
+        """Current actionable issues for the selected recording."""
+        if self._selected_recording is None:
+            return ()
+        assessment = self.selected_recording_assessment
+        if assessment is not None:
+            return assessment.issues
+        relative_path = f"recordings/{self._selected_recording}"
+        return (
+            WorkspaceIssue(
+                code="missing_recording_directory",
+                message=f"{relative_path} no longer exists.",
+                relative_path=relative_path,
+            ),
+        )
 
-                # Valid if: all expected cameras present AND no unexpected mp4 files
-                expected_files_count = len(expected_cam_ids)
-                if expected_cam_ids == available_cam_ids and len(all_mp4s) == expected_files_count:
-                    valid.append(item.name)
+    @property
+    def selected_recording_is_ready(self) -> bool:
+        """Whether the selected session can be submitted for processing."""
+        assessment = self.selected_recording_assessment
+        return bool(self._camera_array.cameras) and assessment is not None and assessment.is_ready
 
-        return sorted(valid)
+    @property
+    def can_process(self) -> bool:
+        """Whether the current recording and tracker selections are processable."""
+        return not self.has_active_task and self.selected_recording_is_ready and self._selected_tracker is not None
+
+    @property
+    def has_active_task(self) -> bool:
+        """Whether reconstruction has been submitted and is not yet terminal."""
+        return self._processing_task is not None and self._processing_task.state in (
+            TaskState.PENDING,
+            TaskState.RUNNING,
+        )
 
     @property
     def available_trackers(self) -> list[str]:
@@ -267,6 +296,9 @@ class ReconstructionPresenter(QObject):
 
         Clears any previous error state when selection changes.
         """
+        if self.has_active_task:
+            logger.warning("Cannot change recording while reconstruction is active")
+            return
         if name not in self.available_recordings:
             logger.warning(f"Recording '{name}' not in available recordings")
             return
@@ -277,11 +309,39 @@ class ReconstructionPresenter(QObject):
         self._emit_state_changed()
         logger.info(f"Selected recording: {name}")
 
+    def refresh_recordings(self, *, preserve_error: bool = False) -> None:
+        """Reconcile selection with recording folders and emit current assessments.
+
+        A running task keeps its original selection even if its source folder is
+        removed. The task is not cancelled by filesystem feedback.
+        """
+        current_error = self._last_error
+        assessments = self.recording_assessments
+        recordings = list(assessments)
+        if not self.has_active_task and self._selected_recording not in recordings:
+            ready_recordings = [
+                name for name, assessment in assessments.items() if self._camera_array.cameras and assessment.is_ready
+            ]
+            self._selected_recording = (
+                ready_recordings[0] if ready_recordings else recordings[0] if recordings else None
+            )
+            self._last_error = None
+            self._processing_task = None
+
+        if preserve_error:
+            self._last_error = current_error
+
+        self.recordings_changed.emit()
+        self._emit_state_changed()
+
     def select_tracker(self, tracker: str) -> None:
         """Select a tracker for processing.
 
         Clears any previous error state when selection changes.
         """
+        if self.has_active_task:
+            logger.warning("Cannot change tracker while reconstruction is active")
+            return
         if tracker not in self.available_trackers:
             logger.warning(f"Tracker '{tracker}' not available")
             return
@@ -297,6 +357,10 @@ class ReconstructionPresenter(QObject):
 
         Requires both recording and tracker to be selected.
         """
+        if self.has_active_task:
+            logger.warning("Cannot start reconstruction while another reconstruction is active")
+            return
+
         if self.state not in (ReconstructionState.IDLE, ReconstructionState.COMPLETE):
             logger.warning(f"Cannot start reconstruction in state {self.state}")
             return
@@ -304,6 +368,15 @@ class ReconstructionPresenter(QObject):
         if not self._selected_recording or not self._selected_tracker:
             logger.warning("Cannot start: recording or tracker not selected")
             self._last_error = "Recording and tracker must be selected"
+            self._emit_state_changed()
+            return
+
+        if not self.selected_recording_is_ready:
+            if not self._camera_array.cameras:
+                issue_messages = ["No calibrated cameras are available for reconstruction."]
+            else:
+                issue_messages = [issue.message for issue in self.selected_recording_issues]
+            logger.warning("Cannot start reconstruction: %s", " ".join(issue_messages))
             self._emit_state_changed()
             return
 
@@ -325,11 +398,6 @@ class ReconstructionPresenter(QObject):
         camera_array = self._camera_array
         cam_ids = sorted(camera_array.cameras.keys())
 
-        tracker = tracker_registry.create(tracker_name)
-        tracker_dir = recording_path / tracker_name
-        tracker_dir.mkdir(parents=True, exist_ok=True)
-        camera_array.to_toml(tracker_dir / "camera_array.toml")
-
         try:
             synced_timestamps = SynchronizedTimestamps.load(recording_path, cam_ids)
         except ValueError as e:
@@ -338,6 +406,11 @@ class ReconstructionPresenter(QObject):
             self._last_error = str(e)
             self._emit_state_changed()
             return
+
+        tracker = tracker_registry.create(tracker_name)
+        tracker_dir = recording_path / tracker_name
+        tracker_dir.mkdir(parents=True, exist_ok=True)
+        camera_array.to_toml(tracker_dir / "camera_array.toml")
 
         save_overlay = bool(self._project_settings and self._project_settings.get_save_tracked_points_video())
         save_xy = bool(self._project_settings and self._project_settings.get_save_xy_points())
@@ -419,8 +492,8 @@ class ReconstructionPresenter(QObject):
         self._emit_state_changed()
 
     def cancel_reconstruction(self) -> None:
-        """Cancel the running reconstruction task."""
-        if self._processing_task is not None and self._processing_task.state == TaskState.RUNNING:
+        """Cancel a submitted reconstruction task."""
+        if self.has_active_task and self._processing_task is not None:
             logger.info("Cancelling reconstruction")
             self._processing_task.cancel()
 
@@ -480,13 +553,18 @@ class ReconstructionPresenter(QObject):
 
     def _on_reconstruction_complete(self, result: object) -> None:
         """Handle successful reconstruction."""
-        output_path = self.xyz_output_path
+        output_path = (
+            result / f"xyz_{self._selected_tracker}.csv"
+            if isinstance(result, Path) and self._selected_tracker is not None
+            else self.xyz_output_path
+        )
         logger.info(f"Reconstruction complete: {output_path}")
 
         self._emit_state_changed()
 
         if output_path is not None:
             self.reconstruction_complete.emit(output_path)
+        self.refresh_recordings()
 
     def _on_reconstruction_failed(self, exc_type: str, message: str) -> None:
         """Handle reconstruction failure."""
@@ -496,11 +574,13 @@ class ReconstructionPresenter(QObject):
         self._last_error = error_msg
         self._emit_state_changed()
         self.reconstruction_failed.emit(error_msg)
+        self.refresh_recordings(preserve_error=True)
 
     def _on_reconstruction_cancelled(self) -> None:
         """Handle reconstruction cancellation."""
         logger.info("Reconstruction was cancelled")
         self._emit_state_changed()
+        self.refresh_recordings()
 
     def _on_progress(self, percent: int, message: str) -> None:
         """Forward progress updates to our signal."""

--- a/src/caliscope/gui/presenters/reconstruction_presenter.py
+++ b/src/caliscope/gui/presenters/reconstruction_presenter.py
@@ -178,6 +178,11 @@ class ReconstructionPresenter(QObject):
         )
 
     @property
+    def workspace_issues(self) -> tuple[WorkspaceIssue, ...]:
+        """Everything the recording feedback label should say right now."""
+        return (*self.recording_layout_issues, *self.selected_recording_issues)
+
+    @property
     def selected_recording_is_ready(self) -> bool:
         """Whether the selected session can be submitted for processing."""
         assessment = self.selected_recording_assessment
@@ -309,7 +314,7 @@ class ReconstructionPresenter(QObject):
         self._emit_state_changed()
         logger.info(f"Selected recording: {name}")
 
-    def refresh_recordings(self, *, preserve_error: bool = False) -> None:
+    def refresh_from_workspace(self, *, preserve_error: bool = False) -> None:
         """Reconcile selection with recording folders and emit current assessments.
 
         A running task keeps its original selection even if its source folder is
@@ -357,10 +362,6 @@ class ReconstructionPresenter(QObject):
 
         Requires both recording and tracker to be selected.
         """
-        if self.has_active_task:
-            logger.warning("Cannot start reconstruction while another reconstruction is active")
-            return
-
         if self.state not in (ReconstructionState.IDLE, ReconstructionState.COMPLETE):
             logger.warning(f"Cannot start reconstruction in state {self.state}")
             return
@@ -553,18 +554,14 @@ class ReconstructionPresenter(QObject):
 
     def _on_reconstruction_complete(self, result: object) -> None:
         """Handle successful reconstruction."""
-        output_path = (
-            result / f"xyz_{self._selected_tracker}.csv"
-            if isinstance(result, Path) and self._selected_tracker is not None
-            else self.xyz_output_path
-        )
+        assert isinstance(result, Path)
+        output_path = result / f"xyz_{self._selected_tracker}.csv"
         logger.info(f"Reconstruction complete: {output_path}")
 
         self._emit_state_changed()
 
-        if output_path is not None:
-            self.reconstruction_complete.emit(output_path)
-        self.refresh_recordings()
+        self.reconstruction_complete.emit(output_path)
+        self.refresh_from_workspace()
 
     def _on_reconstruction_failed(self, exc_type: str, message: str) -> None:
         """Handle reconstruction failure."""
@@ -574,13 +571,13 @@ class ReconstructionPresenter(QObject):
         self._last_error = error_msg
         self._emit_state_changed()
         self.reconstruction_failed.emit(error_msg)
-        self.refresh_recordings(preserve_error=True)
+        self.refresh_from_workspace(preserve_error=True)
 
     def _on_reconstruction_cancelled(self) -> None:
         """Handle reconstruction cancellation."""
         logger.info("Reconstruction was cancelled")
         self._emit_state_changed()
-        self.refresh_recordings()
+        self.refresh_from_workspace()
 
     def _on_progress(self, percent: int, message: str) -> None:
         """Forward progress updates to our signal."""

--- a/src/caliscope/gui/reconstruction_tab.py
+++ b/src/caliscope/gui/reconstruction_tab.py
@@ -1,11 +1,10 @@
 """Container that wraps ReconstructionWidget with its presenter.
 
-Thin pass-through layer following the Pure DI pattern: Tab receives its
-presenter from the call site rather than creating it internally.
+Glue layer: the Tab creates its presenter through the coordinator factory,
+forwards coordinator signals to the presenter, and owns their lifecycle.
 
 Call site responsibility (e.g., MainWidget):
-    presenter = coordinator.create_reconstruction_presenter()
-    tab = ReconstructionTab(presenter, coordinator)
+    tab = ReconstructionTab(coordinator)
 """
 
 from __future__ import annotations
@@ -15,7 +14,6 @@ from typing import TYPE_CHECKING
 
 from PySide6.QtWidgets import QVBoxLayout, QWidget
 
-from caliscope.gui.presenters.reconstruction_presenter import ReconstructionPresenter
 from caliscope.gui.views.reconstruction_widget import ReconstructionWidget
 
 if TYPE_CHECKING:
@@ -27,28 +25,40 @@ logger = logging.getLogger(__name__)
 class ReconstructionTab(QWidget):
     """Container for ReconstructionWidget.
 
-    Receives presenter via constructor (Pure DI pattern).
     Tab owns presenter lifecycle - cleanup must be called before destruction.
     """
 
     def __init__(
         self,
-        presenter: ReconstructionPresenter,
         coordinator: WorkspaceCoordinator,
         parent: QWidget | None = None,
     ):
         super().__init__(parent)
-        self._presenter = presenter
         self._coordinator = coordinator
         self._cleaned_up = False
-        self._widget = ReconstructionWidget(presenter)
-        self._coordinator.status_changed.connect(self._presenter.refresh_recordings)
+        self._presenter = coordinator.create_reconstruction_presenter()
+        self._widget = ReconstructionWidget(self._presenter)
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(self._widget)
 
+        self._connect_signals()
+
         logger.info("ReconstructionTab created")
+
+    def _connect_signals(self) -> None:
+        """Wire coordinator signals to this tab."""
+        self._coordinator.status_changed.connect(self._refresh_from_workspace)
+        self._coordinator.capture_volume_updated.connect(self._on_capture_volume_updated)
+
+    def _refresh_from_workspace(self) -> None:
+        """Follow the workspace: recording folders and their assessments."""
+        self._presenter.refresh_from_workspace()
+
+    def _on_capture_volume_updated(self) -> None:
+        """Rebuild visualization against the recalibrated camera array."""
+        self._presenter.refresh_camera_array(self._coordinator.camera_array)
 
     def cleanup(self) -> None:
         """Clean up resources - call before destruction."""
@@ -56,7 +66,11 @@ class ReconstructionTab(QWidget):
             return
         self._cleaned_up = True
         try:
-            self._coordinator.status_changed.disconnect(self._presenter.refresh_recordings)
+            self._coordinator.status_changed.disconnect(self._refresh_from_workspace)
+        except (RuntimeError, TypeError):
+            pass
+        try:
+            self._coordinator.capture_volume_updated.disconnect(self._on_capture_volume_updated)
         except (RuntimeError, TypeError):
             pass
         self._widget.cleanup()

--- a/src/caliscope/gui/reconstruction_tab.py
+++ b/src/caliscope/gui/reconstruction_tab.py
@@ -5,17 +5,21 @@ presenter from the call site rather than creating it internally.
 
 Call site responsibility (e.g., MainWidget):
     presenter = coordinator.create_reconstruction_presenter()
-    tab = ReconstructionTab(presenter)
+    tab = ReconstructionTab(presenter, coordinator)
 """
 
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
 from PySide6.QtWidgets import QVBoxLayout, QWidget
 
 from caliscope.gui.presenters.reconstruction_presenter import ReconstructionPresenter
 from caliscope.gui.views.reconstruction_widget import ReconstructionWidget
+
+if TYPE_CHECKING:
+    from caliscope.workspace_coordinator import WorkspaceCoordinator
 
 logger = logging.getLogger(__name__)
 
@@ -30,11 +34,15 @@ class ReconstructionTab(QWidget):
     def __init__(
         self,
         presenter: ReconstructionPresenter,
+        coordinator: WorkspaceCoordinator,
         parent: QWidget | None = None,
     ):
         super().__init__(parent)
         self._presenter = presenter
+        self._coordinator = coordinator
+        self._cleaned_up = False
         self._widget = ReconstructionWidget(presenter)
+        self._coordinator.status_changed.connect(self._presenter.refresh_recordings)
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
@@ -44,6 +52,13 @@ class ReconstructionTab(QWidget):
 
     def cleanup(self) -> None:
         """Clean up resources - call before destruction."""
+        if self._cleaned_up:
+            return
+        self._cleaned_up = True
+        try:
+            self._coordinator.status_changed.disconnect(self._presenter.refresh_recordings)
+        except (RuntimeError, TypeError):
+            pass
         self._widget.cleanup()
         self._presenter.cleanup()
         logger.info("ReconstructionTab cleaned up")

--- a/src/caliscope/gui/views/multi_camera_processing_widget.py
+++ b/src/caliscope/gui/views/multi_camera_processing_widget.py
@@ -28,6 +28,7 @@ from caliscope.gui.theme import Styles
 from caliscope.gui.views.camera_thumbnail_card import CameraThumbnailCard
 from caliscope.gui.widgets.coverage_heatmap import CoverageHeatmapWidget
 from caliscope.gui.widgets.structural_warnings import StructuralWarningsWidget
+from caliscope.gui.widgets.workspace_issue_label import WorkspaceIssueLabel
 
 if TYPE_CHECKING:
     from caliscope.core.coverage_analysis import ExtrinsicCoverageReport
@@ -75,6 +76,9 @@ class MultiCameraProcessingWidget(QWidget):
     def _setup_ui(self) -> None:
         """Build the UI layout."""
         layout = QVBoxLayout(self)
+
+        self._issue_label = WorkspaceIssueLabel()
+        layout.addWidget(self._issue_label)
 
         # Camera grid in a scroll area (so it doesn't push controls off screen)
         self._camera_grid = QGridLayout()
@@ -259,6 +263,12 @@ class MultiCameraProcessingWidget(QWidget):
         for cam_id in self._presenter.missing_video_cam_ids:
             self._on_video_missing(cam_id)
 
+        self._refresh_issues()
+
+    def _refresh_issues(self) -> None:
+        """Render the presenter's current workspace file feedback."""
+        self._issue_label.set_issues(self._presenter.workspace_issues)
+
     def _on_video_missing(self, cam_id: int) -> None:
         """Replace a camera's thumbnail with a missing-file notice."""
         if cam_id in self._camera_cards:
@@ -310,6 +320,8 @@ class MultiCameraProcessingWidget(QWidget):
         )
 
         logger.debug(f"Updating UI for state: {state}")
+
+        self._refresh_issues()
 
         if state == MultiCameraProcessingState.UNCONFIGURED:
             self._action_btn.setText("Start Processing")

--- a/src/caliscope/gui/views/project_setup_view.py
+++ b/src/caliscope/gui/views/project_setup_view.py
@@ -819,7 +819,7 @@ class ProjectSetupView(QWidget):
                 () if intrinsic_is_optional_absence else status.intrinsic_video_issues,
             ),
             ("Extrinsic videos", status.extrinsic_video_issues),
-            ("Recordings", status.recording_layout_issues),
+            ("Recordings", status.recording_issues),
         )
         if not any(issues for _, issues in issue_groups):
             detail = "Calibration video file names and locations look correct."
@@ -922,10 +922,21 @@ class ProjectSetupView(QWidget):
             detail = "Waiting for extrinsic calibration"
             step_status = StepStatus.NOT_STARTED
         elif status.recordings_available:
-            # Capability unlocked - show as AVAILABLE (blue)
-            count = len(status.recording_names)
-            detail = f"{count} recording{'s' if count != 1 else ''} available"
+            ready_count = len(status.ready_recording_names)
+            total_count = len(status.recording_names)
+            if ready_count == total_count:
+                detail = f"{ready_count} recording{'s' if ready_count != 1 else ''} ready"
+            else:
+                detail = f"{ready_count}/{total_count} recordings ready; others need attention"
             step_status = StepStatus.AVAILABLE
+        elif status.recording_names or status.recording_issues:
+            count = len(status.recording_names)
+            if count:
+                verb = "needs" if count == 1 else "need"
+                detail = f"{count} recording{'s' if count != 1 else ''} {verb} attention"
+            else:
+                detail = "Recording files need session folders"
+            step_status = StepStatus.INCOMPLETE
         else:
             # Calibrated but no recordings yet
             detail = "No recordings yet"

--- a/src/caliscope/gui/views/reconstruction_widget.py
+++ b/src/caliscope/gui/views/reconstruction_widget.py
@@ -89,8 +89,16 @@ class ReconstructionWidget(QWidget):
         recording_layout = QVBoxLayout(recording_group)
 
         self._recording_list = QListWidget()
+        self._recording_list.setObjectName("recordingList")
         self._recording_list.setMaximumHeight(150)
         recording_layout.addWidget(self._recording_list)
+
+        self._recording_feedback_label = QLabel()
+        self._recording_feedback_label.setObjectName("recordingFeedbackLabel")
+        self._recording_feedback_label.setWordWrap(True)
+        self._recording_feedback_label.setStyleSheet(f"color: {Colors.WARNING};")
+        self._recording_feedback_label.hide()
+        recording_layout.addWidget(self._recording_feedback_label)
 
         left_layout.addWidget(recording_group)
 
@@ -134,6 +142,7 @@ class ReconstructionWidget(QWidget):
         actions_layout = QVBoxLayout(actions_group)
 
         self._process_btn = QPushButton("Process")
+        self._process_btn.setObjectName("processButton")
         self._process_btn.setEnabled(False)
         actions_layout.addWidget(self._process_btn)
 
@@ -181,6 +190,7 @@ class ReconstructionWidget(QWidget):
         self._presenter.progress_updated.connect(self._update_progress)
         self._presenter.reconstruction_complete.connect(self._on_reconstruction_complete)
         self._presenter.reconstruction_failed.connect(self._on_reconstruction_failed)
+        self._presenter.recordings_changed.connect(self._refresh_recording_list)
 
         # View -> Presenter (via adapters)
         self._recording_list.currentTextChanged.connect(self._on_recording_changed)
@@ -193,14 +203,7 @@ class ReconstructionWidget(QWidget):
 
     def _populate_initial_data(self) -> None:
         """Populate lists with available recordings and trackers."""
-        # Populate recordings
-        recordings = self._presenter.available_recordings
-        self._recording_list.clear()
-        self._recording_list.addItems(recordings)
-
-        # Auto-select first recording if available
-        if recordings:
-            self._recording_list.setCurrentRow(0)
+        self._presenter.refresh_recordings()
 
         # Populate trackers
         trackers = self._presenter.available_trackers
@@ -217,7 +220,39 @@ class ReconstructionWidget(QWidget):
         """Handle recording selection change."""
         if name:  # Guard against empty string when list cleared
             self._presenter.select_recording(name)
+            self._update_recording_feedback()
             self._update_visualization()
+
+    def _refresh_recording_list(self) -> None:
+        """Render the current filesystem session list without losing selection."""
+        recordings = self._presenter.available_recordings
+        selected = self._presenter.selected_recording
+
+        self._recording_list.blockSignals(True)
+        self._recording_list.clear()
+        self._recording_list.addItems(recordings)
+        if selected in recordings:
+            self._recording_list.setCurrentRow(recordings.index(selected))
+        self._recording_list.blockSignals(False)
+
+        self._update_recording_feedback()
+        self._update_visualization()
+
+    def _update_recording_feedback(self) -> None:
+        """Show actionable root and selected-session filesystem feedback."""
+        issues = list(self._presenter.recording_layout_issues)
+        issues.extend(self._presenter.selected_recording_issues)
+
+        if issues:
+            self._recording_feedback_label.setText("\n".join(f"• {issue.message}" for issue in issues))
+            self._recording_feedback_label.show()
+        elif not self._presenter.available_recordings:
+            self._recording_feedback_label.setText(
+                "No recording session folders found. Add a named folder inside recordings/."
+            )
+            self._recording_feedback_label.show()
+        else:
+            self._recording_feedback_label.hide()
 
     def _on_tracker_changed(self, index: int) -> None:
         """Handle tracker selection change."""
@@ -304,7 +339,9 @@ class ReconstructionWidget(QWidget):
 
         # Status message
         if state == ReconstructionState.IDLE:
-            if self._presenter.selected_recording and self._presenter.selected_tracker:
+            if self._presenter.selected_recording and not self._presenter.selected_recording_is_ready:
+                self._status_message.setText("Recording files need attention")
+            elif self._presenter.selected_recording and self._presenter.selected_tracker:
                 if self._selected_tracker_needs_download():
                     tracker = self._presenter.selected_tracker
                     if tracker and tracker_registry.has_source_url(tracker):
@@ -320,7 +357,10 @@ class ReconstructionWidget(QWidget):
         elif state == ReconstructionState.RECONSTRUCTING:
             self._status_message.setText("Processing...")
         elif state == ReconstructionState.COMPLETE:
-            self._status_message.setText("Reconstruction complete")
+            if self._presenter.selected_recording_is_ready:
+                self._status_message.setText("Reconstruction complete")
+            else:
+                self._status_message.setText("Reconstruction complete. Source files need attention")
         elif state == ReconstructionState.ERROR:
             error = self._presenter.last_error or "Unknown error"
             self._status_message.setText(f"Error: {error}")
@@ -333,7 +373,7 @@ class ReconstructionWidget(QWidget):
             self._calibration_indicator.hide()
 
         # Process button
-        can_process = self._presenter.selected_recording is not None and self._presenter.selected_tracker is not None
+        can_process = self._presenter.can_process
 
         button_text = self._process_button_text_for_state(state)
         self._process_btn.setText(button_text)

--- a/src/caliscope/gui/views/reconstruction_widget.py
+++ b/src/caliscope/gui/views/reconstruction_widget.py
@@ -30,6 +30,7 @@ from caliscope.gui.presenters.reconstruction_presenter import (
 )
 from caliscope.gui.view_models.playback_view_model import PlaybackViewModel
 from caliscope.gui.widgets.qt3d_playback_widget import Qt3DPlaybackWidget, opengl_available
+from caliscope.gui.widgets.workspace_issue_label import WorkspaceIssueLabel
 from caliscope import MODELS_DIR
 from caliscope.gui.theme import Colors
 from caliscope.trackers import tracker_registry
@@ -93,11 +94,8 @@ class ReconstructionWidget(QWidget):
         self._recording_list.setMaximumHeight(150)
         recording_layout.addWidget(self._recording_list)
 
-        self._recording_feedback_label = QLabel()
+        self._recording_feedback_label = WorkspaceIssueLabel()
         self._recording_feedback_label.setObjectName("recordingFeedbackLabel")
-        self._recording_feedback_label.setWordWrap(True)
-        self._recording_feedback_label.setStyleSheet(f"color: {Colors.WARNING};")
-        self._recording_feedback_label.hide()
         recording_layout.addWidget(self._recording_feedback_label)
 
         left_layout.addWidget(recording_group)
@@ -203,7 +201,7 @@ class ReconstructionWidget(QWidget):
 
     def _populate_initial_data(self) -> None:
         """Populate lists with available recordings and trackers."""
-        self._presenter.refresh_recordings()
+        self._presenter.refresh_from_workspace()
 
         # Populate trackers
         trackers = self._presenter.available_trackers
@@ -240,19 +238,12 @@ class ReconstructionWidget(QWidget):
 
     def _update_recording_feedback(self) -> None:
         """Show actionable root and selected-session filesystem feedback."""
-        issues = list(self._presenter.recording_layout_issues)
-        issues.extend(self._presenter.selected_recording_issues)
-
-        if issues:
-            self._recording_feedback_label.setText("\n".join(f"• {issue.message}" for issue in issues))
-            self._recording_feedback_label.show()
-        elif not self._presenter.available_recordings:
-            self._recording_feedback_label.setText(
-                "No recording session folders found. Add a named folder inside recordings/."
-            )
-            self._recording_feedback_label.show()
-        else:
-            self._recording_feedback_label.hide()
+        empty_text = (
+            ""
+            if self._presenter.available_recordings
+            else "No recording session folders found. Add a named folder inside recordings/."
+        )
+        self._recording_feedback_label.set_issues(self._presenter.workspace_issues, empty_text=empty_text)
 
     def _on_tracker_changed(self, index: int) -> None:
         """Handle tracker selection change."""

--- a/src/caliscope/gui/widgets/workspace_issue_label.py
+++ b/src/caliscope/gui/widgets/workspace_issue_label.py
@@ -1,0 +1,37 @@
+"""Shared label for rendering workspace file issues."""
+
+from collections.abc import Iterable
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QLabel, QWidget
+
+from caliscope.core.workflow_status import WorkspaceIssue
+from caliscope.gui.theme import Colors
+
+
+class WorkspaceIssueLabel(QLabel):
+    """Warning text for workspace file problems, hidden when there is nothing to say."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setObjectName("workspaceIssueLabel")
+        self.setTextFormat(Qt.TextFormat.PlainText)
+        self.setWordWrap(True)
+        self.setStyleSheet(f"color: {Colors.WARNING};")
+        self.hide()
+
+    def set_issues(self, issues: Iterable[WorkspaceIssue], empty_text: str = "") -> None:
+        """Render one line per issue, falling back to empty_text when there are none.
+
+        Hides itself when the resulting text is empty.
+        """
+        text = "\n".join(issue.message for issue in issues)
+        if not text:
+            text = empty_text
+
+        if text:
+            self.setText(text)
+            self.show()
+        else:
+            self.clear()
+            self.hide()

--- a/src/caliscope/workspace_coordinator.py
+++ b/src/caliscope/workspace_coordinator.py
@@ -119,7 +119,7 @@ class WorkspaceCoordinator(QObject):
         self._intrinsic_frame_skip: int = 5
 
     def _setup_filesystem_watcher(self) -> None:
-        """Watch calibration directories for file changes."""
+        """Watch calibration, recording root, and recording session directories."""
         self._watcher = QFileSystemWatcher(parent=self)
 
         dirs_to_watch = [
@@ -130,19 +130,45 @@ class WorkspaceCoordinator(QObject):
 
         for dir_path in dirs_to_watch:
             if dir_path.exists():
-                self._watcher.addPath(str(dir_path))
+                self._watcher.addPath(str(dir_path.resolve()))
                 logger.debug(f"Watching directory: {dir_path}")
 
+        self._reconcile_recording_watches()
+
         self._watcher.directoryChanged.connect(self._on_directory_changed)
+
+    def _recording_session_dirs(self) -> set[Path]:
+        """Return immediate recording session directories currently on disk."""
+        if not self.workspace_guide.recording_dir.exists():
+            return set()
+        return {path.resolve() for path in self.workspace_guide.recording_dir.iterdir() if path.is_dir()}
+
+    def _reconcile_recording_watches(self) -> None:
+        """Keep nested recording watches aligned with current session folders."""
+        recording_root = self.workspace_guide.recording_dir.resolve()
+        desired = self._recording_session_dirs()
+        watched = {Path(path) for path in self._watcher.directories()}
+        watched_sessions = {path for path in watched if path.parent == recording_root}
+
+        removed = sorted(watched_sessions - desired)
+        if removed:
+            self._watcher.removePaths([str(path) for path in removed])
+
+        added = sorted(desired - watched)
+        if added:
+            self._watcher.addPaths([str(path) for path in added])
+            for path in added:
+                logger.debug(f"Watching recording session: {path}")
 
     def _on_directory_changed(self, path: str) -> None:
         """Handle filesystem change in watched directory."""
         logger.info(f"Directory changed: {path}")
-        if Path(path) in {
-            self.workspace_guide.intrinsic_dir,
-            self.workspace_guide.extrinsic_dir,
+        if Path(path).resolve() in {
+            self.workspace_guide.intrinsic_dir.resolve(),
+            self.workspace_guide.extrinsic_dir.resolve(),
         }:
             self._discover_new_cameras()
+        self._reconcile_recording_watches()
         self.status_changed.emit()
 
     @property
@@ -199,10 +225,10 @@ class WorkspaceCoordinator(QObject):
     def reconstruction_tab_enabled(self) -> bool:
         """Whether Reconstruction tab should be enabled.
 
-        Requires: bundle exists AND recordings available.
+        Requires a calibrated capture volume. Recording availability and file
+        feedback are rendered inside the tab.
         """
-        has_bundle = self.capture_volume_repository.camera_array_path.exists()
-        return has_bundle and self.recordings_available()
+        return self.capture_volume_repository.camera_array_path.exists()
 
     def _initialize_project_files(self):
         """Create default project files if they don't exist."""
@@ -311,7 +337,12 @@ class WorkspaceCoordinator(QObject):
 
     def recordings_available(self) -> bool:
         """Check if any valid recording directories exist."""
-        return len(self.workspace_guide.valid_recording_dirs()) > 0
+        expected_cam_ids = self._reconstruction_cam_ids()
+        return bool(self.workspace_guide.ready_recording_dirs(expected_cam_ids))
+
+    def _reconstruction_cam_ids(self) -> set[int]:
+        """Camera IDs required by the camera array used for reconstruction."""
+        return set(self.camera_array.cameras)
 
     def get_workflow_status(self) -> WorkflowStatus:
         """Compute current workflow status from ground truth.
@@ -323,6 +354,15 @@ class WorkspaceCoordinator(QObject):
         extrinsic_assessment = self.workspace_guide.assess_extrinsic_videos(expected_cam_ids)
         intrinsic_assessment = self.workspace_guide.assess_intrinsic_videos(expected_cam_ids)
         camera_count = len(expected_cam_ids)
+        reconstruction_cam_ids = self._reconstruction_cam_ids()
+        recording_assessments = self.workspace_guide.assess_recordings(reconstruction_cam_ids)
+        ready_recording_names = [
+            name for name, assessment in recording_assessments.items() if reconstruction_cam_ids and assessment.is_ready
+        ]
+        recording_issues = (
+            *self.workspace_guide.recording_layout_issues(),
+            *(issue for assessment in recording_assessments.values() for issue in assessment.issues),
+        )
 
         # Cameras needing intrinsic calibration
         cameras_needing = [cam_id for cam_id, cam in self.camera_array.cameras.items() if cam.matrix is None]
@@ -345,9 +385,9 @@ class WorkspaceCoordinator(QObject):
             extrinsic_video_issues=extrinsic_assessment.issues,
             extrinsic_2d_extraction_complete=extraction_complete,
             extrinsic_calibration_complete=self.all_extrinsics_estimated(),
-            recordings_available=self.recordings_available(),
-            recording_names=self.workspace_guide.valid_recording_dirs(),
-            recording_layout_issues=self.workspace_guide.recording_layout_issues(),
+            recording_names=list(recording_assessments),
+            ready_recording_names=ready_recording_names,
+            recording_issues=recording_issues,
         )
 
     def _discover_new_cameras(self) -> None:
@@ -565,6 +605,7 @@ class WorkspaceCoordinator(QObject):
         """
         return ReconstructionPresenter(
             workspace_dir=self.workspace,
+            workspace_guide=self.workspace_guide,
             camera_array=self.camera_array,
             task_manager=self.task_manager,
             project_settings=self.settings_repository,

--- a/src/caliscope/workspace_coordinator.py
+++ b/src/caliscope/workspace_coordinator.py
@@ -190,7 +190,8 @@ class WorkspaceCoordinator(QObject):
         """Authoritative list of camera IDs from extrinsic directory."""
         return self.workspace_guide.get_cam_ids()
 
-    def _expected_cam_ids(self) -> set[int]:
+    @property
+    def expected_cam_ids(self) -> set[int]:
         """Cameras the workspace expects calibration videos for.
 
         Extrinsic videos define the camera set. Loaded cameras keep that set
@@ -359,7 +360,7 @@ class WorkspaceCoordinator(QObject):
         This method queries the filesystem and domain objects to build
         a status snapshot. Called by the Project tab whenever it refreshes.
         """
-        expected_cam_ids = self._expected_cam_ids()
+        expected_cam_ids = self.expected_cam_ids
         extrinsic_assessment = self.workspace_guide.assess_extrinsic_videos(expected_cam_ids)
         intrinsic_assessment = self.workspace_guide.assess_intrinsic_videos(expected_cam_ids)
         camera_count = len(expected_cam_ids)
@@ -629,11 +630,13 @@ class WorkspaceCoordinator(QObject):
         - Managing presenter lifecycle (cleanup on tab close)
 
         Returns:
-            MultiCameraProcessingPresenter configured with task_manager and tracker.
+            MultiCameraProcessingPresenter configured with task_manager, tracker,
+            and the shared workspace guide.
         """
         presenter = MultiCameraProcessingPresenter(
             task_manager=self.task_manager,
             tracker=self.create_extrinsic_tracker(),
+            workspace_guide=self.workspace_guide,
         )
 
         # Wire signal directly - no passthrough needed

--- a/src/caliscope/workspace_coordinator.py
+++ b/src/caliscope/workspace_coordinator.py
@@ -121,6 +121,9 @@ class WorkspaceCoordinator(QObject):
     def _setup_filesystem_watcher(self) -> None:
         """Watch calibration, recording root, and recording session directories."""
         self._watcher = QFileSystemWatcher(parent=self)
+        # Session watches this coordinator added. Qt's own directories() list
+        # lags behind deletions on macOS and Windows, so it is not the record.
+        self._session_watches: set[str] = set()
 
         dirs_to_watch = [
             self.workspace_guide.intrinsic_dir,
@@ -137,28 +140,34 @@ class WorkspaceCoordinator(QObject):
 
         self._watcher.directoryChanged.connect(self._on_directory_changed)
 
-    def _recording_session_dirs(self) -> set[Path]:
+    def _recording_session_dirs(self) -> set[str]:
         """Return immediate recording session directories currently on disk."""
-        if not self.workspace_guide.recording_dir.exists():
+        recording_dir = self.workspace_guide.recording_dir
+        if not recording_dir.exists():
             return set()
-        return {path.resolve() for path in self.workspace_guide.recording_dir.iterdir() if path.is_dir()}
+        recording_root = recording_dir.resolve()
+        return {str(recording_root / path.name) for path in recording_dir.iterdir() if path.is_dir()}
 
     def _reconcile_recording_watches(self) -> None:
-        """Keep nested recording watches aligned with current session folders."""
-        recording_root = self.workspace_guide.recording_dir.resolve()
+        """Keep session watches aligned with the session folders on disk.
+
+        removePaths() is best effort. Qt cannot remove an already-deleted
+        directory on every platform, but every platform drops it on its own
+        once events are processed. Paths addPaths() rejects are retried on the
+        next reconcile.
+        """
         desired = self._recording_session_dirs()
-        watched = {Path(path) for path in self._watcher.directories()}
-        watched_sessions = {path for path in watched if path.parent == recording_root}
+        stale = self._session_watches - desired
+        if stale:
+            self._watcher.removePaths(sorted(stale))
 
-        removed = sorted(watched_sessions - desired)
-        if removed:
-            self._watcher.removePaths([str(path) for path in removed])
-
-        added = sorted(desired - watched)
-        if added:
-            self._watcher.addPaths([str(path) for path in added])
-            for path in added:
+        new = desired - self._session_watches
+        if new:
+            new -= set(self._watcher.addPaths(sorted(new)))
+            for path in sorted(new):
                 logger.debug(f"Watching recording session: {path}")
+
+        self._session_watches = (self._session_watches - stale) | new
 
     def _on_directory_changed(self, path: str) -> None:
         """Handle filesystem change in watched directory."""

--- a/src/caliscope/workspace_guide.py
+++ b/src/caliscope/workspace_guide.py
@@ -55,11 +55,11 @@ class WorkspaceGuide:
         Returns:
             Sorted list of integer camera IDs found
         """
-        return list(self._assess_camera_videos(directory, ()).camera_ids)
+        return list(self.assess_camera_videos(directory, ()).camera_ids)
 
     def assess_intrinsic_videos(self, expected_cam_ids: Collection[int]) -> CameraVideoAssessment:
         """Assess intrinsic videos against the workspace camera set."""
-        return self._assess_camera_videos(self.intrinsic_dir, expected_cam_ids)
+        return self.assess_camera_videos(self.intrinsic_dir, expected_cam_ids)
 
     def assess_extrinsic_videos(self, expected_cam_ids: Collection[int]) -> CameraVideoAssessment:
         """Assess extrinsic videos against the workspace camera set.
@@ -67,7 +67,7 @@ class WorkspaceGuide:
         Per-camera missing issues cover any expected camera. The generic
         "no videos" issue only applies when there is nothing more specific to say.
         """
-        assessment = self._assess_camera_videos(self.extrinsic_dir, expected_cam_ids)
+        assessment = self.assess_camera_videos(self.extrinsic_dir, expected_cam_ids)
         if assessment.camera_ids or assessment.missing_camera_ids:
             return assessment
 
@@ -82,11 +82,16 @@ class WorkspaceGuide:
             issues=(issue, *assessment.issues),
         )
 
-    def _assess_camera_videos(
+    def assess_camera_videos(
         self,
         directory: Path,
         expected_cam_ids: Collection[int],
     ) -> CameraVideoAssessment:
+        """Assess direct-child cam_N.mp4 files in any directory against a camera set.
+
+        Reports missing expected videos, videos outside the expected set, and
+        MP4 files that do not follow the cam_N.mp4 naming.
+        """
         camera_ids: list[int] = []
         file_issues: list[WorkspaceIssue] = []
 
@@ -229,7 +234,7 @@ class WorkspaceGuide:
             return {}
 
         return {
-            path.name: self._assess_camera_videos(path, expected_cam_ids)
+            path.name: self.assess_camera_videos(path, expected_cam_ids)
             for path in sorted(self.recording_dir.iterdir(), key=lambda item: item.name.casefold())
             if path.is_dir()
         }

--- a/src/caliscope/workspace_guide.py
+++ b/src/caliscope/workspace_guide.py
@@ -21,6 +21,11 @@ class CameraVideoAssessment:
     missing_camera_ids: tuple[int, ...]
     issues: tuple[WorkspaceIssue, ...]
 
+    @property
+    def is_ready(self) -> bool:
+        """Whether the directory contains a complete, unambiguous camera set."""
+        return bool(self.camera_ids) and not self.missing_camera_ids and not self.issues
+
 
 class WorkspaceGuide:
     """
@@ -153,38 +158,88 @@ class WorkspaceGuide:
 
         children = tuple(self.recording_dir.iterdir())
         root_mp4s = sorted(path.name for path in children if path.is_file() and path.suffix.casefold() == ".mp4")
-        camera_directories = sorted(
-            path.name
-            for path in children
-            if path.is_dir()
-            and _CAMERA_DIRECTORY_PATTERN.fullmatch(path.name)
-            and any(child.is_file() and child.suffix.casefold() == ".mp4" for child in path.iterdir())
+        root_timestamps = sorted(
+            path.name for path in children if path.is_file() and path.name.casefold() == "timestamps.csv"
         )
+        camera_named_directories = [
+            path for path in children if path.is_dir() and _CAMERA_DIRECTORY_PATTERN.fullmatch(path.name)
+        ]
+        noncanonical_camera_directories: set[str] = set()
+        canonical_partition_directories: set[str] = set()
+        for path in camera_named_directories:
+            mp4_names = {
+                child.name for child in path.iterdir() if child.is_file() and child.suffix.casefold() == ".mp4"
+            }
+            if any(_CAMERA_VIDEO_PATTERN.fullmatch(name) is None for name in mp4_names):
+                noncanonical_camera_directories.add(path.name)
+            if mp4_names == {f"{path.name}.mp4"}:
+                canonical_partition_directories.add(path.name)
+
+        camera_directories = noncanonical_camera_directories
+        if len(canonical_partition_directories) >= 2:
+            camera_directories |= canonical_partition_directories
 
         issues: list[WorkspaceIssue] = []
         if root_mp4s:
+            file_list = ", ".join(f"recordings/{name}" for name in root_mp4s)
             issues.append(
                 WorkspaceIssue(
                     code="recordings_need_session_folder",
                     message=(
-                        "Recording videos are directly inside recordings/. "
-                        "Create a named session folder and place its cam_N.mp4 files there."
+                        f"{file_list} must be inside a named recording session folder. "
+                        "Each session folder should contain its cam_N.mp4 files."
                     ),
                     relative_path="recordings",
                 )
             )
-        if len(camera_directories) >= 2:
+        if root_timestamps:
+            file_list = ", ".join(f"recordings/{name}" for name in root_timestamps)
+            issues.append(
+                WorkspaceIssue(
+                    code="recording_timestamps_need_session_folder",
+                    message=f"{file_list} must be inside the recording session folder it describes.",
+                    relative_path="recordings",
+                )
+            )
+        if camera_directories:
+            directory_list = ", ".join(f"recordings/{name}" for name in sorted(camera_directories))
             issues.append(
                 WorkspaceIssue(
                     code="recording_split_by_camera",
                     message=(
-                        "The recordings/cam_N folders split a recording by camera. "
+                        f"{directory_list} appears to split a recording by camera. "
                         "Create one named session folder containing every cam_N.mp4 file instead."
                     ),
                     relative_path="recordings",
                 )
             )
         return tuple(issues)
+
+    def assess_recordings(
+        self,
+        expected_cam_ids: Collection[int],
+    ) -> dict[str, CameraVideoAssessment]:
+        """Assess every immediate recording session directory.
+
+        Session names are unconstrained. Empty and structurally invalid
+        directories remain in the result so the GUI can show and explain them.
+        A timestamps.csv file is optional and is ignored by camera assessment.
+        """
+        if not self.recording_dir.exists():
+            return {}
+
+        return {
+            path.name: self._assess_camera_videos(path, expected_cam_ids)
+            for path in sorted(self.recording_dir.iterdir(), key=lambda item: item.name.casefold())
+            if path.is_dir()
+        }
+
+    def ready_recording_dirs(self, expected_cam_ids: Collection[int]) -> list[str]:
+        """Return recording session names with a complete camera video set."""
+        if not expected_cam_ids:
+            return []
+        assessments = self.assess_recordings(expected_cam_ids)
+        return [name for name, assessment in assessments.items() if assessment.is_ready]
 
     def _relative_path(self, path: Path) -> str:
         return path.relative_to(self.workspace_dir).as_posix()
@@ -288,19 +343,8 @@ class WorkspaceGuide:
         return "INCOMPLETE"
 
     def valid_recording_dirs(self) -> list[str]:
-        """Return list of valid recording directory names (all cam_N.mp4 present)."""
-        if not self.recording_dir.exists():
-            return []
-
-        dir_list = []
-        for p in self.recording_dir.iterdir():
-            if p.is_dir():
-                # A recording dir is valid if it has videos for all discovered cameras
-                cam_ids_in_dir = self.get_cam_ids_in_dir(p)
-                if cam_ids_in_dir:  # Must have at least some videos
-                    dir_list.append(p.stem)
-
-        return sorted(dir_list)
+        """Return recording sessions ready for the extrinsic camera set."""
+        return self.ready_recording_dirs(self.get_cam_ids())
 
     def valid_recording_dir_text(self) -> str:
         """Return comma-separated list of valid recording directories."""

--- a/tests/gui/presenters/test_extrinsic_calibration_presenter.py
+++ b/tests/gui/presenters/test_extrinsic_calibration_presenter.py
@@ -71,9 +71,9 @@ def test_is_board_origin_falls_back_to_heuristic_when_target_type_unknown(qapp):
     assert presenter._is_board_origin(object_ids=[0], static_ids=frozenset({0})) is False
 
 
-def test_refresh_extraction_status_picks_up_late_extraction(qapp, tmp_path):
+def test_refresh_from_workspace_picks_up_late_extraction(qapp, tmp_path):
     """Extraction output written after construction flips the extract step to
-    COMPLETE and enables calibration once refresh_extraction_status runs."""
+    COMPLETE and enables calibration once refresh_from_workspace runs."""
     image_points_path = tmp_path / "image_points.csv"
     presenter = _make_presenter(image_points_path=image_points_path)
 
@@ -86,13 +86,13 @@ def test_refresh_extraction_status_picks_up_late_extraction(qapp, tmp_path):
 
     # Extraction runs on the Multi-Camera tab and writes the CSV.
     _write_minimal_image_points(image_points_path)
-    presenter.refresh_extraction_status()
+    presenter.refresh_from_workspace()
 
     assert presenter.has_extraction_data is True
     assert steps[-1].extract[0] == StepStatus.COMPLETE
 
 
-def test_refresh_extraction_status_noop_when_already_loaded(qapp, tmp_path):
+def test_refresh_from_workspace_noop_when_already_loaded(qapp, tmp_path):
     """A second refresh after data is loaded does not re-read or re-emit."""
     image_points_path = tmp_path / "image_points.csv"
     _write_minimal_image_points(image_points_path)
@@ -101,5 +101,5 @@ def test_refresh_extraction_status_noop_when_already_loaded(qapp, tmp_path):
 
     steps: list[CalibrationStepData] = []
     presenter.workflow_updated.connect(steps.append)
-    presenter.refresh_extraction_status()
+    presenter.refresh_from_workspace()
     assert steps == []

--- a/tests/gui/presenters/test_multi_camera_processing_presenter.py
+++ b/tests/gui/presenters/test_multi_camera_processing_presenter.py
@@ -22,6 +22,7 @@ from caliscope.gui.presenters.multi_camera_processing_presenter import (
 from caliscope.helper import copy_contents_to_clean_dest
 from caliscope.cameras.camera_array import CameraArray
 from caliscope.task_manager.task_state import TaskState
+from caliscope.workspace_guide import WorkspaceGuide
 
 TEST_SESSION = Path(__root__) / "tests" / "sessions" / "4_cam_recording"
 
@@ -61,11 +62,12 @@ def real_camera_array(workspace_with_recordings):
 
 
 @pytest.fixture
-def presenter(mock_task_manager, mock_tracker, qapp):
+def presenter(mock_task_manager, mock_tracker, tmp_path, qapp):
     """Create a MultiCameraProcessingPresenter for testing."""
     return MultiCameraProcessingPresenter(
         task_manager=mock_task_manager,
         tracker=mock_tracker,
+        workspace_guide=WorkspaceGuide(tmp_path),
     )
 
 
@@ -188,6 +190,7 @@ class TestThumbnailLoading:
         presenter = MultiCameraProcessingPresenter(
             task_manager=mock_task_manager,
             tracker=mock_tracker,
+            workspace_guide=WorkspaceGuide(workspace_with_recordings),
         )
 
         recording_dir = workspace_with_recordings / "recordings" / "recording_1"

--- a/tests/gui/presenters/test_reconstruction_presenter.py
+++ b/tests/gui/presenters/test_reconstruction_presenter.py
@@ -250,7 +250,7 @@ class TestSelection:
         presenter.select_tracker("CHARUCO")
 
         (recording / "cam_2.mp4").unlink()
-        presenter.refresh_recordings()
+        presenter.refresh_from_workspace()
 
         assert presenter.selected_recording == "recording_1"
         assert presenter.can_process is False
@@ -259,7 +259,7 @@ class TestSelection:
         ]
 
         (recording / "cam_2.mp4").touch()
-        presenter.refresh_recordings()
+        presenter.refresh_from_workspace()
 
         assert presenter.selected_recording == "recording_1"
         assert presenter.can_process is True
@@ -278,7 +278,7 @@ class TestSelection:
         presenter._processing_task = active_task
         _remove_recording_session(recording)
 
-        presenter.refresh_recordings()
+        presenter.refresh_from_workspace()
 
         assert presenter.selected_recording == "recording_1"
         assert [issue.code for issue in presenter.selected_recording_issues] == ["missing_recording_directory"]

--- a/tests/gui/presenters/test_reconstruction_presenter.py
+++ b/tests/gui/presenters/test_reconstruction_presenter.py
@@ -21,6 +21,7 @@ from caliscope.helper import copy_contents_to_clean_dest
 from caliscope.cameras.camera_array import CameraArray
 from caliscope.task_manager.task_state import TaskState
 from caliscope.trackers import tracker_registry
+from caliscope.workspace_guide import WorkspaceGuide
 
 # Test session with 4 cameras and recordings
 TEST_SESSION = Path(__root__) / "tests" / "sessions" / "4_cam_recording"
@@ -28,6 +29,20 @@ _CHARUCO_SESSION = Path(__root__) / "tests" / "sessions" / "post_optimization"
 
 # Tracker key used throughout this test module
 _TEST_TRACKER = "CHARUCO"
+
+
+def _create_recording_session(workspace: Path, name: str) -> Path:
+    session = workspace / "recordings" / name
+    session.mkdir()
+    for cam_id in (0, 1, 2, 3):
+        (session / f"cam_{cam_id}.mp4").touch()
+    return session
+
+
+def _remove_recording_session(session: Path) -> None:
+    for child in session.iterdir():
+        child.unlink()
+    session.rmdir()
 
 
 @pytest.fixture
@@ -74,6 +89,7 @@ def presenter(workspace_with_recordings, camera_array, mock_task_manager, qapp):
     """Create a ReconstructionPresenter for testing."""
     return ReconstructionPresenter(
         workspace_dir=workspace_with_recordings,
+        workspace_guide=WorkspaceGuide(workspace_with_recordings),
         camera_array=camera_array,
         task_manager=mock_task_manager,
     )
@@ -92,6 +108,15 @@ class TestStateComputation:
         mock_task.state = TaskState.RUNNING
         presenter._processing_task = mock_task
 
+        assert presenter.state == ReconstructionState.RECONSTRUCTING
+
+    def test_state_reconstructing_when_task_pending(self, presenter):
+        """A submitted task is active before its worker thread starts."""
+        mock_task = MagicMock()
+        mock_task.state = TaskState.PENDING
+        presenter._processing_task = mock_task
+
+        assert presenter.has_active_task is True
         assert presenter.state == ReconstructionState.RECONSTRUCTING
 
     def test_state_error_when_task_failed(self, presenter):
@@ -117,7 +142,7 @@ class TestStateComputation:
         assert presenter.state == ReconstructionState.IDLE
 
     def test_state_complete_when_xyz_exists(self, presenter, workspace_with_recordings):
-        """State is COMPLETE when xyz output file exists."""
+        """Existing output remains complete even if its source recording degrades."""
         presenter._selected_recording = "recording_1"
         presenter._selected_tracker = "CHARUCO"
 
@@ -125,8 +150,10 @@ class TestStateComputation:
         output_dir = workspace_with_recordings / "recordings" / "recording_1" / "CHARUCO"
         output_dir.mkdir(parents=True, exist_ok=True)
         (output_dir / "xyz_CHARUCO.csv").touch()
+        (workspace_with_recordings / "recordings" / "recording_1" / "cam_2.mp4").unlink()
 
         assert presenter.state == ReconstructionState.COMPLETE
+        assert presenter.selected_recording_is_ready is False
 
     def test_task_state_takes_precedence_over_file(self, presenter, workspace_with_recordings):
         """Task RUNNING state takes precedence over file existence."""
@@ -150,11 +177,14 @@ class TestStateComputation:
 class TestAvailableOptions:
     """Tests for available recordings and trackers."""
 
-    def test_available_recordings(self, presenter):
-        """Should list valid recording directories."""
+    def test_available_recordings_includes_invalid_session_directories(self, presenter, workspace_with_recordings):
+        """The list mirrors immediate session directories instead of filtering them."""
+        (workspace_with_recordings / "recordings" / "empty_session").mkdir()
+
         recordings = presenter.available_recordings
+
         assert "recording_1" in recordings
-        assert len(recordings) == 1  # Test session has one recording
+        assert "empty_session" in recordings
 
     def test_available_trackers_excludes_charuco(self, presenter):
         """CHARUCO is a calibration tracker and must not appear in reconstruction trackers."""
@@ -188,10 +218,71 @@ class TestSelection:
         presenter.select_tracker("CHARUCO")
         assert presenter._last_error is None
 
-    def test_select_invalid_recording_ignored(self, presenter):
-        """Selecting an invalid recording is ignored."""
+    def test_select_structurally_invalid_recording_shows_its_assessment(
+        self,
+        presenter,
+        workspace_with_recordings,
+    ):
+        """Invalid session rows remain selectable so their feedback is visible."""
+        invalid = workspace_with_recordings / "recordings" / "partial"
+        invalid.mkdir()
+        (invalid / "cam_0.mp4").touch()
+
+        presenter.select_recording("partial")
+
+        assert presenter.selected_recording == "partial"
+        assert presenter.selected_recording_is_ready is False
+        assert presenter.selected_recording_assessment is not None
+        assert presenter.selected_recording_assessment.missing_camera_ids == (1, 2, 3)
+
+    def test_nonexistent_recording_is_ignored(self, presenter):
         presenter.select_recording("nonexistent")
         assert presenter.selected_recording is None
+
+    def test_refresh_preserves_selection_and_recovers_after_video_restore(
+        self,
+        presenter,
+        workspace_with_recordings,
+        registered_test_tracker,
+    ):
+        recording = workspace_with_recordings / "recordings" / "recording_1"
+        presenter.select_recording("recording_1")
+        presenter.select_tracker("CHARUCO")
+
+        (recording / "cam_2.mp4").unlink()
+        presenter.refresh_recordings()
+
+        assert presenter.selected_recording == "recording_1"
+        assert presenter.can_process is False
+        assert [issue.relative_path for issue in presenter.selected_recording_assessment.issues] == [
+            "recordings/recording_1/cam_2.mp4"
+        ]
+
+        (recording / "cam_2.mp4").touch()
+        presenter.refresh_recordings()
+
+        assert presenter.selected_recording == "recording_1"
+        assert presenter.can_process is True
+
+    @pytest.mark.parametrize("task_state", [TaskState.PENDING, TaskState.RUNNING])
+    def test_refresh_reports_removed_active_session_without_cancelling(
+        self,
+        presenter,
+        workspace_with_recordings,
+        task_state,
+    ):
+        recording = workspace_with_recordings / "recordings" / "recording_1"
+        presenter.select_recording("recording_1")
+        active_task = MagicMock()
+        active_task.state = task_state
+        presenter._processing_task = active_task
+        _remove_recording_session(recording)
+
+        presenter.refresh_recordings()
+
+        assert presenter.selected_recording == "recording_1"
+        assert [issue.code for issue in presenter.selected_recording_issues] == ["missing_recording_directory"]
+        active_task.cancel.assert_not_called()
 
 
 class TestXyzOutputPath:
@@ -258,6 +349,134 @@ class TestStartReconstruction:
         call_kwargs = mock_task_manager.submit.call_args
         assert call_kwargs.kwargs["name"] == "reconstruction"
 
+    def test_missing_camera_video_blocks_submission_even_with_timestamps(
+        self,
+        presenter,
+        workspace_with_recordings,
+        mock_task_manager,
+        qapp,
+        registered_test_tracker,
+    ):
+        recording = workspace_with_recordings / "recordings" / "recording_1"
+        assert (recording / "timestamps.csv").exists()
+        (recording / "cam_3.mp4").unlink()
+        presenter.select_recording("recording_1")
+        presenter.select_tracker("CHARUCO")
+
+        presenter.start_reconstruction()
+
+        mock_task_manager.submit.assert_not_called()
+        assert presenter.selected_recording_is_ready is False
+
+    def test_timestamp_failure_creates_no_tracker_output_or_task(
+        self,
+        presenter,
+        workspace_with_recordings,
+        mock_task_manager,
+        qapp,
+        registered_test_tracker,
+        monkeypatch,
+    ):
+        recording = workspace_with_recordings / "recordings" / "recording_1"
+        load_timestamps = MagicMock(side_effect=ValueError("Timestamp data is incompatible"))
+        create_tracker = MagicMock()
+        monkeypatch.setattr(
+            "caliscope.gui.presenters.reconstruction_presenter.SynchronizedTimestamps.load",
+            load_timestamps,
+        )
+        monkeypatch.setattr(tracker_registry, "create", create_tracker)
+        presenter.select_recording("recording_1")
+        presenter.select_tracker("CHARUCO")
+
+        presenter.start_reconstruction()
+
+        load_timestamps.assert_called_once()
+        create_tracker.assert_not_called()
+        assert not (recording / "CHARUCO").exists()
+        mock_task_manager.submit.assert_not_called()
+
+    def test_repeated_start_does_not_submit_while_first_task_is_pending(
+        self,
+        presenter,
+        mock_task_manager,
+        qapp,
+        registered_test_tracker,
+    ):
+        pending_handle = MagicMock()
+        pending_handle.state = TaskState.PENDING
+        mock_task_manager.submit.return_value = pending_handle
+        presenter.select_recording("recording_1")
+        presenter.select_tracker("CHARUCO")
+
+        presenter.start_reconstruction()
+        presenter.start_reconstruction()
+
+        mock_task_manager.submit.assert_called_once()
+        mock_task_manager.start_task.assert_called_once()
+
+
+class TestTerminalSelectionReconciliation:
+    def test_completion_emits_original_result_before_selecting_remaining_session(
+        self,
+        presenter,
+        workspace_with_recordings,
+        registered_test_tracker,
+    ):
+        remaining = _create_recording_session(workspace_with_recordings, "remaining")
+        original = workspace_with_recordings / "recordings" / "recording_1"
+        presenter.select_recording("recording_1")
+        presenter.select_tracker("CHARUCO")
+        completed_task = MagicMock()
+        completed_task.state = TaskState.COMPLETED
+        presenter._processing_task = completed_task
+        _remove_recording_session(original)
+        result_dir = workspace_with_recordings / "completed-result"
+        observed: list[tuple[Path, str | None]] = []
+        presenter.reconstruction_complete.connect(lambda path: observed.append((path, presenter.selected_recording)))
+
+        presenter._on_reconstruction_complete(result_dir)
+
+        assert observed == [(result_dir / "xyz_CHARUCO.csv", "recording_1")]
+        assert presenter.selected_recording == remaining.name
+
+    def test_failure_reconciles_removed_selection_after_failure_signal(
+        self,
+        presenter,
+        workspace_with_recordings,
+    ):
+        remaining = _create_recording_session(workspace_with_recordings, "remaining")
+        original = workspace_with_recordings / "recordings" / "recording_1"
+        presenter.select_recording("recording_1")
+        failed_task = MagicMock()
+        failed_task.state = TaskState.FAILED
+        presenter._processing_task = failed_task
+        _remove_recording_session(original)
+        observed: list[tuple[str, str | None]] = []
+        presenter.reconstruction_failed.connect(
+            lambda message: observed.append((message, presenter.selected_recording))
+        )
+
+        presenter._on_reconstruction_failed("RuntimeError", "worker failed")
+
+        assert observed == [("RuntimeError: worker failed", "recording_1")]
+        assert presenter.selected_recording == remaining.name
+        assert presenter.last_error == "RuntimeError: worker failed"
+        assert presenter.state == ReconstructionState.ERROR
+
+    def test_cancellation_reconciles_removed_selection(self, presenter, workspace_with_recordings):
+        remaining = _create_recording_session(workspace_with_recordings, "remaining")
+        original = workspace_with_recordings / "recordings" / "recording_1"
+        presenter.select_recording("recording_1")
+        cancelled_task = MagicMock()
+        cancelled_task.state = TaskState.CANCELLED
+        presenter._processing_task = cancelled_task
+        _remove_recording_session(original)
+
+        presenter._on_reconstruction_cancelled()
+
+        assert presenter.selected_recording == remaining.name
+        assert presenter.state == ReconstructionState.IDLE
+
 
 class TestCleanup:
     """Tests for cleanup behavior."""
@@ -275,6 +494,16 @@ class TestCleanup:
     def test_cleanup_safe_when_no_task(self, presenter):
         """cleanup() is safe to call when no task exists."""
         presenter.cleanup()  # Should not raise
+
+    def test_cancel_accepts_pending_task(self, presenter):
+        """A task can be cancelled before its worker thread begins."""
+        mock_task = MagicMock()
+        mock_task.state = TaskState.PENDING
+        presenter._processing_task = mock_task
+
+        presenter.cancel_reconstruction()
+
+        mock_task.cancel.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/gui/test_workspace_feedback.py
+++ b/tests/gui/test_workspace_feedback.py
@@ -196,6 +196,17 @@ def test_reconstruction_tab_follows_nested_recording_changes_through_real_watche
         assert recording_list.count() == 0
         assert str(session.resolve()) not in coordinator._watcher.directories()
         assert presenter.selected_recording is None
+
+        previous_count = status_spy.count()
+        session.mkdir()
+        _wait_for_status_change(
+            qapp,
+            status_spy,
+            previous_count,
+            lambda: recording_list.count() == 1 and str(session.resolve()) in coordinator._session_watches,
+        )
+        assert recording_list.count() == 1
+        assert str(session.resolve()) in coordinator._session_watches
     finally:
         tab.cleanup()
         coordinator.cleanup()

--- a/tests/gui/test_workspace_feedback.py
+++ b/tests/gui/test_workspace_feedback.py
@@ -14,6 +14,7 @@ from caliscope.gui.multi_camera_processing_tab import MultiCameraProcessingTab
 from caliscope.gui.presenters.multi_camera_processing_presenter import MultiCameraProcessingState
 from caliscope.gui.reconstruction_tab import ReconstructionTab
 from caliscope.gui.views.project_setup_view import ProjectSetupView
+from caliscope.gui.widgets.workspace_issue_label import WorkspaceIssueLabel
 from caliscope.trackers import tracker_registry
 from caliscope.workspace_coordinator import WorkspaceCoordinator
 
@@ -73,13 +74,15 @@ def test_open_extract_tab_follows_extrinsic_videos(coordinator: WorkspaceCoordin
     coordinator.load_camera_array()
     tab = MultiCameraProcessingTab(coordinator)
     assert tab._presenter is not None and tab._widget is not None
-    assert tab._file_warning_label.isHidden()
+    label = tab._widget.findChild(WorkspaceIssueLabel)
+    assert label is not None
+    assert label.isHidden()
     assert sorted(tab._widget._camera_cards) == [0, 1]
 
     (extrinsic / "cam_1.mp4").unlink()
     coordinator._on_directory_changed(str(extrinsic))
 
-    assert "Missing calibration/extrinsic/cam_1.mp4" in tab._file_warning_label.text()
+    assert "Missing calibration/extrinsic/cam_1.mp4" in label.text()
     assert tuple(coordinator.camera_array.cameras) == (0, 1)
     assert tab._presenter.state == MultiCameraProcessingState.UNCONFIGURED
     assert tab._widget._camera_cards[1]._thumbnail_label.text() == "No video file for cam_1"
@@ -89,7 +92,7 @@ def test_open_extract_tab_follows_extrinsic_videos(coordinator: WorkspaceCoordin
     (extrinsic / "cam_2.mp4").touch()
     coordinator._on_directory_changed(str(extrinsic))
 
-    assert tab._file_warning_label.isHidden()
+    assert label.isHidden()
     assert tab._presenter.state == MultiCameraProcessingState.READY
     assert tab._widget._action_btn.isEnabled()
     assert sorted(tab._widget._camera_cards) == [0, 1, 2]
@@ -114,8 +117,8 @@ def test_reconstruction_tab_follows_nested_recording_changes_through_real_watche
             1: CameraData(cam_id=1, size=(640, 480)),
         }
     )
-    presenter = coordinator.create_reconstruction_presenter()
-    tab = ReconstructionTab(presenter, coordinator)
+    tab = ReconstructionTab(coordinator)
+    presenter = tab._presenter
     status_spy = QSignalSpy(coordinator.status_changed)
 
     recording_list = tab.findChild(QListWidget, "recordingList")
@@ -164,9 +167,9 @@ def test_reconstruction_tab_follows_nested_recording_changes_through_real_watche
             qapp,
             status_spy,
             previous_count,
-            lambda: feedback_label.text() == "• Missing recordings/walk/cam_1.mp4." and not process_button.isEnabled(),
+            lambda: feedback_label.text() == "Missing recordings/walk/cam_1.mp4." and not process_button.isEnabled(),
         )
-        assert feedback_label.text() == "• Missing recordings/walk/cam_1.mp4."
+        assert feedback_label.text() == "Missing recordings/walk/cam_1.mp4."
         assert not process_button.isEnabled()
         assert recording_list.count() == 1
         assert recording_list.currentItem() is not None

--- a/tests/gui/test_workspace_feedback.py
+++ b/tests/gui/test_workspace_feedback.py
@@ -1,14 +1,45 @@
 """Workspace file feedback reaching already-built views."""
 
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
+from PySide6.QtCore import QElapsedTimer, QEventLoop
+from PySide6.QtTest import QSignalSpy
+from PySide6.QtWidgets import QApplication, QLabel, QListWidget, QPushButton
 
+from caliscope.cameras.camera_array import CameraArray, CameraData
 from caliscope.gui.multi_camera_processing_tab import MultiCameraProcessingTab
 from caliscope.gui.presenters.multi_camera_processing_presenter import MultiCameraProcessingState
+from caliscope.gui.reconstruction_tab import ReconstructionTab
 from caliscope.gui.views.project_setup_view import ProjectSetupView
+from caliscope.trackers import tracker_registry
 from caliscope.workspace_coordinator import WorkspaceCoordinator
+
+
+def _wait_until(
+    qapp: QApplication,
+    condition: Callable[[], bool],
+    timeout_ms: int = 3000,
+) -> None:
+    """Process Qt events until a filesystem-driven UI condition becomes true."""
+    timer = QElapsedTimer()
+    timer.start()
+    while not condition():
+        qapp.processEvents(QEventLoop.ProcessEventsFlag.AllEvents, 50)
+        if timer.elapsed() >= timeout_ms:
+            raise AssertionError("Timed out waiting for filesystem-driven UI update")
+
+
+def _wait_for_status_change(
+    qapp: QApplication,
+    spy: QSignalSpy,
+    previous_count: int,
+    condition: Callable[[], bool],
+) -> None:
+    """Wait for both Coordinator notification and its rendered effect."""
+    _wait_until(qapp, lambda: spy.count() > previous_count and condition())
 
 
 @pytest.fixture
@@ -63,3 +94,112 @@ def test_open_extract_tab_follows_extrinsic_videos(coordinator: WorkspaceCoordin
     assert tab._widget._action_btn.isEnabled()
     assert sorted(tab._widget._camera_cards) == [0, 1, 2]
     tab.cleanup()
+
+
+def test_reconstruction_tab_follows_nested_recording_changes_through_real_watcher(
+    tmp_path: Path,
+    qapp,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A built tab follows nested camera files through QFileSystemWatcher."""
+    tracker_name = "TEST_FEEDBACK"
+    tracker_registry.register(tracker_name, lambda: MagicMock(), display_name="Test Feedback")
+    monkeypatch.setattr("caliscope.gui.views.reconstruction_widget.opengl_available", lambda: False)
+    monkeypatch.chdir(tmp_path.parent)
+    relative_workspace = Path(tmp_path.name)
+    coordinator = WorkspaceCoordinator(relative_workspace)
+    coordinator.camera_array = CameraArray(
+        {
+            0: CameraData(cam_id=0, size=(640, 480)),
+            1: CameraData(cam_id=1, size=(640, 480)),
+        }
+    )
+    presenter = coordinator.create_reconstruction_presenter()
+    tab = ReconstructionTab(presenter, coordinator)
+    status_spy = QSignalSpy(coordinator.status_changed)
+
+    recording_list = tab.findChild(QListWidget, "recordingList")
+    feedback_label = tab.findChild(QLabel, "recordingFeedbackLabel")
+    process_button = tab.findChild(QPushButton, "processButton")
+    assert recording_list is not None
+    assert feedback_label is not None
+    assert process_button is not None
+    presenter.select_tracker(tracker_name)
+
+    try:
+        session = coordinator.workspace_guide.recording_dir / "walk"
+        previous_count = status_spy.count()
+        session.mkdir()
+        _wait_for_status_change(
+            qapp,
+            status_spy,
+            previous_count,
+            lambda: (
+                str(session.resolve()) in coordinator._watcher.directories()
+                and recording_list.count() == 1
+                and recording_list.currentItem() is not None
+                and recording_list.currentItem().text() == "walk"
+            ),
+        )
+        assert str(session.resolve()) in coordinator._watcher.directories()
+        assert recording_list.count() == 1
+        assert recording_list.currentItem() is not None
+        assert recording_list.currentItem().text() == "walk"
+
+        previous_count = status_spy.count()
+        for cam_id in (0, 1):
+            (session / f"cam_{cam_id}.mp4").touch()
+        _wait_for_status_change(
+            qapp,
+            status_spy,
+            previous_count,
+            lambda: feedback_label.isHidden() and process_button.isEnabled(),
+        )
+        assert feedback_label.isHidden()
+        assert process_button.isEnabled()
+
+        previous_count = status_spy.count()
+        (session / "cam_1.mp4").unlink()
+        _wait_for_status_change(
+            qapp,
+            status_spy,
+            previous_count,
+            lambda: feedback_label.text() == "• Missing recordings/walk/cam_1.mp4." and not process_button.isEnabled(),
+        )
+        assert feedback_label.text() == "• Missing recordings/walk/cam_1.mp4."
+        assert not process_button.isEnabled()
+        assert recording_list.count() == 1
+        assert recording_list.currentItem() is not None
+        assert recording_list.currentItem().text() == "walk"
+
+        previous_count = status_spy.count()
+        (session / "cam_1.mp4").touch()
+        _wait_for_status_change(
+            qapp,
+            status_spy,
+            previous_count,
+            lambda: feedback_label.isHidden() and process_button.isEnabled(),
+        )
+        assert feedback_label.isHidden()
+        assert process_button.isEnabled()
+
+        previous_count = status_spy.count()
+        for cam_id in (0, 1):
+            (session / f"cam_{cam_id}.mp4").unlink()
+        session.rmdir()
+        _wait_for_status_change(
+            qapp,
+            status_spy,
+            previous_count,
+            lambda: recording_list.count() == 0 and str(session.resolve()) not in coordinator._watcher.directories(),
+        )
+        assert recording_list.count() == 0
+        assert str(session.resolve()) not in coordinator._watcher.directories()
+        assert presenter.selected_recording is None
+    finally:
+        tab.cleanup()
+        coordinator.cleanup()
+        tracker_registry._factories.pop(tracker_name, None)
+        tracker_registry._display_names.pop(tracker_name, None)
+        tracker_registry._wireframes.pop(tracker_name, None)
+        tracker_registry._model_cards.pop(tracker_name, None)

--- a/tests/gui/test_workspace_issue_label.py
+++ b/tests/gui/test_workspace_issue_label.py
@@ -1,0 +1,18 @@
+"""Canary for the shared workspace issue label."""
+
+from caliscope.core.workflow_status import WorkspaceIssue
+from caliscope.gui.widgets.workspace_issue_label import WorkspaceIssueLabel
+
+
+def test_label_shows_issues_and_hides_when_there_is_nothing_to_say(qapp) -> None:
+    label = WorkspaceIssueLabel()
+    assert label.isHidden()
+
+    label.set_issues([WorkspaceIssue(code="x", message="Missing a.mp4.", relative_path="a.mp4")])
+    assert label.text() == "Missing a.mp4."
+
+    label.set_issues([])
+    assert label.isHidden()
+
+    label.set_issues([], empty_text="Nothing here")
+    assert label.text() == "Nothing here"

--- a/tests/test_workspace_coordinator.py
+++ b/tests/test_workspace_coordinator.py
@@ -118,3 +118,59 @@ def test_directory_change_discovers_cameras_and_keeps_persisted_calibration(
     assert coordinator.camera_repository.load().cameras[0].matrix is not None
     assert coordinator.cameras_tab_enabled is True
     assert coordinator.multi_camera_tab_enabled is True
+
+
+def test_reconstruction_status_counts_all_sessions_and_ready_sessions(
+    coordinator: WorkspaceCoordinator,
+):
+    coordinator.camera_array = CameraArray(
+        {
+            0: CameraData(cam_id=0, size=(640, 480)),
+            2: CameraData(cam_id=2, size=(640, 480)),
+        }
+    )
+    recordings = coordinator.workspace_guide.recording_dir
+    ready = recordings / "ready"
+    partial = recordings / "partial"
+    empty = recordings / "empty"
+    for session in (ready, partial, empty):
+        session.mkdir()
+    for cam_id in (0, 2):
+        (ready / f"cam_{cam_id}.mp4").touch()
+    (partial / "cam_0.mp4").touch()
+
+    status = coordinator.get_workflow_status()
+
+    assert status.recording_names == ["empty", "partial", "ready"]
+    assert status.ready_recording_names == ["ready"]
+    assert status.recordings_available is True
+    assert [issue.relative_path for issue in status.recording_issues] == [
+        "recordings/empty/cam_0.mp4",
+        "recordings/empty/cam_2.mp4",
+        "recordings/partial/cam_2.mp4",
+    ]
+
+
+def test_reconstruction_tab_only_requires_capture_volume_bundle(
+    coordinator: WorkspaceCoordinator,
+):
+    assert coordinator.workspace_guide.assess_recordings([]) == {}
+    coordinator.capture_volume_repository.camera_array_path.touch()
+
+    assert coordinator.reconstruction_tab_enabled is True
+
+
+def test_recording_session_watches_follow_root_directory_changes(
+    coordinator: WorkspaceCoordinator,
+):
+    session = coordinator.workspace_guide.recording_dir / "walk"
+    session.mkdir()
+
+    coordinator._on_directory_changed(str(coordinator.workspace_guide.recording_dir))
+
+    assert str(session.resolve()) in coordinator._watcher.directories()
+
+    session.rmdir()
+    coordinator._on_directory_changed(str(coordinator.workspace_guide.recording_dir))
+
+    assert str(session.resolve()) not in coordinator._watcher.directories()

--- a/tests/test_workspace_coordinator.py
+++ b/tests/test_workspace_coordinator.py
@@ -163,14 +163,20 @@ def test_reconstruction_tab_only_requires_capture_volume_bundle(
 def test_recording_session_watches_follow_root_directory_changes(
     coordinator: WorkspaceCoordinator,
 ):
+    """Session watches are the coordinator's record, reconciled on every root change.
+
+    Qt's own directories() list is not asserted here: fsevents and the Windows
+    engine only drop a deleted directory asynchronously, through the event loop.
+    """
+    recording_dir = str(coordinator.workspace_guide.recording_dir)
     session = coordinator.workspace_guide.recording_dir / "walk"
     session.mkdir()
 
-    coordinator._on_directory_changed(str(coordinator.workspace_guide.recording_dir))
+    coordinator._on_directory_changed(recording_dir)
 
-    assert str(session.resolve()) in coordinator._watcher.directories()
+    assert str(session.resolve()) in coordinator._session_watches
 
     session.rmdir()
-    coordinator._on_directory_changed(str(coordinator.workspace_guide.recording_dir))
+    coordinator._on_directory_changed(recording_dir)
 
-    assert str(session.resolve()) not in coordinator._watcher.directories()
+    assert str(session.resolve()) not in coordinator._session_watches

--- a/tests/test_workspace_guide.py
+++ b/tests/test_workspace_guide.py
@@ -95,10 +95,71 @@ class TestRecordingLayoutIssues:
             camera_dir.mkdir(parents=True)
             (camera_dir / "take.mp4").touch()
         (recordings / "cam_0.mp4").touch()
+        (recordings / "timestamps.csv").touch()
 
         issues = WorkspaceGuide(workspace).recording_layout_issues()
 
-        assert [issue.code for issue in issues] == ["recordings_need_session_folder", "recording_split_by_camera"]
+        assert [issue.code for issue in issues] == [
+            "recordings_need_session_folder",
+            "recording_timestamps_need_session_folder",
+            "recording_split_by_camera",
+        ]
+
+    def test_single_camera_split_directory_is_recognized_from_contents(self, workspace: Path) -> None:
+        camera_dir = workspace / "recordings" / "cam_7"
+        camera_dir.mkdir(parents=True)
+        (camera_dir / "walk_trial.mp4").touch()
+
+        issues = WorkspaceGuide(workspace).recording_layout_issues()
+
+        assert [issue.code for issue in issues] == ["recording_split_by_camera"]
+
+    def test_canonical_camera_partition_directories_are_recognized(self, workspace: Path) -> None:
+        recordings = workspace / "recordings"
+        for cam_id in (0, 1):
+            camera_dir = recordings / f"cam_{cam_id}"
+            camera_dir.mkdir(parents=True)
+            (camera_dir / f"cam_{cam_id}.mp4").touch()
+
+        issues = WorkspaceGuide(workspace).recording_layout_issues()
+
+        assert [issue.code for issue in issues] == ["recording_split_by_camera"]
+
+    def test_session_name_is_not_constrained(self, workspace: Path) -> None:
+        session = workspace / "recordings" / "cam_7"
+        session.mkdir(parents=True)
+        _touch_cam_ids(session, [0, 7])
+
+        guide = WorkspaceGuide(workspace)
+
+        assert guide.recording_layout_issues() == ()
+        assert guide.assess_recordings([0, 7])["cam_7"].is_ready is True
+
+
+class TestRecordingAssessments:
+    def test_all_immediate_sessions_are_returned_and_timestamps_are_optional(self, workspace: Path) -> None:
+        recordings = workspace / "recordings"
+        ready = recordings / "ready"
+        without_timestamps = recordings / "without_timestamps"
+        missing_camera = recordings / "missing_camera"
+        empty = recordings / "empty"
+        for session in (ready, without_timestamps, missing_camera, empty):
+            session.mkdir(parents=True)
+
+        _touch_cam_ids(ready, [0, 2])
+        (ready / "timestamps.csv").touch()
+        _touch_cam_ids(without_timestamps, [0, 2])
+        _touch_cam_ids(missing_camera, [0])
+
+        guide = WorkspaceGuide(workspace)
+        assessments = guide.assess_recordings([0, 2])
+
+        assert list(assessments) == ["empty", "missing_camera", "ready", "without_timestamps"]
+        assert assessments["ready"].is_ready is True
+        assert assessments["without_timestamps"].is_ready is True
+        assert assessments["missing_camera"].missing_camera_ids == (2,)
+        assert assessments["empty"].missing_camera_ids == (0, 2)
+        assert guide.ready_recording_dirs([0, 2]) == ["ready", "without_timestamps"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- make Reconstruct mirror every named session under recordings and explain missing, unexpected, or malformed camera videos instead of silently hiding invalid sessions
- keep timestamps.csv optional inside sessions while reporting recording artifacts placed at the recordings root or split across camera directories
- refresh existing tabs from nested filesystem changes and share one recording assessment between Project, Reconstruct, and processing preflight
- preserve reconstruction task lifecycle and completed outputs while source files change

## Test plan

- [x] visually verified empty, valid-without-timestamps, missing-camera, restored-camera, and misplaced-root states through the real filesystem watcher
- [x] Ruff and Ruff format
- [x] BasedPyright
- [x] focused workspace, presenter, and watcher-to-widget integration tests: 57 passed
- [x] full suite under xvfb: 809 passed, 1 existing warning

Closes #1021